### PR TITLE
Refactor to have Object Storage

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -82,7 +82,7 @@ func NewObjectAlreadyExistsError(objectID hash.Hash) *ObjectAlreadyExistsError {
 type UnexpectedObjectCountError struct {
 	ExpectedCount int
 	ActualCount   int
-	Objects       map[string]*protocol.PackfileObject
+	Objects       []*protocol.PackfileObject
 }
 
 func (e *UnexpectedObjectCountError) Error() string {
@@ -99,7 +99,7 @@ func (e *UnexpectedObjectCountError) Unwrap() error {
 }
 
 // NewUnexpectedObjectCountError creates a new UnexpectedObjectCountError with the specified details.
-func NewUnexpectedObjectCountError(expectedCount int, objects map[string]*protocol.PackfileObject) *UnexpectedObjectCountError {
+func NewUnexpectedObjectCountError(expectedCount int, objects []*protocol.PackfileObject) *UnexpectedObjectCountError {
 	return &UnexpectedObjectCountError{
 		ExpectedCount: expectedCount,
 		ActualCount:   len(objects),

--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -31,6 +31,17 @@ func (s InMemoryStorage) Add(objs ...*protocol.PackfileObject) {
 	}
 }
 
+// TODO: This is a temporary function to add a map of objects to the storage.
+func (s InMemoryStorage) AddMap(objs map[string]*protocol.PackfileObject) {
+	for _, obj := range objs {
+		s[obj.Hash.String()] = obj
+	}
+}
+
 func (s InMemoryStorage) Delete(key hash.Hash) {
 	delete(s, key.String())
+}
+
+func (s InMemoryStorage) Len() int {
+	return len(s)
 }

--- a/internal/storage/inmemory.go
+++ b/internal/storage/inmemory.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+)
+
+type InMemoryStorage map[string]*protocol.PackfileObject
+
+func NewInMemoryStorage() InMemoryStorage {
+	return make(InMemoryStorage)
+}
+
+func (s InMemoryStorage) Get(key hash.Hash) (*protocol.PackfileObject, bool) {
+	obj, ok := s[key.String()]
+	return obj, ok
+}
+
+func (s InMemoryStorage) GetAllKeys() []hash.Hash {
+	keys := make([]hash.Hash, 0, len(s))
+	for key := range s {
+		keys = append(keys, hash.MustFromHex(key))
+	}
+
+	return keys
+}
+
+func (s InMemoryStorage) Add(objs ...*protocol.PackfileObject) {
+	for _, obj := range objs {
+		s[obj.Hash.String()] = obj
+	}
+}
+
+func (s InMemoryStorage) Delete(key hash.Hash) {
+	delete(s, key.String())
+}

--- a/internal/storage/inmemory_test.go
+++ b/internal/storage/inmemory_test.go
@@ -14,6 +14,7 @@ func TestInMemoryStorage(t *testing.T) {
 		storage := NewInMemoryStorage()
 		require.NotNil(t, storage)
 		require.Empty(t, storage)
+		require.Equal(t, 0, storage.Len())
 	})
 
 	t.Run("Add and Get", func(t *testing.T) {
@@ -27,6 +28,7 @@ func TestInMemoryStorage(t *testing.T) {
 		got, ok := storage.Get(obj.Hash)
 		require.True(t, ok)
 		require.Equal(t, obj, got)
+		require.Equal(t, 1, storage.Len())
 	})
 
 	t.Run("Get non-existent", func(t *testing.T) {
@@ -51,6 +53,7 @@ func TestInMemoryStorage(t *testing.T) {
 		storage.Add(obj1, obj2)
 		keys := storage.GetAllKeys()
 		require.Len(t, keys, 2)
+		require.Equal(t, 2, storage.Len())
 		require.Contains(t, keys, obj1.Hash)
 		require.Contains(t, keys, obj2.Hash)
 	})
@@ -67,6 +70,7 @@ func TestInMemoryStorage(t *testing.T) {
 		got, ok := storage.Get(obj.Hash)
 		require.False(t, ok)
 		require.Nil(t, got)
+		require.Equal(t, 0, storage.Len())
 	})
 
 	t.Run("Add multiple objects", func(t *testing.T) {
@@ -82,6 +86,35 @@ func TestInMemoryStorage(t *testing.T) {
 
 		storage.Add(obj1, obj2)
 		require.Len(t, storage, 2)
+		require.Equal(t, 2, storage.Len())
+
+		got1, ok1 := storage.Get(obj1.Hash)
+		require.True(t, ok1)
+		require.Equal(t, obj1, got1)
+
+		got2, ok2 := storage.Get(obj2.Hash)
+		require.True(t, ok2)
+		require.Equal(t, obj2, got2)
+	})
+
+	t.Run("AddMap", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		obj1 := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("0123456789abcdef"),
+			Type: protocol.ObjectTypeBlob,
+		}
+		obj2 := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("fedcba9876543210"),
+			Type: protocol.ObjectTypeTree,
+		}
+		objects := map[string]*protocol.PackfileObject{
+			obj1.Hash.String(): obj1,
+			obj2.Hash.String(): obj2,
+		}
+
+		storage.AddMap(objects)
+		require.Len(t, storage, 2)
+		require.Equal(t, 2, storage.Len())
 
 		got1, ok1 := storage.Get(obj1.Hash)
 		require.True(t, ok1)

--- a/internal/storage/inmemory_test.go
+++ b/internal/storage/inmemory_test.go
@@ -1,0 +1,94 @@
+package storage_test
+
+import (
+	"testing"
+
+	. "github.com/grafana/nanogit/internal/storage"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryStorage(t *testing.T) {
+	t.Run("NewInMemoryStorage", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		require.NotNil(t, storage)
+		require.Empty(t, storage)
+	})
+
+	t.Run("Add and Get", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		obj := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("0123456789abcdef"),
+			Type: protocol.ObjectTypeBlob,
+		}
+
+		storage.Add(obj)
+		got, ok := storage.Get(obj.Hash)
+		require.True(t, ok)
+		require.Equal(t, obj, got)
+	})
+
+	t.Run("Get non-existent", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		hash := hash.MustFromHex("0123456789abcdef")
+		got, ok := storage.Get(hash)
+		require.False(t, ok)
+		require.Nil(t, got)
+	})
+
+	t.Run("GetAllKeys", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		obj1 := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("0123456789abcdef"),
+			Type: protocol.ObjectTypeBlob,
+		}
+		obj2 := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("fedcba9876543210"),
+			Type: protocol.ObjectTypeTree,
+		}
+
+		storage.Add(obj1, obj2)
+		keys := storage.GetAllKeys()
+		require.Len(t, keys, 2)
+		require.Contains(t, keys, obj1.Hash)
+		require.Contains(t, keys, obj2.Hash)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		obj := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("0123456789abcdef"),
+			Type: protocol.ObjectTypeBlob,
+		}
+
+		storage.Add(obj)
+		storage.Delete(obj.Hash)
+		got, ok := storage.Get(obj.Hash)
+		require.False(t, ok)
+		require.Nil(t, got)
+	})
+
+	t.Run("Add multiple objects", func(t *testing.T) {
+		storage := NewInMemoryStorage()
+		obj1 := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("0123456789abcdef"),
+			Type: protocol.ObjectTypeBlob,
+		}
+		obj2 := &protocol.PackfileObject{
+			Hash: hash.MustFromHex("fedcba9876543210"),
+			Type: protocol.ObjectTypeTree,
+		}
+
+		storage.Add(obj1, obj2)
+		require.Len(t, storage, 2)
+
+		got1, ok1 := storage.Get(obj1.Hash)
+		require.True(t, ok1)
+		require.Equal(t, obj1, got1)
+
+		got2, ok2 := storage.Get(obj2.Hash)
+		require.True(t, ok2)
+		require.Equal(t, obj2, got2)
+	})
+}

--- a/object.go
+++ b/object.go
@@ -125,7 +125,8 @@ func (c *httpClient) getCommit(ctx context.Context, want hash.Hash) (*protocol.P
 		return nil, fmt.Errorf("parsing fetch response: %w", err)
 	}
 
-	objects := make(map[string]*protocol.PackfileObject)
+	objects := make([]*protocol.PackfileObject, 0)
+	var foundObj *protocol.PackfileObject
 	for {
 		obj, err := response.Packfile.ReadObject()
 		if err != nil {
@@ -147,7 +148,10 @@ func (c *httpClient) getCommit(ctx context.Context, want hash.Hash) (*protocol.P
 			return nil, NewUnexpectedObjectTypeError(want, protocol.ObjectTypeCommit, obj.Object.Type)
 		}
 
-		objects[obj.Object.Hash.String()] = obj.Object
+		objects = append(objects, obj.Object)
+		if obj.Object.Hash.Is(want) {
+			foundObj = obj.Object
+		}
 	}
 
 	// we got more commits than expected
@@ -155,25 +159,84 @@ func (c *httpClient) getCommit(ctx context.Context, want hash.Hash) (*protocol.P
 		return nil, NewUnexpectedObjectCountError(1, objects)
 	}
 
-	if obj, ok := objects[want.String()]; ok {
-		return obj, nil
+	if foundObj != nil {
+		return foundObj, nil
 	}
 
 	return nil, NewObjectNotFoundError(want)
 }
 
 func (c *httpClient) getBlob(ctx context.Context, want hash.Hash) (*protocol.PackfileObject, error) {
-	objects, err := c.getObjects(ctx, want)
-	if err != nil {
-		return nil, err
+	packs := []protocol.Pack{
+		protocol.PackLine("command=fetch\n"),
+		protocol.PackLine("object-format=sha1\n"),
+		protocol.SpecialPack(protocol.DelimeterPacket),
+		protocol.PackLine("no-progress\n"),
+		protocol.PackLine(fmt.Sprintf("want %s\n", want.String())),
+		protocol.PackLine("done\n"),
 	}
 
-	if len(objects) != 1 {
+	pkt, err := protocol.FormatPacks(packs...)
+	if err != nil {
+		return nil, fmt.Errorf("formatting packets: %w", err)
+	}
+
+	c.logger.Debug("Specific fetch request", "want", want, "request", string(pkt))
+
+	out, err := c.uploadPack(ctx, pkt)
+	if err != nil {
+		c.logger.Debug("UploadPack error", "want", want, "error", err)
+		if strings.Contains(err.Error(), "not our ref") {
+			return nil, NewObjectNotFoundError(want)
+		}
+		return nil, fmt.Errorf("sending commands: %w", err)
+	}
+
+	c.logger.Debug("Raw server response", "want", want, "response", hex.EncodeToString(out))
+
+	lines, _, err := protocol.ParsePack(out)
+	if err != nil {
+		c.logger.Debug("ParsePack error", "want", want, "error", err)
+		return nil, fmt.Errorf("parsing packet: %w", err)
+	}
+
+	c.logger.Debug("Parsed lines", "want", want, "lines", lines)
+
+	response, err := protocol.ParseFetchResponse(lines)
+	if err != nil {
+		c.logger.Debug("ParseFetchResponse error", "want", want, "error", err)
+		return nil, fmt.Errorf("parsing fetch response: %w", err)
+	}
+
+	objects := make([]*protocol.PackfileObject, 0)
+	var foundObj *protocol.PackfileObject
+	for {
+		obj, err := response.Packfile.ReadObject()
+		if err != nil {
+			c.logger.Debug("ReadObject error", "want", want, "error", err)
+			break
+		}
+		if obj.Object == nil {
+			break
+		}
+
+		if obj.Object.Type != protocol.ObjectTypeBlob {
+			return nil, NewUnexpectedObjectTypeError(want, protocol.ObjectTypeBlob, obj.Object.Type)
+		}
+
+		objects = append(objects, obj.Object)
+		if obj.Object.Hash.Is(want) {
+			foundObj = obj.Object
+		}
+	}
+
+	// we got more commits than expected
+	if len(objects) > 1 {
 		return nil, NewUnexpectedObjectCountError(1, objects)
 	}
 
-	if obj, ok := objects[want.String()]; ok {
-		return obj, nil
+	if foundObj != nil {
+		return foundObj, nil
 	}
 
 	return nil, NewObjectNotFoundError(want)

--- a/protocol/hash/hash.go
+++ b/protocol/hash/hash.go
@@ -23,6 +23,17 @@ func FromHex(hs string) (Hash, error) {
 	return Hash(b), err
 }
 
+// MustFromHex is like FromHex but panics if the hex string is invalid.
+// It is intended for use in tests and other situations where the hex string
+// is known to be valid.
+func MustFromHex(hs string) Hash {
+	h, err := FromHex(hs)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
 func (h Hash) String() string {
 	return hex.EncodeToString(h)
 }

--- a/protocol/hash/hash_test.go
+++ b/protocol/hash/hash_test.go
@@ -153,3 +153,40 @@ func TestHash_Is(t *testing.T) {
 		})
 	}
 }
+
+func TestMustFromHex(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      Hash
+		wantPanic bool
+	}{
+		{
+			name:      "valid hex string",
+			input:     "0123456789abcdef",
+			want:      Hash{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
+			wantPanic: false,
+		},
+		{
+			name:      "invalid hex string",
+			input:     "invalid",
+			want:      Zero,
+			wantPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.wantPanic {
+				require.Panics(t, func() {
+					MustFromHex(tt.input)
+				})
+				return
+			}
+			got := MustFromHex(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,13 @@
+package nanogit
+
+import (
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+)
+
+type PackfileStorage interface {
+	Get(key hash.Hash) (*protocol.PackfileObject, bool)
+	GetAllKeys() []hash.Hash
+	Add(objs ...*protocol.PackfileObject)
+	Delete(key hash.Hash)
+}


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Add new package to have some inmemory storage for objects.

## Why

<!-- Explain the motivation behind these changes -->

We cannot control what the git servers gives us, so we need to keep track of that in memory in complex logic. This was implemented already in tree and writer but it will be also used in other places such us `ListCommits`.

## How

<!-- Describe how these changes were implemented -->

- Add MustFromHex
- Add initial inmemory storage
- Use storage for writer
- Use storage also for tree building

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

This will probably eventually evolve in some caching mechanism we could decide to use to optimize things in Git Sync.

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

