### PR TITLE
Make CI test execution faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run linter
         run: make lint
 
-  test:
-    name: Test
+  test-unit:
+    name: Unit Tests
     runs-on: ubuntu-latest
     container:
       image: golang:1.24-alpine
@@ -48,16 +48,51 @@ jobs:
       - name: Install build dependencies
         run: |
           apk add --no-cache git make gcc musl-dev bash curl gpg
-      - name: Run tests
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run unit tests
         env:
           CGO_ENABLED: 1
-        run: make test
+          GOFLAGS: -mod=vendor
+        run: make test-unit
       - name: Upload coverage
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           fail_ci_if_error: true
           files: ./coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.24-alpine
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache git make gcc musl-dev bash curl gpg
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run integration tests
+        env:
+          CGO_ENABLED: 1
+          GOFLAGS: -mod=vendor
+        run: make test-integration
 
   security:
     name: Security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Sync vendor directory
+        run: go mod vendor
       - name: Run unit tests
         env:
           CGO_ENABLED: 1
@@ -88,6 +90,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+      - name: Sync vendor directory
+        run: go mod vendor
       - name: Run integration tests
         env:
           CGO_ENABLED: 1

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ lint:
 
 .PHONY: test-unit
 test-unit: lint
-	go test -coverprofile=coverage.txt -covermode=atomic -race -parallel 4 ./...
+	go test -coverprofile=coverage.txt -covermode=atomic -race -parallel 6 ./...
 
 .PHONY: test-integration
-test-integration: lint
-	go test -tags=integration -cover -race -parallel 4 ./client/integration/...
+test-integration:
+	go test -tags=integration -cover -race -parallel 6 ./client/integration/...
 
 test: test-unit test-integration

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2 run
 
 .PHONY: test-unit
-test-unit: lint
+test-unit:
 	go test -coverprofile=coverage.txt -covermode=atomic -race -parallel 6 ./...
 
 .PHONY: test-integration


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Make CI execution faster.

## Why

<!-- Explain the motivation behind these changes -->

Improve dev cycle.

## How

<!-- Describe how these changes were implemented -->

- Split integration test from unit.
- Cache go modules.
- Increase parallel execution from 4 to 6
- Remove lint from make test

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

