### PR TITLE
Optimize requests

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -82,7 +82,6 @@ type Blob struct {
 //	}
 //	fmt.Printf("File content: %s\n", string(blob.Content))
 func (c *httpClient) GetBlobByPath(ctx context.Context, rootHash hash.Hash, path string) (*Blob, error) {
-	// TODO: optimize this one
 	if path == "" {
 		return nil, errors.New("path cannot be empty")
 	}

--- a/blob.go
+++ b/blob.go
@@ -29,8 +29,7 @@ import (
 //	}
 //	fmt.Printf("File content: %s\n", string(blob.Content))
 func (c *httpClient) GetBlob(ctx context.Context, blobID hash.Hash) (*Blob, error) {
-	// TODO: optimize this one
-	obj, err := c.getSingleObject(ctx, blobID)
+	obj, err := c.getBlob(ctx, blobID)
 	if err != nil {
 		return nil, fmt.Errorf("get object: %w", err)
 	}

--- a/client.go
+++ b/client.go
@@ -127,6 +127,7 @@ func (c *httpClient) uploadPack(ctx context.Context, data []byte) ([]byte, error
 	// See: https://git-scm.com/docs/protocol-v2#_http_transport
 	u := c.base.JoinPath("git-upload-pack").String()
 
+	c.logger.Info("UploadPack", "url", u)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, body)
 	if err != nil {
 		return nil, err
@@ -146,7 +147,14 @@ func (c *httpClient) uploadPack(ctx context.Context, data []byte) ([]byte, error
 		return nil, fmt.Errorf("got status code %d: %s", res.StatusCode, res.Status)
 	}
 
-	return io.ReadAll(res.Body)
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	c.logger.Info("UploadPack", "status", res.StatusCode, "statusText", res.Status, "responseBody", string(responseBody), "requestBody", string(data), "url", u)
+
+	return responseBody, nil
 }
 
 // receivePack sends a POST request to the git-receive-pack endpoint.

--- a/commit.go
+++ b/commit.go
@@ -220,8 +220,7 @@ func (c *httpClient) compareTrees(base, head *FlatTree) ([]CommitFile, error) {
 //	}
 //	fmt.Printf("Commit by %s: %s\n", commit.Author.Name, commit.Message)
 func (c *httpClient) GetCommit(ctx context.Context, hash hash.Hash) (*Commit, error) {
-	// TODO: optimize this one
-	commit, err := c.getSingleObject(ctx, hash)
+	commit, err := c.getCommit(ctx, hash)
 	if err != nil {
 		return nil, fmt.Errorf("getting commit: %w", err)
 	}

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package nanogit
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/grafana/nanogit/protocol"
 	"github.com/grafana/nanogit/protocol/hash"
@@ -27,6 +28,10 @@ var (
 	// ErrNothingToCommit is returned when attempting to commit but no changes have been staged.
 	// This error should only be used with errors.Is() for comparison, not for type assertions.
 	ErrNothingToCommit = errors.New("nothing to commit")
+
+	// ErrUnexpectedObjectCount is returned when the number of objects returned by the server is unexpected.
+	// This error should only be used with errors.Is() for comparison, not for type assertions.
+	ErrUnexpectedObjectCount = errors.New("unexpected object count")
 )
 
 // ObjectNotFoundError provides structured information about a Git object that was not found.
@@ -68,6 +73,29 @@ func (e *ObjectAlreadyExistsError) Unwrap() error {
 func NewObjectAlreadyExistsError(objectID hash.Hash) *ObjectAlreadyExistsError {
 	return &ObjectAlreadyExistsError{
 		ObjectID: objectID,
+	}
+}
+
+// UnexpectedObjectCountError provides structured information about a Git object with an unexpected count.
+type UnexpectedObjectCountError struct {
+	ExpectedCount int
+	ActualCount   int
+}
+
+func (e *UnexpectedObjectCountError) Error() string {
+	return "unexpected object count: expected " + strconv.Itoa(e.ExpectedCount) + " but got " + strconv.Itoa(e.ActualCount)
+}
+
+// Unwrap enables errors.Is() compatibility with ErrUnexpectedObjectCount
+func (e *UnexpectedObjectCountError) Unwrap() error {
+	return ErrUnexpectedObjectCount
+}
+
+// NewUnexpectedObjectCountError creates a new UnexpectedObjectCountError with the specified details.
+func NewUnexpectedObjectCountError(expectedCount, actualCount int) *UnexpectedObjectCountError {
+	return &UnexpectedObjectCountError{
+		ExpectedCount: expectedCount,
+		ActualCount:   actualCount,
 	}
 }
 

--- a/object.go
+++ b/object.go
@@ -74,13 +74,6 @@ func (c *httpClient) getTree(ctx context.Context, want hash.Hash) (*protocol.Pac
 	// Due to Git protocol limitations, when fetching a tree object, we receive all tree objects
 	// in the path. We must filter the response to extract only the requested tree.
 	if obj, ok := objects[want.String()]; ok {
-		expected := len(obj.Tree) + 1
-		// We got more objects than expected, which means we got recursive trees
-		// We don't care if we got less, as we got the wanted tree
-		if len(objects) > expected {
-			return nil, NewUnexpectedObjectCountError(expected, objects)
-		}
-
 		return obj, nil
 	}
 

--- a/object.go
+++ b/object.go
@@ -23,6 +23,83 @@ func (c *httpClient) getSingleObject(ctx context.Context, want hash.Hash) (*prot
 	return nil, NewObjectNotFoundError(want)
 }
 
+func (c *httpClient) getTree(ctx context.Context, want hash.Hash) (*protocol.PackfileObject, error) {
+	packs := []protocol.Pack{
+		protocol.PackLine("command=fetch\n"),
+		protocol.PackLine("object-format=sha1\n"),
+		protocol.SpecialPack(protocol.DelimeterPacket),
+		protocol.PackLine("no-progress\n"),
+		protocol.PackLine("filter blob:none\n"),
+		protocol.PackLine(fmt.Sprintf("want %s\n", want.String())),
+		protocol.PackLine("done\n"),
+	}
+
+	pkt, err := protocol.FormatPacks(packs...)
+	if err != nil {
+		return nil, fmt.Errorf("formatting packets: %w", err)
+	}
+
+	c.logger.Debug("Specific fetch request", "want", want, "request", string(pkt))
+
+	out, err := c.uploadPack(ctx, pkt)
+	if err != nil {
+		c.logger.Debug("UploadPack error", "want", want, "error", err)
+		if strings.Contains(err.Error(), "not our ref") {
+			return nil, NewObjectNotFoundError(want)
+		}
+		return nil, fmt.Errorf("sending commands: %w", err)
+	}
+
+	c.logger.Debug("Raw server response", "want", want, "response", hex.EncodeToString(out))
+
+	lines, _, err := protocol.ParsePack(out)
+	if err != nil {
+		c.logger.Debug("ParsePack error", "want", want, "error", err)
+		return nil, fmt.Errorf("parsing packet: %w", err)
+	}
+
+	c.logger.Debug("Parsed lines", "want", want, "lines", lines)
+
+	response, err := protocol.ParseFetchResponse(lines)
+	if err != nil {
+		c.logger.Debug("ParseFetchResponse error", "want", want, "error", err)
+		return nil, fmt.Errorf("parsing fetch response: %w", err)
+	}
+
+	objects := make(map[string]*protocol.PackfileObject)
+	for {
+		obj, err := response.Packfile.ReadObject()
+		if err != nil {
+			c.logger.Debug("ReadObject error", "want", want, "error", err)
+			break
+		}
+		if obj.Object == nil {
+			break
+		}
+
+		if obj.Object.Type != protocol.ObjectTypeTree {
+			return nil, NewUnexpectedObjectTypeError(want, protocol.ObjectTypeTree, obj.Object.Type)
+		}
+
+		objects[obj.Object.Hash.String()] = obj.Object
+	}
+
+	// Due to Git protocol limitations, when fetching a tree object, we receive all tree objects
+	// in the path. We must filter the response to extract only the requested tree.
+	if obj, ok := objects[want.String()]; ok {
+		expected := len(obj.Tree) + 1
+		// We got more objects than expected, which means we got recursive trees
+		// We don't care if we got less, as we got the wanted tree
+		if len(objects) > expected {
+			return nil, NewUnexpectedObjectCountError(expected, objects)
+		}
+
+		return obj, nil
+	}
+
+	return nil, NewObjectNotFoundError(want)
+}
+
 func (c *httpClient) getCommit(ctx context.Context, want hash.Hash) (*protocol.PackfileObject, error) {
 	packs := []protocol.Pack{
 		protocol.PackLine("command=fetch\n"),

--- a/object.go
+++ b/object.go
@@ -156,9 +156,9 @@ func (c *httpClient) getCommit(ctx context.Context, want hash.Hash) (*protocol.P
 			break
 		}
 
-		// Skip tree objects as they are included in the response
-		// despite requesting blob:none filter, since most Git servers
-		// don't support the tree:0 filter specification
+		// Skip tree objects that are included in the response despite the blob:none filter.
+		// Most Git servers don't support tree:0 filter specification, so we may receive
+		// recursive tree objects that we need to filter out.
 		if obj.Object.Type == protocol.ObjectTypeTree {
 			continue
 		}
@@ -170,6 +170,7 @@ func (c *httpClient) getCommit(ctx context.Context, want hash.Hash) (*protocol.P
 		objects[obj.Object.Hash.String()] = obj.Object
 	}
 
+	// we got more commits than expected
 	if len(objects) > 1 {
 		return nil, NewUnexpectedObjectCountError(1, objects)
 	}

--- a/object.go
+++ b/object.go
@@ -23,6 +23,23 @@ func (c *httpClient) getSingleObject(ctx context.Context, want hash.Hash) (*prot
 	return nil, NewObjectNotFoundError(want)
 }
 
+func (c *httpClient) getBlob(ctx context.Context, want hash.Hash) (*protocol.PackfileObject, error) {
+	objects, err := c.getObjects(ctx, want)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(objects) != 1 {
+		return nil, NewUnexpectedObjectCountError(1, len(objects))
+	}
+
+	if obj, ok := objects[want.String()]; ok {
+		return obj, nil
+	}
+
+	return nil, NewObjectNotFoundError(want)
+}
+
 // getRootTree fetches the root tree of the repository.
 func (c *httpClient) getCommitTree(ctx context.Context, commitHash hash.Hash) (map[string]*protocol.PackfileObject, error) {
 	packs := []protocol.Pack{

--- a/object.go
+++ b/object.go
@@ -10,19 +10,6 @@ import (
 	"github.com/grafana/nanogit/protocol/hash"
 )
 
-func (c *httpClient) getSingleObject(ctx context.Context, want hash.Hash) (*protocol.PackfileObject, error) {
-	objects, err := c.getObjects(ctx, want)
-	if err != nil {
-		return nil, err
-	}
-
-	if obj, ok := objects[want.String()]; ok {
-		return obj, nil
-	}
-
-	return nil, NewObjectNotFoundError(want)
-}
-
 func (c *httpClient) getTree(ctx context.Context, want hash.Hash) (*protocol.PackfileObject, error) {
 	packs := []protocol.Pack{
 		protocol.PackLine("command=fetch\n"),

--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/grafana/nanogit"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/test/commits_test.go
+++ b/test/commits_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/grafana/nanogit/protocol/hash"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/test/helpers/localrepo.go
+++ b/test/helpers/localrepo.go
@@ -135,7 +135,7 @@ func (r *LocalGitRepo) QuickInit(user *User, remoteURL string) (client nanogit.C
 	r.logger.Info("📦 [LOCAL] Tracking current branch")
 	r.Git("branch", "--set-upstream-to=origin/main", "main")
 
-	client, err := nanogit.NewHTTPClient(remoteURL, nanogit.WithBasicAuth(user.Username, user.Password))
+	client, err := nanogit.NewHTTPClient(remoteURL, nanogit.WithBasicAuth(user.Username, user.Password), nanogit.WithLogger(r.logger))
 	Expect(err).NotTo(HaveOccurred())
 	return client, "test.txt"
 }

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/grafana/nanogit"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/test/refs_test.go
+++ b/test/refs_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/grafana/nanogit/protocol/hash"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/test/repo_test.go
+++ b/test/repo_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/grafana/nanogit"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/test/tree_test.go
+++ b/test/tree_test.go
@@ -9,9 +9,7 @@ import (
 	"github.com/grafana/nanogit/protocol/hash"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/test/writer_test.go
+++ b/test/writer_test.go
@@ -14,9 +14,7 @@ import (
 	"github.com/grafana/nanogit/protocol/hash"
 	"github.com/grafana/nanogit/test/helpers"
 
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/ginkgo/v2"
-	//nolint:stylecheck // specifically ignore ST1001 (dot-imports)
 	. "github.com/onsi/gomega"
 )
 

--- a/tree.go
+++ b/tree.go
@@ -586,7 +586,6 @@ func (c *httpClient) GetTree(ctx context.Context, h hash.Hash) (*Tree, error) {
 //	    fmt.Printf("%s\n", entry.Name)
 //	}
 func (c *httpClient) GetTreeByPath(ctx context.Context, rootHash hash.Hash, path string) (*Tree, error) {
-	// TODO: optimize this one
 	if path == "" || path == "." {
 		// Return the root tree
 		return c.GetTree(ctx, rootHash)

--- a/tree.go
+++ b/tree.go
@@ -2,7 +2,6 @@ package nanogit
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -504,7 +503,7 @@ func (c *httpClient) flatten(treeHash hash.Hash, allTreeObjects map[string]*prot
 //
 // Parameters:
 //   - ctx: Context for the operation
-//   - h: Hash of either a tree object or commit object
+//   - h: Hash of either a tree object
 //
 // Returns:
 //   - *Tree: Tree object containing direct children only
@@ -521,30 +520,13 @@ func (c *httpClient) flatten(treeHash hash.Hash, allTreeObjects map[string]*prot
 //	    }
 //	}
 func (c *httpClient) GetTree(ctx context.Context, h hash.Hash) (*Tree, error) {
-	// TODO: optimize this one
-	obj, err := c.getSingleObject(ctx, h)
+	tree, err := c.getTree(ctx, h)
 	if err != nil {
-		return nil, fmt.Errorf("getting object: %w", err)
+		return nil, fmt.Errorf("get tree object: %w", err)
 	}
 
-	var tree *protocol.PackfileObject
-	if obj.Type == protocol.ObjectTypeCommit && obj.Hash.Is(h) {
-		// If it's a commit, get the tree hash from it
-		treeHash, err := hash.FromHex(obj.Commit.Tree.String())
-		if err != nil {
-			return nil, fmt.Errorf("parsing tree hash: %w", err)
-		}
-
-		treeObj, err := c.getSingleObject(ctx, treeHash)
-		if err != nil {
-			return nil, fmt.Errorf("getting tree: %w", err)
-		}
-		tree = treeObj
-		h = treeHash
-	} else if obj.Type == protocol.ObjectTypeTree && obj.Hash.Is(h) {
-		tree = obj
-	} else {
-		return nil, errors.New("not found")
+	if tree.Type != protocol.ObjectTypeTree {
+		return nil, NewUnexpectedObjectTypeError(h, protocol.ObjectTypeTree, tree.Type)
 	}
 
 	// Convert PackfileTreeEntry to TreeEntry (direct children only)

--- a/tree.go
+++ b/tree.go
@@ -525,10 +525,6 @@ func (c *httpClient) GetTree(ctx context.Context, h hash.Hash) (*Tree, error) {
 		return nil, fmt.Errorf("get tree object: %w", err)
 	}
 
-	if tree.Type != protocol.ObjectTypeTree {
-		return nil, NewUnexpectedObjectTypeError(h, protocol.ObjectTypeTree, tree.Type)
-	}
-
 	// Convert PackfileTreeEntry to TreeEntry (direct children only)
 	entries := make([]TreeEntry, len(tree.Tree))
 	for i, entry := range tree.Tree {

--- a/writer.go
+++ b/writer.go
@@ -70,12 +70,11 @@ func (c *httpClient) NewStagedWriter(ctx context.Context, ref Ref) (StagedWriter
 	// Create a packfile writer
 	writer := protocol.NewPackfileWriter(crypto.SHA1)
 	return &stagedWriter{
-		httpClient: c,
-		ref:        ref,
-		writer:     writer,
-		lastCommit: commit,
-		lastTree:   treeObj,
-		// TODO: I think we only need one
+		httpClient:  c,
+		ref:         ref,
+		writer:      writer,
+		lastCommit:  commit,
+		lastTree:    treeObj,
 		treeCache:   cache,
 		treeEntries: entries,
 	}, nil

--- a/writer.go
+++ b/writer.go
@@ -45,13 +45,9 @@ func (c *httpClient) NewStagedWriter(ctx context.Context, ref Ref) (StagedWriter
 		return nil, fmt.Errorf("getting root tree: %w", err)
 	}
 
-	treeObj, err := c.getSingleObject(ctx, commit.Tree)
+	treeObj, err := c.getTree(ctx, commit.Tree)
 	if err != nil {
 		return nil, fmt.Errorf("getting tree object: %w", err)
-	}
-
-	if treeObj.Type != protocol.ObjectTypeTree {
-		return nil, errors.New("root is not a tree")
 	}
 
 	cache := make(map[string]*protocol.PackfileObject)
@@ -557,7 +553,7 @@ func (w *stagedWriter) addMissingOrStaleTreeEntries(ctx context.Context, path st
 			if !ok {
 				w.logger.Info("fetch tree not found in cache", "path", currentPath, "hash", existingObj.Hash.String())
 				var err error
-				existingTree, err = w.getSingleObject(ctx, existingObj.Hash)
+				existingTree, err = w.getTree(ctx, existingObj.Hash)
 				if err != nil {
 					return fmt.Errorf("get existing tree %s: %w", currentPath, err)
 				}
@@ -708,7 +704,7 @@ func (w *stagedWriter) removeBlobFromTree(ctx context.Context, path string) erro
 		treeObj, ok := w.treeCache[existingObj.Hash.String()]
 		if !ok {
 			var err error
-			treeObj, err = w.getSingleObject(ctx, existingObj.Hash)
+			treeObj, err = w.getTree(ctx, existingObj.Hash)
 			if err != nil {
 				return fmt.Errorf("get tree %s: %w", currentPath, err)
 			}
@@ -825,7 +821,7 @@ func (w *stagedWriter) removeTreeFromTree(ctx context.Context, path string) erro
 		treeObj, ok := w.treeCache[existingObj.Hash.String()]
 		if !ok {
 			var err error
-			treeObj, err = w.getSingleObject(ctx, existingObj.Hash)
+			treeObj, err = w.getTree(ctx, existingObj.Hash)
 			if err != nil {
 				return fmt.Errorf("get tree %s: %w", currentPath, err)
 			}


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Optimize requests to fetch the minimum number of objects possible and the make the least amount of requests (in safe and scalable way).

## Why

<!-- Explain the motivation behind these changes -->

The implementation of some of the functions don't scale very well when using the library with big repositories or with a lot of history.

## How

<!-- Describe how these changes were implemented -->

- Remove nolint from where it's not needed
- Optimize `GetRef`
- Optimize `GetBlob`
- Optimize `GetCommit`
- Remove todo for `GetBlobByPath` as it's already implemented in the best way.
- Optimize `Tree` operations.

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

Maybe there is more room for improvement but this should be a good start to use the library more confidently.


Excluded `ListCommits` in this PR.

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

