### PR TITLE
Use public codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,9 @@ jobs:
           CGO_ENABLED: 1
         run: make test
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.4.3
         with:
+          files: ./coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
-          apk add --no-cache git make gcc musl-dev bash
+          apk add --no-cache git make gcc musl-dev bash curl gpg
       - name: Run tests
         env:
           CGO_ENABLED: 1
@@ -55,6 +55,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
+          fail_ci_if_error: true
           files: ./coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           CGO_ENABLED: 1
         run: make test
       - name: Upload coverage
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           files: ./coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
-          apk add --no-cache git make gcc musl-dev
+          apk add --no-cache git make gcc musl-dev bash
       - name: Run tests
         env:
           CGO_ENABLED: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
         env:
           CGO_ENABLED: 1
         run: make test
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   security:
     name: Security

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.env
 __debug_bin*
 vendor
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 
 .PHONY: test-unit
 test-unit: lint
-	go test -cover -race -parallel 4 ./...
+	go test -coverprofile=coverage.txt -covermode=atomic -race -parallel 4 ./...
 
 .PHONY: test-integration
 test-integration: lint

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A limited, cloud-ready Git implementation for use in Grafana.
 [![License](https://img.shields.io/github/license/grafana/nanogit)](LICENSE.md)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/nanogit)](https://goreportcard.com/report/github.com/grafana/nanogit)
 [![GoDoc](https://godoc.org/github.com/grafana/nanogit?status.svg)](https://godoc.org/github.com/grafana/nanogit)
+[![codecov](https://codecov.io/gh/grafana/nanogit/branch/main/graph/badge.svg)](https://codecov.io/gh/grafana/nanogit)
 
 ## Overview
 


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Attempt to use public Codecov as other OSS in Grafana org.

![image](https://github.com/user-attachments/assets/5cafd804-6aa1-4cd2-a417-9b35f695282a)


## Why

<!-- Explain the motivation behind these changes -->

To have visibility of code coverage in the public repo.

## How

<!-- Describe how these changes were implemented -->

Add Codecov GitHub Action to the workflow. This action will upload the coverage report to Codecov.

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

