### PR TITLE
Implement basic ref operations

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,7 @@ type Client interface {
 	SendCommands(ctx context.Context, data []byte) ([]byte, error)
 	SmartInfoRequest(ctx context.Context) ([]byte, error)
 	ListRefs(ctx context.Context) ([]Ref, error)
+	GetRef(ctx context.Context, ref string) (Ref, error)
 }
 
 // Option is a function that configures a Client.

--- a/client/client.go
+++ b/client/client.go
@@ -14,9 +14,16 @@ import (
 
 // Client defines the interface for interacting with a Git repository.
 type Client interface {
-	// TODO(mem): this is probably not the right interface.
-	SendCommands(ctx context.Context, data []byte) ([]byte, error)
-	SmartInfoRequest(ctx context.Context) ([]byte, error)
+	// TODO: this is probably not the right interface, we may have to separate the client
+	// Raw protocol requests
+	// UploadPack sends a POST request to the git-upload-pack endpoint.
+	UploadPack(ctx context.Context, data []byte) ([]byte, error)
+	// ReceivePack sends a POST request to the git-receive-pack endpoint.
+	ReceivePack(ctx context.Context, data []byte) ([]byte, error)
+	// SmartInfo sends a GET request to the info/refs endpoint.
+	SmartInfo(ctx context.Context, service string) ([]byte, error)
+
+	// Ref operations
 	ListRefs(ctx context.Context) ([]Ref, error)
 	GetRef(ctx context.Context, ref string) (Ref, error)
 }
@@ -48,11 +55,11 @@ func (c *clientImpl) addDefaultHeaders(req *http.Request) {
 		req.Header.Set("Authorization", *c.tokenAuth)
 	}
 
-	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
 }
 
-// SendCommands sends a POST request to the git-upload-pack endpoint.
-func (c *clientImpl) SendCommands(ctx context.Context, data []byte) ([]byte, error) {
+// UploadPack sends a POST request to the git-upload-pack endpoint.
+// This endpoint is used to fetch objects and refs from the remote repository.
+func (c *clientImpl) UploadPack(ctx context.Context, data []byte) ([]byte, error) {
 	body := bytes.NewReader(data)
 
 	// NOTE: This path is defined in the protocol-v2 spec as required under $GIT_URL/git-upload-pack.
@@ -64,6 +71,7 @@ func (c *clientImpl) SendCommands(ctx context.Context, data []byte) ([]byte, err
 		return nil, err
 	}
 
+	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
 	c.addDefaultHeaders(req)
 
 	res, err := c.client.Do(req)
@@ -80,8 +88,40 @@ func (c *clientImpl) SendCommands(ctx context.Context, data []byte) ([]byte, err
 	return io.ReadAll(res.Body)
 }
 
-// SmartInfoRequest sends a GET request to the info/refs endpoint.
-func (c *clientImpl) SmartInfoRequest(ctx context.Context) ([]byte, error) {
+// ReceivePack sends a POST request to the git-receive-pack endpoint.
+// This endpoint is used to send objects to the remote repository.
+func (c *clientImpl) ReceivePack(ctx context.Context, data []byte) ([]byte, error) {
+	body := bytes.NewReader(data)
+
+	// NOTE: This path is defined in the protocol-v2 spec as required under $GIT_URL/git-receive-pack.
+	// See: https://git-scm.com/docs/protocol-v2#_http_transport
+	u := c.base.JoinPath("git-receive-pack")
+	slog.Info("GitReceivePack", "url", u.String())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	c.addDefaultHeaders(req)
+	req.Header.Add("Content-Type", "application/x-git-receive-pack-request")
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("got status code %d: %s", res.StatusCode, res.Status)
+	}
+
+	return io.ReadAll(res.Body)
+}
+
+// SmartInfo sends a GET request to the info/refs endpoint.
+func (c *clientImpl) SmartInfo(ctx context.Context, service string) ([]byte, error) {
 	// NOTE: This path is defined in the protocol-v2 spec as required under $GIT_URL/info/refs.
 	// The ?service=git-upload-pack is documented in the protocol-v2 spec. It also implies elsewhere that ?svc is also valid.
 	// See: https://git-scm.com/docs/http-protocol#_smart_clients
@@ -89,10 +129,10 @@ func (c *clientImpl) SmartInfoRequest(ctx context.Context) ([]byte, error) {
 	u := c.base.JoinPath("info/refs")
 
 	query := make(url.Values)
-	query.Set("service", "git-upload-pack")
+	query.Set("service", service)
 	u.RawQuery = query.Encode()
 
-	slog.Info("SmartInfoRequest", "url", u.String())
+	slog.Info("SmartInfo", "url", u.String())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -187,7 +187,7 @@ func TestWithHTTPClient(t *testing.T) {
 	}
 }
 
-func TestSendCommands(t *testing.T) {
+func TestUploadPack(t *testing.T) {
 	tests := []struct {
 		name           string
 		statusCode     int
@@ -299,7 +299,7 @@ func TestSendCommands(t *testing.T) {
 				tt.setupClient(c)
 			}
 
-			response, err := client.SendCommands(context.Background(), []byte("test data"))
+			response, err := client.UploadPack(context.Background(), []byte("test data"))
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -312,7 +312,132 @@ func TestSendCommands(t *testing.T) {
 	}
 }
 
-func TestSmartInfoRequest(t *testing.T) {
+func TestReceivePack(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectedError  string
+		expectedResult string
+		setupClient    func(*clientImpl)
+	}{
+		{
+			name:           "successful response",
+			statusCode:     http.StatusOK,
+			responseBody:   "refs data",
+			expectedError:  "",
+			expectedResult: "refs data",
+			setupClient:    nil,
+		},
+		{
+			name:           "not found",
+			statusCode:     http.StatusNotFound,
+			responseBody:   "not found",
+			expectedError:  "got status code 404: 404 Not Found",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:           "server error",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   "server error",
+			expectedError:  "got status code 500: 500 Internal Server Error",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:           "timeout error",
+			statusCode:     0,
+			responseBody:   "",
+			expectedError:  "context deadline exceeded",
+			expectedResult: "",
+			setupClient: func(c *clientImpl) {
+				c.client = &http.Client{
+					Timeout: 1 * time.Nanosecond,
+				}
+			},
+		},
+		{
+			name:           "connection refused",
+			statusCode:     0,
+			responseBody:   "",
+			expectedError:  "i/o timeout",
+			expectedResult: "",
+			setupClient: func(c *clientImpl) {
+				c.base, _ = url.Parse("http://127.0.0.1:0")
+				c.client = &http.Client{
+					Transport: &http.Transport{
+						DialContext: (&net.Dialer{
+							Timeout: 1 * time.Nanosecond,
+						}).DialContext,
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var server *httptest.Server
+			if tt.setupClient == nil {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/git-receive-pack" {
+						t.Errorf("expected path /git-receive-pack, got %s", r.URL.Path)
+						return
+					}
+					if r.Method != http.MethodPost {
+						t.Errorf("expected method POST, got %s", r.Method)
+						return
+					}
+
+					// Check default headers
+					if gitProtocol := r.Header.Get("Git-Protocol"); gitProtocol != "version=2" {
+						t.Errorf("expected Git-Protocol header 'version=2', got %s", gitProtocol)
+						return
+					}
+					if userAgent := r.Header.Get("User-Agent"); userAgent != "nanogit/0" {
+						t.Errorf("expected User-Agent header 'nanogit/0', got %s", userAgent)
+						return
+					}
+
+					w.WriteHeader(tt.statusCode)
+					if _, err := w.Write([]byte(tt.responseBody)); err != nil {
+						t.Errorf("failed to write response: %v", err)
+						return
+					}
+				}))
+				defer server.Close()
+			}
+
+			url := "http://127.0.0.1:0"
+			if server != nil {
+				url = server.URL
+			}
+
+			client, err := New(url)
+			require.NoError(t, err)
+			if tt.setupClient != nil {
+				c, ok := client.(*clientImpl)
+				require.True(t, ok, "client should be of type *client")
+				tt.setupClient(c)
+			}
+
+			response, err := client.ReceivePack(context.Background(), []byte("test data"))
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+				require.Empty(t, response)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedResult, string(response))
+			}
+		})
+	}
+}
+
+func TestSmartInfo(t *testing.T) {
 	tests := []struct {
 		name           string
 		statusCode     int
@@ -387,8 +512,8 @@ func TestSmartInfoRequest(t *testing.T) {
 						t.Errorf("expected path starting with /info/refs, got %s", r.URL.Path)
 						return
 					}
-					if r.URL.Query().Get("service") != "git-upload-pack" {
-						t.Errorf("expected service=git-upload-pack, got %s", r.URL.Query().Get("service"))
+					if r.URL.Query().Get("service") != "custom-service" {
+						t.Errorf("expected service=custom-service, got %s", r.URL.Query().Get("service"))
 						return
 					}
 					if r.Method != http.MethodGet {
@@ -428,7 +553,7 @@ func TestSmartInfoRequest(t *testing.T) {
 				tt.setupClient(c)
 			}
 
-			response, err := client.SmartInfoRequest(context.Background())
+			response, err := client.SmartInfo(context.Background(), "custom-service")
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -495,7 +620,7 @@ func TestAuthentication(t *testing.T) {
 			client, err := New(server.URL, tt.authOption)
 			require.NoError(t, err)
 
-			_, err = client.SendCommands(context.Background(), []byte("test"))
+			_, err = client.UploadPack(context.Background(), []byte("test"))
 			require.NoError(t, err)
 		})
 	}

--- a/client/integration/refs_test.go
+++ b/client/integration/refs_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient_ListRefs(t *testing.T) {
+func TestClient_Refs(t *testing.T) {
 	// set up remote repo
 	gitServer := helpers.NewGitServer(t)
 	user := gitServer.CreateUser(t)
@@ -63,4 +63,16 @@ func TestClient_ListRefs(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t, wantRefs, refs)
+
+	// Get refs one by one
+	for _, ref := range wantRefs {
+		ref, err := gitClient.GetRef(ctx, ref.Name)
+		require.NoError(t, err, "GetRef failed: %v", err)
+		assert.Equal(t, ref.Name, ref.Name)
+		assert.Equal(t, hash, ref.Hash)
+	}
+
+	// get-ref with non-existent ref
+	_, err = gitClient.GetRef(ctx, "refs/heads/non-existent")
+	require.Equal(t, err, client.ErrRefNotFound)
 }

--- a/client/refs.go
+++ b/client/refs.go
@@ -62,6 +62,24 @@ func (c *clientImpl) ListRefs(ctx context.Context) ([]Ref, error) {
 	return refs, nil
 }
 
+// GetRef sends a request to get a single reference in the repository.
+// It returns the reference name, hash, and any error encountered.
+// FIXME: In protocol v1, you cannot filter the refs you want to get.
+func (c *clientImpl) GetRef(ctx context.Context, ref string) (Ref, error) {
+	refs, err := c.ListRefs(ctx)
+	if err != nil {
+		return Ref{}, fmt.Errorf("list refs: %w", err)
+	}
+
+	for _, r := range refs {
+		if r.Name == ref {
+			return r, nil
+		}
+	}
+
+	return Ref{}, ErrRefNotFound
+}
+
 // parseRefLine parses a single reference line from the git response.
 // Returns the reference name, hash, and any error encountered.
 func parseRefLine(line []byte) (ref, hash string, err error) {

--- a/client/refs.go
+++ b/client/refs.go
@@ -23,7 +23,7 @@ type Ref struct {
 // It returns a map of reference names to their commit hashes.
 func (c *clientImpl) ListRefs(ctx context.Context) ([]Ref, error) {
 	// First get the initial capability advertisement
-	_, err := c.SmartInfoRequest(ctx)
+	_, err := c.SmartInfo(ctx, "git-upload-pack")
 	if err != nil {
 		return nil, fmt.Errorf("get repository info: %w", err)
 	}
@@ -38,7 +38,7 @@ func (c *clientImpl) ListRefs(ctx context.Context) ([]Ref, error) {
 		return nil, fmt.Errorf("format ls-refs command: %w", err)
 	}
 
-	refsData, err := c.SendCommands(ctx, pkt)
+	refsData, err := c.UploadPack(ctx, pkt)
 	if err != nil {
 		return nil, fmt.Errorf("send ls-refs command: %w", err)
 	}

--- a/client/refs_test.go
+++ b/client/refs_test.go
@@ -165,3 +165,96 @@ func TestListRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		infoRefsResp  string
+		lsRefsResp    string
+		refToGet      string
+		expectedRef   Ref
+		expectedError error
+		setupClient   func(*clientImpl)
+	}{
+		{
+			name:         "successful get of existing ref",
+			infoRefsResp: "001e# service=git-upload-pack\n0000",
+			lsRefsResp: func() string {
+				pkt, _ := protocol.FormatPacks(
+					protocol.PackLine("7fd1a60b01f91b314f59955a4e4d4e80d8edf11d refs/heads/master\n"),
+				)
+				return string(pkt)
+			}(),
+			refToGet: "refs/heads/master",
+			expectedRef: Ref{
+				Name: "refs/heads/master",
+				Hash: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			},
+			expectedError: nil,
+		},
+		{
+			name:         "get non-existent ref",
+			infoRefsResp: "001e# service=git-upload-pack\n0000",
+			lsRefsResp: func() string {
+				pkt, _ := protocol.FormatPacks(
+					protocol.PackLine("7fd1a60b01f91b314f59955a4e4d4e80d8edf11d refs/heads/master\n"),
+				)
+				return string(pkt)
+			}(),
+			refToGet:      "refs/heads/non-existent",
+			expectedRef:   Ref{},
+			expectedError: ErrRefNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var server *httptest.Server
+			if tt.setupClient == nil {
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if strings.HasPrefix(r.URL.Path, "/info/refs") {
+						if _, err := w.Write([]byte(tt.infoRefsResp)); err != nil {
+							t.Errorf("failed to write response: %v", err)
+							return
+						}
+						return
+					}
+					if r.URL.Path == "/git-upload-pack" {
+						if _, err := w.Write([]byte(tt.lsRefsResp)); err != nil {
+							t.Errorf("failed to write response: %v", err)
+							return
+						}
+						return
+					}
+					t.Errorf("unexpected request path: %s", r.URL.Path)
+				}))
+				defer server.Close()
+			}
+
+			url := "http://127.0.0.1:0"
+			if server != nil {
+				url = server.URL
+			}
+
+			client, err := New(url)
+			require.NoError(t, err)
+			if tt.setupClient != nil {
+				c, ok := client.(*clientImpl)
+				require.True(t, ok, "client should be of type *client")
+				tt.setupClient(c)
+			}
+
+			ref, err := client.GetRef(context.Background(), tt.refToGet)
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err)
+				require.Equal(t, Ref{}, ref)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedRef, ref)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func run() error {
 	}
 
 	{
-		reply, err := c.SmartInfoRequest(ctx)
+		reply, err := c.SmartInfo(ctx, "git-upload-pack")
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func run() error {
 		return err
 	}
 
-	refsData, err := c.SendCommands(ctx, pkt)
+	refsData, err := c.UploadPack(ctx, pkt)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func run() error {
 		return err
 	}
 
-	out, err := c.SendCommands(ctx, pkt)
+	out, err := c.UploadPack(ctx, pkt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Implement basic ref operations in client (Get, Create, Delete).

## Why

<!-- Explain the motivation behind these changes -->

For Git Sync we need basic operations to check if a branch exist or to create it.

## How

<!-- Describe how these changes were implemented -->

- Refactor raw client to have receive and upload packs.
- [ ] Add `GetRef`.
- [ ] Add `DeleteRef`.
- [ ] Add `CreateRef`.
- Content-Type header not part of default headers.

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changes have been tested locally.

