### PR TITLE
Do not expose low-level primitives

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -16,7 +16,7 @@ import (
 //   - error if there are any other connection or protocol issues
 func (c *clientImpl) IsAuthorized(ctx context.Context) (bool, error) {
 	// First get the initial capability advertisement
-	_, err := c.SmartInfo(ctx, "git-upload-pack")
+	_, err := c.smartInfo(ctx, "git-upload-pack")
 	if err != nil {
 		if strings.Contains(err.Error(), "401 Unauthorized") {
 			return false, nil

--- a/client_test.go
+++ b/client_test.go
@@ -342,13 +342,13 @@ func TestUploadPack(t *testing.T) {
 
 			client, err := NewClient(url)
 			require.NoError(t, err)
+			c, ok := client.(*clientImpl)
+			require.True(t, ok, "client should be of type *client")
 			if tt.setupClient != nil {
-				c, ok := client.(*clientImpl)
-				require.True(t, ok, "client should be of type *client")
 				tt.setupClient(c)
 			}
 
-			response, err := client.UploadPack(context.Background(), []byte("test data"))
+			response, err := c.uploadPack(context.Background(), []byte("test data"))
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -467,13 +467,13 @@ func TestReceivePack(t *testing.T) {
 
 			client, err := NewClient(url)
 			require.NoError(t, err)
+			c, ok := client.(*clientImpl)
+			require.True(t, ok, "client should be of type *client")
 			if tt.setupClient != nil {
-				c, ok := client.(*clientImpl)
-				require.True(t, ok, "client should be of type *client")
 				tt.setupClient(c)
 			}
 
-			response, err := client.ReceivePack(context.Background(), []byte("test data"))
+			response, err := c.receivePack(context.Background(), []byte("test data"))
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -596,13 +596,13 @@ func TestSmartInfo(t *testing.T) {
 
 			client, err := NewClient(url)
 			require.NoError(t, err)
+			c, ok := client.(*clientImpl)
+			require.True(t, ok, "client should be of type *client")
 			if tt.setupClient != nil {
-				c, ok := client.(*clientImpl)
-				require.True(t, ok, "client should be of type *client")
 				tt.setupClient(c)
 			}
 
-			response, err := client.SmartInfo(context.Background(), "custom-service")
+			response, err := c.smartInfo(context.Background(), "custom-service")
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
@@ -669,7 +669,10 @@ func TestAuthentication(t *testing.T) {
 			client, err := NewClient(server.URL, tt.authOption)
 			require.NoError(t, err)
 
-			_, err = client.UploadPack(context.Background(), []byte("test"))
+			c, ok := client.(*clientImpl)
+			require.True(t, ok, "client should be of type *client")
+
+			_, err = c.uploadPack(context.Background(), []byte("test"))
 			require.NoError(t, err)
 		})
 	}

--- a/object.go
+++ b/object.go
@@ -27,7 +27,7 @@ func (c *clientImpl) GetObject(ctx context.Context, hash hash.Hash) (*protocol.P
 
 	c.logger.Debug("Fetch request", "object", hash.String(), "request", string(pkt))
 
-	out, err := c.UploadPack(ctx, pkt)
+	out, err := c.uploadPack(ctx, pkt)
 	if err != nil {
 		c.logger.Debug("UploadPack error", "object", hash.String(), "error", err)
 		if strings.Contains(err.Error(), "not our ref") {

--- a/refs.go
+++ b/refs.go
@@ -24,7 +24,7 @@ type Ref struct {
 // It returns a map of reference names to their commit hashes.
 func (c *clientImpl) ListRefs(ctx context.Context) ([]Ref, error) {
 	// First get the initial capability advertisement
-	_, err := c.SmartInfo(ctx, "git-upload-pack")
+	_, err := c.smartInfo(ctx, "git-upload-pack")
 	if err != nil {
 		return nil, fmt.Errorf("get repository info: %w", err)
 	}
@@ -39,7 +39,7 @@ func (c *clientImpl) ListRefs(ctx context.Context) ([]Ref, error) {
 		return nil, fmt.Errorf("format ls-refs command: %w", err)
 	}
 
-	refsData, err := c.UploadPack(ctx, pkt)
+	refsData, err := c.uploadPack(ctx, pkt)
 	if err != nil {
 		return nil, fmt.Errorf("send ls-refs command: %w", err)
 	}
@@ -93,7 +93,7 @@ func (c *clientImpl) CreateRef(ctx context.Context, ref Ref) error {
 	}
 
 	// First get the initial capability advertisement
-	_, err = c.SmartInfo(ctx, "git-receive-pack")
+	_, err = c.smartInfo(ctx, "git-receive-pack")
 	if err != nil {
 		return fmt.Errorf("get receive-pack capability: %w", err)
 	}
@@ -104,7 +104,7 @@ func (c *clientImpl) CreateRef(ctx context.Context, ref Ref) error {
 	}
 
 	// Send the ref update
-	_, err = c.ReceivePack(ctx, pkt)
+	_, err = c.receivePack(ctx, pkt)
 	if err != nil {
 		return fmt.Errorf("send ref update: %w", err)
 	}
@@ -125,7 +125,7 @@ func (c *clientImpl) UpdateRef(ctx context.Context, ref Ref) error {
 	}
 
 	// First get the initial capability advertisement
-	_, err = c.SmartInfo(ctx, "git-receive-pack")
+	_, err = c.smartInfo(ctx, "git-receive-pack")
 	if err != nil {
 		return fmt.Errorf("get receive-pack capability: %w", err)
 	}
@@ -137,7 +137,7 @@ func (c *clientImpl) UpdateRef(ctx context.Context, ref Ref) error {
 	}
 
 	// Send the ref update
-	_, err = c.ReceivePack(ctx, pkt)
+	_, err = c.receivePack(ctx, pkt)
 	if err != nil {
 		return fmt.Errorf("update ref: %w", err)
 	}
@@ -159,7 +159,7 @@ func (c *clientImpl) DeleteRef(ctx context.Context, refName string) error {
 	}
 
 	// First get the initial capability advertisement
-	_, err = c.SmartInfo(ctx, "git-receive-pack")
+	_, err = c.smartInfo(ctx, "git-receive-pack")
 	if err != nil {
 		return fmt.Errorf("get receive-pack capability: %w", err)
 	}
@@ -171,7 +171,7 @@ func (c *clientImpl) DeleteRef(ctx context.Context, refName string) error {
 	}
 
 	// Send the ref update
-	_, err = c.ReceivePack(ctx, pkt)
+	_, err = c.receivePack(ctx, pkt)
 	if err != nil {
 		return fmt.Errorf("delete ref: %w", err)
 	}

--- a/repo.go
+++ b/repo.go
@@ -14,7 +14,7 @@ import (
 //   - false if the repository does not exist (404)
 //   - error if there are any other connection or protocol issues
 func (c *clientImpl) RepoExists(ctx context.Context) (bool, error) {
-	_, err := c.SmartInfo(ctx, "git-upload-pack")
+	_, err := c.smartInfo(ctx, "git-upload-pack")
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
 			return false, nil


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Do not expose low-level primitives in the public client interface.

## Why

<!-- Explain the motivation behind these changes -->

Just to keep to the minimum and avoid misused until those methods can be exposed in a better way.

## How

<!-- Describe how these changes were implemented -->

Remove them from the interface and made them private.

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

