### PR TITLE
Use streaming for writing and add storage options

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,3 +21,5 @@ ignore:
   - "log/mocks/"
   - "log/noop.go"
   - "storage/noop.go"
+  - "perf/"
+

--- a/README.md
+++ b/README.md
@@ -7,17 +7,23 @@
 
 ## Overview
 
-nanogit is a lightweight Git implementation designed for cloud environments, with a focus on HTTPS-based operations. It provides a subset of Git functionality optimized for reading and writing Git objects over HTTPS.
+nanogit is a lightweight, cloud-native Git implementation designed for applications that need efficient Git operations over HTTPS without the complexity and resource overhead of traditional Git implementations.
 
 ## Features
 
-- Support any HTTPS Git service that supports the Git Smart HTTP Protocol (version 2).
-- Secure HTTPS-based operations for Git objects (blobs, commits, trees, deltas)
-- Remote Git reference management via HTTPS
-- File system operations over HTTPS
-- Commit comparison and diffing capabilities
-- Authentication support (Basic Auth and API tokens)
-- SHA-1 repository compatibility
+- **HTTPS-only Git operations** - Works with any Git service supporting Smart HTTP Protocol v2 (GitHub, GitLab, Bitbucket, etc.), eliminating the need for SSH key management in cloud environments
+
+- **Stateless architecture** - No local .git directory dependency, making it perfect for serverless functions, containers, and microservices where persistent local state isn't available or desired
+
+- **Memory-optimized design** - Streaming packfile operations and configurable writing modes minimize memory usage, crucial for bulk operations and memory-constrained environments
+
+- **Flexible storage architecture** - Pluggable object storage and configurable writing modes allow optimization for different deployment patterns, from high-performance in-memory operations to memory-efficient disk-based processing
+
+- **Cloud-native authentication** - Built-in support for Basic Auth and API tokens, designed for automated workflows and CI/CD systems without interactive authentication
+
+- **Essential Git operations** - Focused on core functionality (read/write objects, commit operations, diffing) without the complexity of full Git implementations, reducing attack surface and resource requirements
+
+- **High performance** - Significantly faster than traditional Git implementations for common cloud operations, with up to 300x speed improvements for certain scenarios
 
 ## Non-Goals
 
@@ -40,7 +46,7 @@ While [go-git](https://github.com/go-git/go-git) is a mature Git implementation,
 | Feature        | nanogit                                                | go-git                 |
 | -------------- | ------------------------------------------------------ | ---------------------- |
 | Protocol       | HTTPS-only                                             | All protocols          |
-| Storage        | Stateless, configurable storage (memory, disk, custom) | Local disk operations  |
+| Storage        | Stateless, configurable object storage + writing modes | Local disk operations  |
 | Scope          | Essential operations only                              | Full Git functionality |
 | Use Case       | Cloud services, multitenant                            | General purpose        |
 | Resource Usage | Minimal footprint                                      | Full Git features      |
@@ -106,42 +112,43 @@ commit, err := writer.Commit(ctx, "Add feature and update docs", author, committ
 writer.Push(ctx)
 ```
 
-## Storage and Caching
+### Configurable Writing Modes
 
-nanogit offers a flexible storage system for managing Git objects with multiple implementation options. Git objects (commits, trees, blobs) are immutable by design - once created, their content and hash remain constant. This immutability enables efficient caching and sharing of objects across repositories. Local caching of these objects is crucial for performance as it reduces network requests and speeds up common operations like diffing, merging, and history traversal.
+nanogit provides flexible writing modes to optimize memory usage during write operations:
 
-### Flexibility on context caching
+```go
+// Auto mode (default) - smart memory/disk switching
+writer, err := client.NewStagedWriter(ctx, ref)
 
-nanogit provides flexibility in how Git objects are cached through context-based storage configuration. This allows different parts of your application to use different storage strategies:
+// Memory mode - maximum performance
+writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithMemoryStorage())
 
-- Use in-memory storage for temporary operations
-- Implement persistent storage for long-running processes
-- Configure different storage backends per request
-- Share storage across multiple operations
-- Optimize storage based on specific use cases
-- Scale storage independently of Git operations
-- Persist Git objects across service restarts
+// Disk mode - minimal memory usage for bulk operations
+writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithDiskStorage())
+```
 
-The context-based approach enables fine-grained control over object caching while maintaining clean separation of concerns.
+For detailed information about writing modes, performance characteristics, and use cases, see [Storage Architecture Documentation](STORAGE_ARCHITECTURE.md).
 
-### In-Memory Storage
+## Storage Architecture
 
-The default implementation uses an in-memory cache for Git objects, optimized for:
+nanogit features a flexible two-layer storage architecture that separates concerns and allows independent optimization:
 
-- Stateless operations requiring minimal resource footprint
-- Temporary caching during Git operations
-- High-performance read/write operations
+1. **Writing modes**: Control temporary storage during packfile creation (memory/disk/auto)
+2. **Object storage**: Handle long-term caching and retrieval of Git objects (pluggable backends)
 
-### Custom Storage Implementations
+### Object Storage and Caching
 
-The storage system is built with extensibility in mind through a well-defined interface. This allows you to:
+nanogit provides context-based object storage with pluggable backends. The default in-memory implementation is optimized for stateless operations, but you can implement custom backends for persistent caching:
 
-- Implement custom storage backends (Redis, disk, etc.)
-- Optimize storage for specific use cases
-- Scale storage independently of the Git operations
-- Persist Git objects across service restarts
+```go
+// Custom storage example
+ctx = storage.ToContext(ctx, myRedisStorage)
+client, err := nanogit.NewHTTPClient(repo, options...)
+```
 
-To implement a custom storage backend, simply implement the `PackfileStorage` interface and put it using `storage.ToContext`.
+This enables sharing Git object cache across multiple repositories, persistent caching across service restarts, and optimization for specific deployment patterns.
+
+For detailed information about storage architecture, writing modes, and custom implementations, see [Storage Architecture Documentation](STORAGE_ARCHITECTURE.md).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Choose nanogit for lightweight cloud services requiring stateless operations and
 
 This are some of the performance differences between nanogit and go-git in some of the measured scenarios:
 
-| Scenario                                      | Speed Improvement | Memory Usage Improvement                         |
-| --------------------------------------------- | ----------------- | ------------------------------------------------ |
-| **CreateFile (XL repo)**                      | 262x faster       | 195x less memory                                 |
-| **UpdateFile (XL repo)**                      | 275x faster       | 180x less memory                                 |
-| **DeleteFile (XL repo)**                      | 269x faster       | 212x less memory                                 |
-| **BulkCreateFiles (1000 files, medium repo)** | 89x faster        | 24x more memory (regression, easy fix I believe) |
-| **CompareCommits (XL repo)**                  | 111x faster       | 114x less memory                                 |
-| **GetFlatTree (XL repo)**                     | 303x faster       | 137x less memory                                 |
+| Scenario                                  | Speed       | Memory Usage |
+| ----------------------------------------- | ----------- | ------------ |
+| CreateFile (XL repo)                      | 262x faster | 195x less    |
+| UpdateFile (XL repo)                      | 275x faster | 180x less    |
+| DeleteFile (XL repo)                      | 269x faster | 212x less    |
+| BulkCreateFiles (1000 files, medium repo) | 50x faster  | 9x less      |
+| CompareCommits (XL repo)                  | 111x faster | 114x less    |
+| GetFlatTree (XL repo)                     | 303x faster | 137x less    |
 
 For detailed performance metrics, see the [latest performance report](test/performance/LAST_REPORT.md).
 
@@ -199,4 +199,3 @@ If you find a security vulnerability, please report it to <security@grafana.com>
 
 - The Grafana team for their support and guidance
 - The open source community for their valuable feedback and contributions
-

--- a/STORAGE_ARCHITECTURE.md
+++ b/STORAGE_ARCHITECTURE.md
@@ -1,0 +1,154 @@
+# nanogit Storage Architecture
+
+This document describes nanogit's flexible storage architecture, including configurable writing modes and pluggable object storage systems.
+
+## Overview
+
+nanogit features a sophisticated two-layer storage architecture designed for cloud-native environments:
+
+1. **Writing Modes**: Control temporary storage during packfile creation
+2. **Object Storage**: Handle long-term caching and retrieval of Git objects
+
+This separation allows you to optimize each layer independently for your specific performance, memory, and deployment requirements.
+
+## Writing Modes
+
+The `StagedWriter` supports configurable writing modes for packfile operations, allowing you to optimize how objects are temporarily stored while building packfiles during write operations.
+
+These writing modes control how Git objects are stored during the staging and packfile creation process, giving you fine-grained control over performance vs memory usage trade-offs.
+
+### Available Writing Modes
+
+#### `PackfileStorageAuto` (Default)
+- **Behavior**: Automatically chooses between memory and disk storage based on object count
+- **Memory Usage**: Uses memory for small operations (≤10 objects), switches to disk for larger operations
+- **Use Case**: Balanced approach suitable for most applications
+
+#### `PackfileStorageMemory`
+- **Behavior**: Always stores objects in memory
+- **Memory Usage**: Higher memory usage, especially for bulk operations
+- **Use Case**: Performance-critical scenarios where memory usage is not a constraint
+
+#### `PackfileStorageDisk`
+- **Behavior**: Always stores objects in temporary files on disk
+- **Memory Usage**: Minimal memory usage
+- **Use Case**: Bulk operations or memory-constrained environments
+
+## Usage Examples
+
+### Default Auto Mode
+```go
+// Uses auto mode by default
+writer, err := client.NewStagedWriter(ctx, ref)
+```
+
+### Explicit Memory Storage
+```go
+// Always use memory for best performance
+writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithMemoryStorage())
+```
+
+### Explicit Disk Storage
+```go
+// Always use disk to minimize memory usage
+writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithDiskStorage())
+```
+
+### Explicit Auto Mode
+```go
+// Explicitly enable auto mode (same as default)
+writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithAutoStorage())
+```
+
+## Performance Characteristics
+
+| Writing Mode | Memory Usage | Performance | Best For |
+|--------------|--------------|-------------|----------|
+| Auto | Variable | Balanced | General use cases |
+| Memory | High | Fastest | Small operations, performance-critical |
+| Disk | Low | Slightly slower | Bulk operations, memory-constrained |
+
+## Migration Notes
+
+- Existing code continues to work without changes (backward compatible)
+- The `...WriterOption` parameter is variadic, so zero options is valid
+- Default behavior remains the same (auto mode with 10 object threshold)
+
+## Object Storage and Caching
+
+Object storage in nanogit handles long-term caching and retrieval of Git objects (commits, trees, blobs). This is separate from writing modes and operates through a context-based configuration system.
+
+### Key Characteristics
+
+- **Immutable objects**: Git objects never change once created, enabling efficient caching
+- **Context-based**: Storage backend is configured per operation via Go context
+- **Pluggable**: Implement custom backends for different storage systems
+- **Shareable**: Cache objects across multiple repositories and operations
+
+### Default In-Memory Storage
+
+The default implementation uses an in-memory cache optimized for:
+
+- Stateless operations requiring minimal resource footprint
+- Temporary caching during Git operations
+- High-performance object retrieval and diffing
+
+### Custom Storage Implementations
+
+The object storage system supports custom backends through the `PackfileStorage` interface:
+
+```go
+// Example: Redis-based object storage
+ctx = storage.ToContext(ctx, myRedisStorage)
+client, err := nanogit.NewHTTPClient(repo, options...)
+
+// Example: Database-based object storage  
+ctx = storage.ToContext(ctx, myDatabaseStorage)
+writer, err := client.NewStagedWriter(ctx, ref)
+```
+
+**Benefits of custom storage:**
+- Persist Git objects across service restarts
+- Share object cache across multiple repositories
+- Scale storage independently of Git operations
+- Optimize for specific deployment patterns (e.g., microservices)
+- Implement TTL-based cache eviction
+- Add metrics and monitoring
+
+### Two-Layer Architecture Benefits
+
+The separation between writing modes and object storage provides several advantages:
+
+1. **Independent optimization**: Use disk-based writing for memory efficiency while maintaining Redis-based object caching for fast reads
+2. **Flexible deployment**: Configure each layer based on specific infrastructure constraints
+3. **Clear separation of concerns**: Temporary vs persistent storage have different requirements
+4. **Scalability**: Scale each layer independently based on workload patterns
+
+### Example Configurations
+
+```go
+// Memory-optimized: Fast writing + persistent caching
+writer, err := client.NewStagedWriter(
+    storage.ToContext(ctx, redisStorage),
+    ref,
+    nanogit.WithMemoryStorage(),
+)
+
+// Memory-constrained: Disk writing + in-memory caching
+writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithDiskStorage())
+
+// Balanced: Auto writing + custom persistent storage
+writer, err := client.NewStagedWriter(
+    storage.ToContext(ctx, myCustomStorage),
+    ref,
+    // Auto mode is default
+)
+```
+
+## Implementation Details
+
+- Writing mode is configured per `StagedWriter` instance
+- The same writing mode is maintained across multiple push operations
+- Temporary files are automatically cleaned up after successful pushes
+- All writing modes support the streaming packfile implementation for reduced memory usage during transmission
+- Writing modes are independent from object storage - you can mix and match configurations

--- a/client.go
+++ b/client.go
@@ -49,7 +49,7 @@ type StagedWriter interface {
 	// Cleanup releases any resources held by the writer and clears all staged changes.
 	// This should be called when the writer is no longer needed or to cancel all pending changes.
 	// After calling Cleanup, the writer should not be used for further operations.
-	Cleanup() error
+	Cleanup(ctx context.Context) error
 }
 
 // Client defines the interface for interacting with a Git repository.

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ type Client interface {
 	CompareCommits(ctx context.Context, baseCommit, headCommit hash.Hash) ([]CommitFile, error)
 	ListCommits(ctx context.Context, startCommit hash.Hash, options ListCommitsOptions) ([]Commit, error)
 	// Write operations
-	NewStagedWriter(ctx context.Context, ref Ref) (StagedWriter, error)
+	NewStagedWriter(ctx context.Context, ref Ref, options ...WriterOption) (StagedWriter, error)
 }
 
 // httpClient is the private implementation of the Client interface.

--- a/client.go
+++ b/client.go
@@ -45,6 +45,11 @@ type StagedWriter interface {
 	// This is the final step that makes changes visible to others.
 	// It will update the reference to point to the last commit.
 	Push(ctx context.Context) error
+
+	// Cleanup releases any resources held by the writer and clears all staged changes.
+	// This should be called when the writer is no longer needed or to cancel all pending changes.
+	// After calling Cleanup, the writer should not be used for further operations.
+	Cleanup() error
 }
 
 // Client defines the interface for interacting with a Git repository.

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -190,11 +190,12 @@ type FakeClient struct {
 		result1 []nanogit.Ref
 		result2 error
 	}
-	NewStagedWriterStub        func(context.Context, nanogit.Ref) (nanogit.StagedWriter, error)
+	NewStagedWriterStub        func(context.Context, nanogit.Ref, ...nanogit.WriterOption) (nanogit.StagedWriter, error)
 	newStagedWriterMutex       sync.RWMutex
 	newStagedWriterArgsForCall []struct {
 		arg1 context.Context
 		arg2 nanogit.Ref
+		arg3 []nanogit.WriterOption
 	}
 	newStagedWriterReturns struct {
 		result1 nanogit.StagedWriter
@@ -1074,19 +1075,20 @@ func (fake *FakeClient) ListRefsReturnsOnCall(i int, result1 []nanogit.Ref, resu
 	}{result1, result2}
 }
 
-func (fake *FakeClient) NewStagedWriter(arg1 context.Context, arg2 nanogit.Ref) (nanogit.StagedWriter, error) {
+func (fake *FakeClient) NewStagedWriter(arg1 context.Context, arg2 nanogit.Ref, arg3 ...nanogit.WriterOption) (nanogit.StagedWriter, error) {
 	fake.newStagedWriterMutex.Lock()
 	ret, specificReturn := fake.newStagedWriterReturnsOnCall[len(fake.newStagedWriterArgsForCall)]
 	fake.newStagedWriterArgsForCall = append(fake.newStagedWriterArgsForCall, struct {
 		arg1 context.Context
 		arg2 nanogit.Ref
-	}{arg1, arg2})
+		arg3 []nanogit.WriterOption
+	}{arg1, arg2, arg3})
 	stub := fake.NewStagedWriterStub
 	fakeReturns := fake.newStagedWriterReturns
-	fake.recordInvocation("NewStagedWriter", []interface{}{arg1, arg2})
+	fake.recordInvocation("NewStagedWriter", []interface{}{arg1, arg2, arg3})
 	fake.newStagedWriterMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1100,17 +1102,17 @@ func (fake *FakeClient) NewStagedWriterCallCount() int {
 	return len(fake.newStagedWriterArgsForCall)
 }
 
-func (fake *FakeClient) NewStagedWriterCalls(stub func(context.Context, nanogit.Ref) (nanogit.StagedWriter, error)) {
+func (fake *FakeClient) NewStagedWriterCalls(stub func(context.Context, nanogit.Ref, ...nanogit.WriterOption) (nanogit.StagedWriter, error)) {
 	fake.newStagedWriterMutex.Lock()
 	defer fake.newStagedWriterMutex.Unlock()
 	fake.NewStagedWriterStub = stub
 }
 
-func (fake *FakeClient) NewStagedWriterArgsForCall(i int) (context.Context, nanogit.Ref) {
+func (fake *FakeClient) NewStagedWriterArgsForCall(i int) (context.Context, nanogit.Ref, []nanogit.WriterOption) {
 	fake.newStagedWriterMutex.RLock()
 	defer fake.newStagedWriterMutex.RUnlock()
 	argsForCall := fake.newStagedWriterArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeClient) NewStagedWriterReturns(result1 nanogit.StagedWriter, result2 error) {

--- a/mocks/raw_client.go
+++ b/mocks/raw_client.go
@@ -3,6 +3,7 @@ package mocks
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"github.com/grafana/nanogit/protocol"
@@ -51,11 +52,11 @@ type FakeRawClient struct {
 		result1 []protocol.RefLine
 		result2 error
 	}
-	ReceivePackStub        func(context.Context, []byte) ([]byte, error)
+	ReceivePackStub        func(context.Context, io.Reader) ([]byte, error)
 	receivePackMutex       sync.RWMutex
 	receivePackArgsForCall []struct {
 		arg1 context.Context
-		arg2 []byte
+		arg2 io.Reader
 	}
 	receivePackReturns struct {
 		result1 []byte
@@ -291,21 +292,16 @@ func (fake *FakeRawClient) LsRefsReturnsOnCall(i int, result1 []protocol.RefLine
 	}{result1, result2}
 }
 
-func (fake *FakeRawClient) ReceivePack(arg1 context.Context, arg2 []byte) ([]byte, error) {
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
+func (fake *FakeRawClient) ReceivePack(arg1 context.Context, arg2 io.Reader) ([]byte, error) {
 	fake.receivePackMutex.Lock()
 	ret, specificReturn := fake.receivePackReturnsOnCall[len(fake.receivePackArgsForCall)]
 	fake.receivePackArgsForCall = append(fake.receivePackArgsForCall, struct {
 		arg1 context.Context
-		arg2 []byte
-	}{arg1, arg2Copy})
+		arg2 io.Reader
+	}{arg1, arg2})
 	stub := fake.ReceivePackStub
 	fakeReturns := fake.receivePackReturns
-	fake.recordInvocation("ReceivePack", []interface{}{arg1, arg2Copy})
+	fake.recordInvocation("ReceivePack", []interface{}{arg1, arg2})
 	fake.receivePackMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -322,13 +318,13 @@ func (fake *FakeRawClient) ReceivePackCallCount() int {
 	return len(fake.receivePackArgsForCall)
 }
 
-func (fake *FakeRawClient) ReceivePackCalls(stub func(context.Context, []byte) ([]byte, error)) {
+func (fake *FakeRawClient) ReceivePackCalls(stub func(context.Context, io.Reader) ([]byte, error)) {
 	fake.receivePackMutex.Lock()
 	defer fake.receivePackMutex.Unlock()
 	fake.ReceivePackStub = stub
 }
 
-func (fake *FakeRawClient) ReceivePackArgsForCall(i int) (context.Context, []byte) {
+func (fake *FakeRawClient) ReceivePackArgsForCall(i int) (context.Context, io.Reader) {
 	fake.receivePackMutex.RLock()
 	defer fake.receivePackMutex.RUnlock()
 	argsForCall := fake.receivePackArgsForCall[i]

--- a/mocks/staged_writer.go
+++ b/mocks/staged_writer.go
@@ -24,6 +24,16 @@ type FakeStagedWriter struct {
 		result1 bool
 		result2 error
 	}
+	CleanupStub        func() error
+	cleanupMutex       sync.RWMutex
+	cleanupArgsForCall []struct {
+	}
+	cleanupReturns struct {
+		result1 error
+	}
+	cleanupReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CommitStub        func(context.Context, string, nanogit.Author, nanogit.Committer) (*nanogit.Commit, error)
 	commitMutex       sync.RWMutex
 	commitArgsForCall []struct {
@@ -190,6 +200,59 @@ func (fake *FakeStagedWriter) BlobExistsReturnsOnCall(i int, result1 bool, resul
 		result1 bool
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeStagedWriter) Cleanup() error {
+	fake.cleanupMutex.Lock()
+	ret, specificReturn := fake.cleanupReturnsOnCall[len(fake.cleanupArgsForCall)]
+	fake.cleanupArgsForCall = append(fake.cleanupArgsForCall, struct {
+	}{})
+	stub := fake.CleanupStub
+	fakeReturns := fake.cleanupReturns
+	fake.recordInvocation("Cleanup", []interface{}{})
+	fake.cleanupMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStagedWriter) CleanupCallCount() int {
+	fake.cleanupMutex.RLock()
+	defer fake.cleanupMutex.RUnlock()
+	return len(fake.cleanupArgsForCall)
+}
+
+func (fake *FakeStagedWriter) CleanupCalls(stub func() error) {
+	fake.cleanupMutex.Lock()
+	defer fake.cleanupMutex.Unlock()
+	fake.CleanupStub = stub
+}
+
+func (fake *FakeStagedWriter) CleanupReturns(result1 error) {
+	fake.cleanupMutex.Lock()
+	defer fake.cleanupMutex.Unlock()
+	fake.CleanupStub = nil
+	fake.cleanupReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStagedWriter) CleanupReturnsOnCall(i int, result1 error) {
+	fake.cleanupMutex.Lock()
+	defer fake.cleanupMutex.Unlock()
+	fake.CleanupStub = nil
+	if fake.cleanupReturnsOnCall == nil {
+		fake.cleanupReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.cleanupReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeStagedWriter) Commit(arg1 context.Context, arg2 string, arg3 nanogit.Author, arg4 nanogit.Committer) (*nanogit.Commit, error) {
@@ -662,6 +725,8 @@ func (fake *FakeStagedWriter) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.blobExistsMutex.RLock()
 	defer fake.blobExistsMutex.RUnlock()
+	fake.cleanupMutex.RLock()
+	defer fake.cleanupMutex.RUnlock()
 	fake.commitMutex.RLock()
 	defer fake.commitMutex.RUnlock()
 	fake.createBlobMutex.RLock()

--- a/mocks/staged_writer.go
+++ b/mocks/staged_writer.go
@@ -24,9 +24,10 @@ type FakeStagedWriter struct {
 		result1 bool
 		result2 error
 	}
-	CleanupStub        func() error
+	CleanupStub        func(context.Context) error
 	cleanupMutex       sync.RWMutex
 	cleanupArgsForCall []struct {
+		arg1 context.Context
 	}
 	cleanupReturns struct {
 		result1 error
@@ -202,17 +203,18 @@ func (fake *FakeStagedWriter) BlobExistsReturnsOnCall(i int, result1 bool, resul
 	}{result1, result2}
 }
 
-func (fake *FakeStagedWriter) Cleanup() error {
+func (fake *FakeStagedWriter) Cleanup(arg1 context.Context) error {
 	fake.cleanupMutex.Lock()
 	ret, specificReturn := fake.cleanupReturnsOnCall[len(fake.cleanupArgsForCall)]
 	fake.cleanupArgsForCall = append(fake.cleanupArgsForCall, struct {
-	}{})
+		arg1 context.Context
+	}{arg1})
 	stub := fake.CleanupStub
 	fakeReturns := fake.cleanupReturns
-	fake.recordInvocation("Cleanup", []interface{}{})
+	fake.recordInvocation("Cleanup", []interface{}{arg1})
 	fake.cleanupMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -226,10 +228,17 @@ func (fake *FakeStagedWriter) CleanupCallCount() int {
 	return len(fake.cleanupArgsForCall)
 }
 
-func (fake *FakeStagedWriter) CleanupCalls(stub func() error) {
+func (fake *FakeStagedWriter) CleanupCalls(stub func(context.Context) error) {
 	fake.cleanupMutex.Lock()
 	defer fake.cleanupMutex.Unlock()
 	fake.CleanupStub = stub
+}
+
+func (fake *FakeStagedWriter) CleanupArgsForCall(i int) context.Context {
+	fake.cleanupMutex.RLock()
+	defer fake.cleanupMutex.RUnlock()
+	argsForCall := fake.cleanupArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeStagedWriter) CleanupReturns(result1 error) {

--- a/perf/LAST_REPORT.md
+++ b/perf/LAST_REPORT.md
@@ -1,81 +1,81 @@
 # 🚀 Performance Benchmark Report
 
-**Generated:** 2025-06-19T10:12:56+02:00  
+**Generated:** 2025-06-19T14:05:00+02:00  
 **Total Benchmarks:** 168
 
 ## 📊 Performance Overview
 
 | Operation | Speed Winner | Duration | In-Memory Winner | Memory Usage |
 |-----------|--------------|----------|------------------|-------------|
-| BulkCreateFiles_bulk_1000_files_medium | 🚀 nanogit | 798.7ms | 🐹 go-git | 29.3 MB |
-| BulkCreateFiles_bulk_1000_files_small | 🚀 nanogit | 805.5ms | 🐹 go-git | 5.5 MB |
-| BulkCreateFiles_bulk_100_files_medium | 🚀 nanogit | 105.2ms | 💚 nanogit | 5.3 MB |
-| BulkCreateFiles_bulk_100_files_small | 🚀 nanogit | 97.1ms | 💚 nanogit | 3.2 MB |
-| CompareCommits_adjacent_commits_large | 🚀 nanogit | 124.4ms | 💚 nanogit | 4.2 MB |
-| CompareCommits_adjacent_commits_medium | 🚀 nanogit | 102.1ms | 💚 nanogit | 1.5 MB |
-| CompareCommits_adjacent_commits_small | 🐹 go-git | 69.5ms | 💚 nanogit | 544.3 KB |
-| CompareCommits_adjacent_commits_xlarge | 🚀 nanogit | 185.1ms | 💚 nanogit | 15.5 MB |
-| CompareCommits_few_commits_large | 🚀 nanogit | 221.7ms | 💚 nanogit | 3.7 MB |
-| CompareCommits_few_commits_medium | 🚀 nanogit | 183.6ms | 💚 nanogit | 1.8 MB |
-| CompareCommits_few_commits_small | 🐹 go-git | 71.4ms | 💚 nanogit | 296.9 KB |
-| CompareCommits_few_commits_xlarge | 🚀 nanogit | 324.4ms | 💚 nanogit | 14.5 MB |
-| CompareCommits_max_commits_large | 🚀 nanogit | 324.7ms | 💚 nanogit | 3.1 MB |
-| CompareCommits_max_commits_medium | 🚀 nanogit | 252.7ms | 💚 nanogit | 1.1 MB |
-| CompareCommits_max_commits_small | 🐹 go-git | 74.1ms | 💚 nanogit | 581.4 KB |
-| CompareCommits_max_commits_xlarge | 🚀 nanogit | 520.5ms | 💚 nanogit | 15.0 MB |
-| CreateFile_large_repo | 🚀 nanogit | 58.8ms | 💚 nanogit | 4.2 MB |
-| CreateFile_medium_repo | 🚀 nanogit | 51.0ms | 💚 nanogit | 2.3 MB |
-| CreateFile_small_repo | 🚀 nanogit | 51.1ms | 💚 nanogit | 1.6 MB |
-| CreateFile_xlarge_repo | 🚀 nanogit | 86.4ms | 💚 nanogit | 10.8 MB |
-| DeleteFile_large_repo | 🚀 nanogit | 58.9ms | 💚 nanogit | 3.9 MB |
-| DeleteFile_medium_repo | 🚀 nanogit | 50.5ms | 💚 nanogit | 2.1 MB |
-| DeleteFile_small_repo | 🚀 nanogit | 46.7ms | 💚 nanogit | 1.2 MB |
-| DeleteFile_xlarge_repo | 🚀 nanogit | 83.9ms | 💚 nanogit | 10.0 MB |
-| GetFlatTree_large_tree | 🚀 nanogit | 39.8ms | 💚 nanogit | 2.0 MB |
-| GetFlatTree_medium_tree | 🚀 nanogit | 34.5ms | 💚 nanogit | 1.0 MB |
-| GetFlatTree_small_tree | 🚀 nanogit | 44.6ms | 💚 nanogit | 35.5 KB |
-| GetFlatTree_xlarge_tree | 🚀 nanogit | 67.6ms | 💚 nanogit | 12.7 MB |
-| UpdateFile_large_repo | 🚀 nanogit | 59.1ms | 💚 nanogit | 4.2 MB |
-| UpdateFile_medium_repo | 🚀 nanogit | 49.2ms | 💚 nanogit | 2.9 MB |
-| UpdateFile_small_repo | 🚀 nanogit | 48.7ms | 💚 nanogit | 1.9 MB |
-| UpdateFile_xlarge_repo | 🚀 nanogit | 81.8ms | 💚 nanogit | 11.9 MB |
+| BulkCreateFiles_bulk_1000_files_medium | 🚀 nanogit | 1.52s | 💚 nanogit | 4.5 MB |
+| BulkCreateFiles_bulk_1000_files_small | 🚀 nanogit | 1.49s | 💚 nanogit | 1.5 MB |
+| BulkCreateFiles_bulk_100_files_medium | 🚀 nanogit | 125.8ms | 💚 nanogit | 2.9 MB |
+| BulkCreateFiles_bulk_100_files_small | 🚀 nanogit | 124.2ms | 💚 nanogit | 971.5 KB |
+| CompareCommits_adjacent_commits_large | 🚀 nanogit | 115.3ms | 💚 nanogit | 3.3 MB |
+| CompareCommits_adjacent_commits_medium | 🚀 nanogit | 110.7ms | 💚 nanogit | 953.9 KB |
+| CompareCommits_adjacent_commits_small | 🐹 go-git | 80.1ms | 💚 nanogit | 553.6 KB |
+| CompareCommits_adjacent_commits_xlarge | 🚀 nanogit | 183.2ms | 💚 nanogit | 15.4 MB |
+| CompareCommits_few_commits_large | 🚀 nanogit | 199.7ms | 💚 nanogit | 4.2 MB |
+| CompareCommits_few_commits_medium | 🚀 nanogit | 165.7ms | 💚 nanogit | 2.3 MB |
+| CompareCommits_few_commits_small | 🐹 go-git | 68.5ms | 💚 nanogit | 258.9 KB |
+| CompareCommits_few_commits_xlarge | 🚀 nanogit | 360.0ms | 💚 nanogit | 17.5 MB |
+| CompareCommits_max_commits_large | 🚀 nanogit | 316.1ms | 💚 nanogit | 4.1 MB |
+| CompareCommits_max_commits_medium | 🚀 nanogit | 270.2ms | 💚 nanogit | 1.8 MB |
+| CompareCommits_max_commits_small | 🐹 go-git | 85.3ms | 💚 nanogit | 1.3 MB |
+| CompareCommits_max_commits_xlarge | 🚀 nanogit | 511.4ms | 💚 nanogit | 14.3 MB |
+| CreateFile_large_repo | 🚀 nanogit | 60.7ms | 💚 nanogit | 5.0 MB |
+| CreateFile_medium_repo | 🚀 nanogit | 52.6ms | 💚 nanogit | 3.3 MB |
+| CreateFile_small_repo | 🚀 nanogit | 55.7ms | 💚 nanogit | 1.1 MB |
+| CreateFile_xlarge_repo | 🚀 nanogit | 88.6ms | 💚 nanogit | 12.5 MB |
+| DeleteFile_large_repo | 🚀 nanogit | 57.2ms | 💚 nanogit | 3.4 MB |
+| DeleteFile_medium_repo | 🚀 nanogit | 53.7ms | 💚 nanogit | 2.3 MB |
+| DeleteFile_small_repo | 🚀 nanogit | 48.0ms | 💚 nanogit | 2.2 MB |
+| DeleteFile_xlarge_repo | 🚀 nanogit | 91.1ms | 💚 nanogit | 12.1 MB |
+| GetFlatTree_large_tree | 🚀 nanogit | 56.9ms | 💚 nanogit | 2.3 MB |
+| GetFlatTree_medium_tree | 🚀 nanogit | 50.4ms | 💚 nanogit | 611.4 KB |
+| GetFlatTree_small_tree | 🚀 nanogit | 46.7ms | 💚 nanogit | 366.7 KB |
+| GetFlatTree_xlarge_tree | 🚀 nanogit | 81.8ms | 💚 nanogit | 10.2 MB |
+| UpdateFile_large_repo | 🚀 nanogit | 56.7ms | 💚 nanogit | 4.2 MB |
+| UpdateFile_medium_repo | 🚀 nanogit | 52.7ms | 💚 nanogit | 2.6 MB |
+| UpdateFile_small_repo | 🚀 nanogit | 47.3ms | 💚 nanogit | 1.4 MB |
+| UpdateFile_xlarge_repo | 🚀 nanogit | 86.4ms | 💚 nanogit | 10.8 MB |
 
 ## ⚡ Duration Comparison
 
 | Operation | git-cli | go-git | nanogit |
 |-----------|-----------|-----------|-----------|
-| BulkCreateFiles_bulk_1000_files_medium | 10.39s 🐌 | 70.99s 🐌 | 798.7ms 🏆 |
-| BulkCreateFiles_bulk_1000_files_small | 9.95s 🐌 | 18.18s 🐌 | 805.5ms 🏆 |
-| BulkCreateFiles_bulk_100_files_medium | 1.66s 🐌 | 6.56s 🐌 | 105.2ms 🏆 |
-| BulkCreateFiles_bulk_100_files_small | 1.29s 🐌 | 901.0ms 🐌 | 97.1ms 🏆 |
-| CompareCommits_adjacent_commits_large | 1.38s 🐌 | 2.63s 🐌 | 124.4ms 🏆 |
-| CompareCommits_adjacent_commits_medium | 562.2ms 🐌 | 416.4ms | 102.1ms 🏆 |
-| CompareCommits_adjacent_commits_small | 348.7ms 🐌 | 69.5ms 🏆 | 82.2ms ✅ |
-| CompareCommits_adjacent_commits_xlarge | 5.60s 🐌 | 20.45s 🐌 | 185.1ms 🏆 |
-| CompareCommits_few_commits_large | 1.50s 🐌 | 2.62s 🐌 | 221.7ms 🏆 |
-| CompareCommits_few_commits_medium | 516.4ms | 418.9ms | 183.6ms 🏆 |
-| CompareCommits_few_commits_small | 351.1ms | 71.4ms 🏆 | 158.6ms |
-| CompareCommits_few_commits_xlarge | 5.71s 🐌 | 20.51s 🐌 | 324.4ms 🏆 |
-| CompareCommits_max_commits_large | 1.37s | 2.61s 🐌 | 324.7ms 🏆 |
-| CompareCommits_max_commits_medium | 480.7ms ✅ | 413.5ms ✅ | 252.7ms 🏆 |
-| CompareCommits_max_commits_small | 348.0ms | 74.1ms 🏆 | 226.5ms |
-| CompareCommits_max_commits_xlarge | 7.88s 🐌 | 20.91s 🐌 | 520.5ms 🏆 |
-| CreateFile_large_repo | 1.76s 🐌 | 2.94s 🐌 | 58.8ms 🏆 |
-| CreateFile_medium_repo | 967.7ms 🐌 | 513.4ms 🐌 | 51.0ms 🏆 |
-| CreateFile_small_repo | 819.2ms 🐌 | 111.9ms | 51.1ms 🏆 |
-| CreateFile_xlarge_repo | 8.82s 🐌 | 22.65s 🐌 | 86.4ms 🏆 |
-| DeleteFile_large_repo | 1.75s 🐌 | 2.95s 🐌 | 58.9ms 🏆 |
-| DeleteFile_medium_repo | 965.4ms 🐌 | 505.5ms 🐌 | 50.5ms 🏆 |
-| DeleteFile_small_repo | 790.2ms 🐌 | 105.0ms | 46.7ms 🏆 |
-| DeleteFile_xlarge_repo | 6.86s 🐌 | 22.56s 🐌 | 83.9ms 🏆 |
-| GetFlatTree_large_tree | 1.14s 🐌 | 2.79s 🐌 | 39.8ms 🏆 |
-| GetFlatTree_medium_tree | 506.0ms 🐌 | 455.5ms 🐌 | 34.5ms 🏆 |
-| GetFlatTree_small_tree | 395.7ms 🐌 | 73.2ms ✅ | 44.6ms 🏆 |
-| GetFlatTree_xlarge_tree | 5.21s 🐌 | 20.47s 🐌 | 67.6ms 🏆 |
-| UpdateFile_large_repo | 1.77s 🐌 | 2.96s 🐌 | 59.1ms 🏆 |
-| UpdateFile_medium_repo | 950.8ms 🐌 | 503.1ms 🐌 | 49.2ms 🏆 |
-| UpdateFile_small_repo | 789.0ms 🐌 | 107.6ms | 48.7ms 🏆 |
-| UpdateFile_xlarge_repo | 8.59s 🐌 | 22.52s 🐌 | 81.8ms 🏆 |
+| BulkCreateFiles_bulk_1000_files_medium | 14.03s 🐌 | 72.33s 🐌 | 1.52s 🏆 |
+| BulkCreateFiles_bulk_1000_files_small | 14.17s 🐌 | 19.12s 🐌 | 1.49s 🏆 |
+| BulkCreateFiles_bulk_100_files_medium | 2.43s 🐌 | 6.59s 🐌 | 125.8ms 🏆 |
+| BulkCreateFiles_bulk_100_files_small | 1.69s 🐌 | 907.4ms 🐌 | 124.2ms 🏆 |
+| CompareCommits_adjacent_commits_large | 1.62s 🐌 | 2.64s 🐌 | 115.3ms 🏆 |
+| CompareCommits_adjacent_commits_medium | 861.3ms 🐌 | 422.8ms | 110.7ms 🏆 |
+| CompareCommits_adjacent_commits_small | 443.3ms 🐌 | 80.1ms 🏆 | 84.5ms ✅ |
+| CompareCommits_adjacent_commits_xlarge | 12.90s 🐌 | 20.76s 🐌 | 183.2ms 🏆 |
+| CompareCommits_few_commits_large | 3.85s 🐌 | 2.61s 🐌 | 199.7ms 🏆 |
+| CompareCommits_few_commits_medium | 960.1ms 🐌 | 406.4ms | 165.7ms 🏆 |
+| CompareCommits_few_commits_small | 443.6ms 🐌 | 68.5ms 🏆 | 167.7ms |
+| CompareCommits_few_commits_xlarge | 7.14s 🐌 | 20.66s 🐌 | 360.0ms 🏆 |
+| CompareCommits_max_commits_large | 3.89s 🐌 | 2.66s 🐌 | 316.1ms 🏆 |
+| CompareCommits_max_commits_medium | 1.00s | 425.9ms ✅ | 270.2ms 🏆 |
+| CompareCommits_max_commits_small | 440.0ms 🐌 | 85.3ms 🏆 | 258.1ms |
+| CompareCommits_max_commits_xlarge | 10.04s 🐌 | 20.53s 🐌 | 511.4ms 🏆 |
+| CreateFile_large_repo | 1.96s 🐌 | 2.96s 🐌 | 60.7ms 🏆 |
+| CreateFile_medium_repo | 1.02s 🐌 | 508.0ms 🐌 | 52.6ms 🏆 |
+| CreateFile_small_repo | 872.2ms 🐌 | 109.8ms ✅ | 55.7ms 🏆 |
+| CreateFile_xlarge_repo | 12.77s 🐌 | 22.65s 🐌 | 88.6ms 🏆 |
+| DeleteFile_large_repo | 1.90s 🐌 | 2.95s 🐌 | 57.2ms 🏆 |
+| DeleteFile_medium_repo | 1.03s 🐌 | 498.9ms 🐌 | 53.7ms 🏆 |
+| DeleteFile_small_repo | 853.1ms 🐌 | 105.0ms | 48.0ms 🏆 |
+| DeleteFile_xlarge_repo | 10.45s 🐌 | 22.69s 🐌 | 91.1ms 🏆 |
+| GetFlatTree_large_tree | 1.69s 🐌 | 2.72s 🐌 | 56.9ms 🏆 |
+| GetFlatTree_medium_tree | 566.1ms 🐌 | 467.0ms 🐌 | 50.4ms 🏆 |
+| GetFlatTree_small_tree | 397.0ms 🐌 | 79.7ms ✅ | 46.7ms 🏆 |
+| GetFlatTree_xlarge_tree | 8.28s 🐌 | 20.72s 🐌 | 81.8ms 🏆 |
+| UpdateFile_large_repo | 1.88s 🐌 | 2.95s 🐌 | 56.7ms 🏆 |
+| UpdateFile_medium_repo | 1.03s 🐌 | 501.9ms 🐌 | 52.7ms 🏆 |
+| UpdateFile_small_repo | 853.1ms 🐌 | 106.2ms | 47.3ms 🏆 |
+| UpdateFile_xlarge_repo | 10.15s 🐌 | 22.63s 🐌 | 86.4ms 🏆 |
 
 ## 💾 Memory Usage Comparison
 
@@ -83,38 +83,38 @@
 
 | Operation | git-cli | go-git | nanogit |
 |-----------|-----------|-----------|-----------|
-| BulkCreateFiles_bulk_1000_files_medium | 1.0 MB 💾 | 29.3 MB 🏆 | 179.3 MB 🔥 |
-| BulkCreateFiles_bulk_1000_files_small | 121.3 KB 💾 | 5.5 MB 🏆 | 128.8 MB 🔥 |
-| BulkCreateFiles_bulk_100_files_medium | -226264 B 💾 | 33.4 MB 🔥 | 5.3 MB 🏆 |
-| BulkCreateFiles_bulk_100_files_small | 1.3 MB 💾 | 4.8 MB ✅ | 3.2 MB 🏆 |
-| CompareCommits_adjacent_commits_large | 72.8 KB 💾 | 186.7 MB 🔥 | 4.2 MB 🏆 |
-| CompareCommits_adjacent_commits_medium | 72.4 KB 💾 | 38.6 MB 🔥 | 1.5 MB 🏆 |
-| CompareCommits_adjacent_commits_small | 72.8 KB 💾 | 3.7 MB 🔥 | 544.3 KB 🏆 |
-| CompareCommits_adjacent_commits_xlarge | 73.7 KB 💾 | 1.7 GB 🔥 | 15.5 MB 🏆 |
-| CompareCommits_few_commits_large | 72.8 KB 💾 | 209.3 MB 🔥 | 3.7 MB 🏆 |
-| CompareCommits_few_commits_medium | 72.8 KB 💾 | 39.3 MB 🔥 | 1.8 MB 🏆 |
-| CompareCommits_few_commits_small | 72.8 KB 💾 | 3.1 MB 🔥 | 296.9 KB 🏆 |
-| CompareCommits_few_commits_xlarge | 72.8 KB 💾 | 1.5 GB 🔥 | 14.5 MB 🏆 |
-| CompareCommits_max_commits_large | 73.6 KB 💾 | 209.2 MB 🔥 | 3.1 MB 🏆 |
-| CompareCommits_max_commits_medium | 73.2 KB 💾 | 40.1 MB 🔥 | 1.1 MB 🏆 |
-| CompareCommits_max_commits_small | 72.4 KB 💾 | 3.1 MB 🔥 | 581.4 KB 🏆 |
-| CompareCommits_max_commits_xlarge | 72.6 KB 💾 | 1.5 GB 🔥 | 15.0 MB 🏆 |
-| CreateFile_large_repo | 139.4 KB 💾 | 214.9 MB 🔥 | 4.2 MB 🏆 |
-| CreateFile_medium_repo | 139.6 KB 💾 | 44.6 MB 🔥 | 2.3 MB 🏆 |
-| CreateFile_small_repo | 139.3 KB 💾 | 5.0 MB | 1.6 MB 🏆 |
-| CreateFile_xlarge_repo | 139.7 KB 💾 | 2.1 GB 🔥 | 10.8 MB 🏆 |
-| DeleteFile_large_repo | 139.4 KB 💾 | 253.4 MB 🔥 | 3.9 MB 🏆 |
-| DeleteFile_medium_repo | 139.3 KB 💾 | 43.3 MB 🔥 | 2.1 MB 🏆 |
-| DeleteFile_small_repo | 139.9 KB 💾 | 3.4 MB | 1.2 MB 🏆 |
-| DeleteFile_xlarge_repo | 139.4 KB 💾 | 2.1 GB 🔥 | 10.0 MB 🏆 |
-| GetFlatTree_large_tree | 3.2 MB 💾 | 206.7 MB 🔥 | 2.0 MB 🏆 |
-| GetFlatTree_medium_tree | 743.1 KB 💾 | 47.9 MB 🔥 | 1.0 MB 🏆 |
-| GetFlatTree_small_tree | 157.6 KB 💾 | 3.2 MB 🔥 | 35.5 KB 🏆 |
-| GetFlatTree_xlarge_tree | 18.7 MB 💾 | 1.7 GB 🔥 | 12.7 MB 🏆 |
-| UpdateFile_large_repo | 138.8 KB 💾 | 216.1 MB 🔥 | 4.2 MB 🏆 |
-| UpdateFile_medium_repo | 138.6 KB 💾 | 50.1 MB 🔥 | 2.9 MB 🏆 |
-| UpdateFile_small_repo | 138.8 KB 💾 | 3.4 MB ✅ | 1.9 MB 🏆 |
-| UpdateFile_xlarge_repo | 138.5 KB 💾 | 2.1 GB 🔥 | 11.9 MB 🏆 |
+| BulkCreateFiles_bulk_1000_files_medium | -686864 B 💾 | 38.9 MB 🔥 | 4.5 MB 🏆 |
+| BulkCreateFiles_bulk_1000_files_small | 159.9 KB 💾 | 5.4 MB | 1.5 MB 🏆 |
+| BulkCreateFiles_bulk_100_files_medium | -1026344 B 💾 | 38.7 MB 🔥 | 2.9 MB 🏆 |
+| BulkCreateFiles_bulk_100_files_small | -1023328 B 💾 | 5.2 MB 🔥 | 971.5 KB 🏆 |
+| CompareCommits_adjacent_commits_large | 70.2 KB 💾 | 210.8 MB 🔥 | 3.3 MB 🏆 |
+| CompareCommits_adjacent_commits_medium | 70.2 KB 💾 | 39.2 MB 🔥 | 953.9 KB 🏆 |
+| CompareCommits_adjacent_commits_small | 70.6 KB 💾 | 3.6 MB 🔥 | 553.6 KB 🏆 |
+| CompareCommits_adjacent_commits_xlarge | 70.5 KB 💾 | 1.5 GB 🔥 | 15.4 MB 🏆 |
+| CompareCommits_few_commits_large | 70.2 KB 💾 | 186.5 MB 🔥 | 4.2 MB 🏆 |
+| CompareCommits_few_commits_medium | 70.5 KB 💾 | 40.4 MB 🔥 | 2.3 MB 🏆 |
+| CompareCommits_few_commits_small | 70.5 KB 💾 | 3.3 MB 🔥 | 258.9 KB 🏆 |
+| CompareCommits_few_commits_xlarge | 70.5 KB 💾 | 1.7 GB 🔥 | 17.5 MB 🏆 |
+| CompareCommits_max_commits_large | 70.2 KB 💾 | 207.5 MB 🔥 | 4.1 MB 🏆 |
+| CompareCommits_max_commits_medium | 70.5 KB 💾 | 38.7 MB 🔥 | 1.8 MB 🏆 |
+| CompareCommits_max_commits_small | 70.5 KB 💾 | 3.3 MB | 1.3 MB 🏆 |
+| CompareCommits_max_commits_xlarge | 70.2 KB 💾 | 1.7 GB 🔥 | 14.3 MB 🏆 |
+| CreateFile_large_repo | 136.1 KB 💾 | 178.5 MB 🔥 | 5.0 MB 🏆 |
+| CreateFile_medium_repo | 135.8 KB 💾 | 36.5 MB 🔥 | 3.3 MB 🏆 |
+| CreateFile_small_repo | 136.2 KB 💾 | 4.2 MB | 1.1 MB 🏆 |
+| CreateFile_xlarge_repo | 136.2 KB 💾 | 2.1 GB 🔥 | 12.5 MB 🏆 |
+| DeleteFile_large_repo | 136.1 KB 💾 | 176.5 MB 🔥 | 3.4 MB 🏆 |
+| DeleteFile_medium_repo | 135.8 KB 💾 | 33.3 MB 🔥 | 2.3 MB 🏆 |
+| DeleteFile_small_repo | 136.6 KB 💾 | 4.1 MB ✅ | 2.2 MB 🏆 |
+| DeleteFile_xlarge_repo | 136.1 KB 💾 | 2.1 GB 🔥 | 12.1 MB 🏆 |
+| GetFlatTree_large_tree | 3.2 MB 💾 | 280.6 MB 🔥 | 2.3 MB 🏆 |
+| GetFlatTree_medium_tree | 740.9 KB 💾 | 44.9 MB 🔥 | 611.4 KB 🏆 |
+| GetFlatTree_small_tree | 155.8 KB 💾 | 4.0 MB 🔥 | 366.7 KB 🏆 |
+| GetFlatTree_xlarge_tree | 18.7 MB 💾 | 1.7 GB 🔥 | 10.2 MB 🏆 |
+| UpdateFile_large_repo | 135.4 KB 💾 | 254.4 MB 🔥 | 4.2 MB 🏆 |
+| UpdateFile_medium_repo | 135.0 KB 💾 | 38.9 MB 🔥 | 2.6 MB 🏆 |
+| UpdateFile_small_repo | 135.4 KB 💾 | 3.5 MB | 1.4 MB 🏆 |
+| UpdateFile_xlarge_repo | 135.4 KB 💾 | 2.1 GB 🔥 | 10.8 MB 🏆 |
 
 ## 🎯 Nanogit Performance Analysis
 
@@ -122,38 +122,38 @@
 
 | Operation | vs git-cli | vs go-git |
 |-----------|-----------|-----------|
-| BulkCreateFiles_bulk_1000_files_medium | 13.0x faster 🚀 | 88.9x faster 🚀 |
-| BulkCreateFiles_bulk_1000_files_small | 12.4x faster 🚀 | 22.6x faster 🚀 |
-| BulkCreateFiles_bulk_100_files_medium | 15.8x faster 🚀 | 62.4x faster 🚀 |
-| BulkCreateFiles_bulk_100_files_small | 13.3x faster 🚀 | 9.3x faster 🚀 |
-| CompareCommits_adjacent_commits_large | 11.1x faster 🚀 | 21.1x faster 🚀 |
-| CompareCommits_adjacent_commits_medium | 5.5x faster 🚀 | 4.1x faster 🚀 |
-| CompareCommits_adjacent_commits_small | 4.2x faster 🚀 | 1.2x slower 🐌 |
-| CompareCommits_adjacent_commits_xlarge | 30.2x faster 🚀 | 110.5x faster 🚀 |
-| CompareCommits_few_commits_large | 6.8x faster 🚀 | 11.8x faster 🚀 |
-| CompareCommits_few_commits_medium | 2.8x faster 🚀 | 2.3x faster 🚀 |
-| CompareCommits_few_commits_small | 2.2x faster 🚀 | 2.2x slower 🐌 |
-| CompareCommits_few_commits_xlarge | 17.6x faster 🚀 | 63.2x faster 🚀 |
-| CompareCommits_max_commits_large | 4.2x faster 🚀 | 8.0x faster 🚀 |
-| CompareCommits_max_commits_medium | 1.9x faster ✅ | 1.6x faster ✅ |
-| CompareCommits_max_commits_small | 1.5x faster ✅ | 3.1x slower 🐌 |
-| CompareCommits_max_commits_xlarge | 15.1x faster 🚀 | 40.2x faster 🚀 |
-| CreateFile_large_repo | 30.0x faster 🚀 | 50.0x faster 🚀 |
-| CreateFile_medium_repo | 19.0x faster 🚀 | 10.1x faster 🚀 |
-| CreateFile_small_repo | 16.0x faster 🚀 | 2.2x faster 🚀 |
-| CreateFile_xlarge_repo | 102.1x faster 🚀 | 262.1x faster 🚀 |
-| DeleteFile_large_repo | 29.7x faster 🚀 | 50.2x faster 🚀 |
-| DeleteFile_medium_repo | 19.1x faster 🚀 | 10.0x faster 🚀 |
-| DeleteFile_small_repo | 16.9x faster 🚀 | 2.2x faster 🚀 |
-| DeleteFile_xlarge_repo | 81.7x faster 🚀 | 268.7x faster 🚀 |
-| GetFlatTree_large_tree | 28.6x faster 🚀 | 70.0x faster 🚀 |
-| GetFlatTree_medium_tree | 14.7x faster 🚀 | 13.2x faster 🚀 |
-| GetFlatTree_small_tree | 8.9x faster 🚀 | 1.6x faster ✅ |
-| GetFlatTree_xlarge_tree | 77.1x faster 🚀 | 302.7x faster 🚀 |
-| UpdateFile_large_repo | 30.0x faster 🚀 | 50.0x faster 🚀 |
-| UpdateFile_medium_repo | 19.3x faster 🚀 | 10.2x faster 🚀 |
-| UpdateFile_small_repo | 16.2x faster 🚀 | 2.2x faster 🚀 |
-| UpdateFile_xlarge_repo | 105.1x faster 🚀 | 275.4x faster 🚀 |
+| BulkCreateFiles_bulk_1000_files_medium | 9.2x faster 🚀 | 47.7x faster 🚀 |
+| BulkCreateFiles_bulk_1000_files_small | 9.5x faster 🚀 | 12.8x faster 🚀 |
+| BulkCreateFiles_bulk_100_files_medium | 19.3x faster 🚀 | 52.4x faster 🚀 |
+| BulkCreateFiles_bulk_100_files_small | 13.6x faster 🚀 | 7.3x faster 🚀 |
+| CompareCommits_adjacent_commits_large | 14.1x faster 🚀 | 22.9x faster 🚀 |
+| CompareCommits_adjacent_commits_medium | 7.8x faster 🚀 | 3.8x faster 🚀 |
+| CompareCommits_adjacent_commits_small | 5.2x faster 🚀 | ~same ⚖️ |
+| CompareCommits_adjacent_commits_xlarge | 70.4x faster 🚀 | 113.3x faster 🚀 |
+| CompareCommits_few_commits_large | 19.3x faster 🚀 | 13.1x faster 🚀 |
+| CompareCommits_few_commits_medium | 5.8x faster 🚀 | 2.5x faster 🚀 |
+| CompareCommits_few_commits_small | 2.6x faster 🚀 | 2.4x slower 🐌 |
+| CompareCommits_few_commits_xlarge | 19.8x faster 🚀 | 57.4x faster 🚀 |
+| CompareCommits_max_commits_large | 12.3x faster 🚀 | 8.4x faster 🚀 |
+| CompareCommits_max_commits_medium | 3.7x faster 🚀 | 1.6x faster ✅ |
+| CompareCommits_max_commits_small | 1.7x faster ✅ | 3.0x slower 🐌 |
+| CompareCommits_max_commits_xlarge | 19.6x faster 🚀 | 40.1x faster 🚀 |
+| CreateFile_large_repo | 32.2x faster 🚀 | 48.7x faster 🚀 |
+| CreateFile_medium_repo | 19.3x faster 🚀 | 9.6x faster 🚀 |
+| CreateFile_small_repo | 15.7x faster 🚀 | 2.0x faster ✅ |
+| CreateFile_xlarge_repo | 144.1x faster 🚀 | 255.7x faster 🚀 |
+| DeleteFile_large_repo | 33.3x faster 🚀 | 51.6x faster 🚀 |
+| DeleteFile_medium_repo | 19.2x faster 🚀 | 9.3x faster 🚀 |
+| DeleteFile_small_repo | 17.8x faster 🚀 | 2.2x faster 🚀 |
+| DeleteFile_xlarge_repo | 114.6x faster 🚀 | 249.0x faster 🚀 |
+| GetFlatTree_large_tree | 29.7x faster 🚀 | 47.7x faster 🚀 |
+| GetFlatTree_medium_tree | 11.2x faster 🚀 | 9.3x faster 🚀 |
+| GetFlatTree_small_tree | 8.5x faster 🚀 | 1.7x faster ✅ |
+| GetFlatTree_xlarge_tree | 101.2x faster 🚀 | 253.4x faster 🚀 |
+| UpdateFile_large_repo | 33.1x faster 🚀 | 52.0x faster 🚀 |
+| UpdateFile_medium_repo | 19.6x faster 🚀 | 9.5x faster 🚀 |
+| UpdateFile_small_repo | 18.0x faster 🚀 | 2.2x faster 🚀 |
+| UpdateFile_xlarge_repo | 117.4x faster 🚀 | 261.8x faster 🚀 |
 
 ### 💾 Memory Comparison
 
@@ -161,38 +161,38 @@
 
 | Operation | vs git-cli | vs go-git |
 |-----------|-----------|-----------|
-| BulkCreateFiles_bulk_1000_files_medium | 179.2x more 💾 | 6.1x more 🔥 |
-| BulkCreateFiles_bulk_1000_files_small | 1087.8x more 💾 | 23.6x more 🔥 |
-| BulkCreateFiles_bulk_100_files_medium | -24.4x more 💾 | 6.3x less 💚 |
-| BulkCreateFiles_bulk_100_files_small | 2.4x more 💾 | 1.5x less ✅ |
-| CompareCommits_adjacent_commits_large | 58.8x more 💾 | 44.7x less 💚 |
-| CompareCommits_adjacent_commits_medium | 21.0x more 💾 | 26.1x less 💚 |
-| CompareCommits_adjacent_commits_small | 7.5x more 💾 | 7.0x less 💚 |
-| CompareCommits_adjacent_commits_xlarge | 215.1x more 💾 | 113.6x less 💚 |
-| CompareCommits_few_commits_large | 52.2x more 💾 | 56.5x less 💚 |
-| CompareCommits_few_commits_medium | 26.0x more 💾 | 21.3x less 💚 |
-| CompareCommits_few_commits_small | 4.1x more 💾 | 10.8x less 💚 |
-| CompareCommits_few_commits_xlarge | 204.7x more 💾 | 109.0x less 💚 |
-| CompareCommits_max_commits_large | 43.6x more 💾 | 66.6x less 💚 |
-| CompareCommits_max_commits_medium | 15.6x more 💾 | 35.9x less 💚 |
-| CompareCommits_max_commits_small | 8.0x more 💾 | 5.4x less 💚 |
-| CompareCommits_max_commits_xlarge | 211.7x more 💾 | 105.1x less 💚 |
-| CreateFile_large_repo | 30.8x more 💾 | 51.2x less 💚 |
-| CreateFile_medium_repo | 17.0x more 💾 | 19.3x less 💚 |
-| CreateFile_small_repo | 12.1x more 💾 | 3.0x less 💚 |
-| CreateFile_xlarge_repo | 79.2x more 💾 | 195.0x less 💚 |
-| DeleteFile_large_repo | 28.9x more 💾 | 64.4x less 💚 |
-| DeleteFile_medium_repo | 15.1x more 💾 | 21.1x less 💚 |
-| DeleteFile_small_repo | 8.6x more 💾 | 2.9x less 💚 |
-| DeleteFile_xlarge_repo | 73.6x more 💾 | 211.8x less 💚 |
-| GetFlatTree_large_tree | 0.6x more 💾 | 104.1x less 💚 |
-| GetFlatTree_medium_tree | 1.4x more 💾 | 47.1x less 💚 |
-| GetFlatTree_small_tree | 0.2x more 💾 | 93.0x less 💚 |
-| GetFlatTree_xlarge_tree | 0.7x more 💾 | 136.8x less 💚 |
-| UpdateFile_large_repo | 31.0x more 💾 | 51.5x less 💚 |
-| UpdateFile_medium_repo | 21.1x more 💾 | 17.5x less 💚 |
-| UpdateFile_small_repo | 14.4x more 💾 | 1.7x less ✅ |
-| UpdateFile_xlarge_repo | 87.8x more 💾 | 179.7x less 💚 |
+| BulkCreateFiles_bulk_1000_files_medium | -6.9x more 💾 | 8.6x less 💚 |
+| BulkCreateFiles_bulk_1000_files_small | 9.7x more 💾 | 3.6x less 💚 |
+| BulkCreateFiles_bulk_100_files_medium | -3.0x more 💾 | 13.2x less 💚 |
+| BulkCreateFiles_bulk_100_files_small | -1.0x more 💾 | 5.5x less 💚 |
+| CompareCommits_adjacent_commits_large | 48.6x more 💾 | 63.2x less 💚 |
+| CompareCommits_adjacent_commits_medium | 13.6x more 💾 | 42.1x less 💚 |
+| CompareCommits_adjacent_commits_small | 7.8x more 💾 | 6.6x less 💚 |
+| CompareCommits_adjacent_commits_xlarge | 223.5x more 💾 | 103.0x less 💚 |
+| CompareCommits_few_commits_large | 60.9x more 💾 | 44.7x less 💚 |
+| CompareCommits_few_commits_medium | 33.5x more 💾 | 17.5x less 💚 |
+| CompareCommits_few_commits_small | 3.7x more 💾 | 12.9x less 💚 |
+| CompareCommits_few_commits_xlarge | 253.4x more 💾 | 101.2x less 💚 |
+| CompareCommits_max_commits_large | 59.6x more 💾 | 50.8x less 💚 |
+| CompareCommits_max_commits_medium | 25.6x more 💾 | 22.0x less 💚 |
+| CompareCommits_max_commits_small | 18.5x more 💾 | 2.6x less 💚 |
+| CompareCommits_max_commits_xlarge | 208.2x more 💾 | 123.4x less 💚 |
+| CreateFile_large_repo | 37.4x more 💾 | 35.9x less 💚 |
+| CreateFile_medium_repo | 25.2x more 💾 | 10.9x less 💚 |
+| CreateFile_small_repo | 8.4x more 💾 | 3.7x less 💚 |
+| CreateFile_xlarge_repo | 94.3x more 💾 | 169.1x less 💚 |
+| DeleteFile_large_repo | 25.6x more 💾 | 51.8x less 💚 |
+| DeleteFile_medium_repo | 17.4x more 💾 | 14.4x less 💚 |
+| DeleteFile_small_repo | 16.5x more 💾 | 1.9x less ✅ |
+| DeleteFile_xlarge_repo | 91.3x more 💾 | 175.2x less 💚 |
+| GetFlatTree_large_tree | 0.7x more 💾 | 123.2x less 💚 |
+| GetFlatTree_medium_tree | 0.8x more 💾 | 75.3x less 💚 |
+| GetFlatTree_small_tree | 2.4x more 💾 | 11.1x less 💚 |
+| GetFlatTree_xlarge_tree | 0.5x more 💾 | 170.3x less 💚 |
+| UpdateFile_large_repo | 31.6x more 💾 | 60.8x less 💚 |
+| UpdateFile_medium_repo | 19.5x more 💾 | 15.2x less 💚 |
+| UpdateFile_small_repo | 10.8x more 💾 | 2.5x less 💚 |
+| UpdateFile_xlarge_repo | 81.5x more 💾 | 197.8x less 💚 |
 
 ## 📈 Detailed Statistics
 
@@ -200,255 +200,255 @@
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 10.39s | 10.39s | 1.0 MB | 1.0 MB |
-| go-git | 1 | ✅ 100.0% | 70.99s | 70.99s | 29.3 MB | 29.3 MB |
-| nanogit | 1 | ✅ 100.0% | 798.7ms | 798.7ms | 179.3 MB | 179.3 MB |
+| git-cli | 1 | ✅ 100.0% | 14.03s | 14.03s | -686864 B | -686864 B |
+| go-git | 1 | ✅ 100.0% | 72.33s | 72.33s | 38.9 MB | 38.9 MB |
+| nanogit | 1 | ✅ 100.0% | 1.52s | 1.52s | 4.5 MB | 4.5 MB |
 
 ### BulkCreateFiles_bulk_1000_files_small
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 9.95s | 9.95s | 121.3 KB | 121.3 KB |
-| go-git | 1 | ✅ 100.0% | 18.18s | 18.18s | 5.5 MB | 5.5 MB |
-| nanogit | 1 | ✅ 100.0% | 805.5ms | 805.5ms | 128.8 MB | 128.8 MB |
+| git-cli | 1 | ✅ 100.0% | 14.17s | 14.17s | 159.9 KB | 159.9 KB |
+| go-git | 1 | ✅ 100.0% | 19.12s | 19.12s | 5.4 MB | 5.4 MB |
+| nanogit | 1 | ✅ 100.0% | 1.49s | 1.49s | 1.5 MB | 1.5 MB |
 
 ### BulkCreateFiles_bulk_100_files_medium
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 1.66s | 1.66s | -226264 B | -226264 B |
-| go-git | 1 | ✅ 100.0% | 6.56s | 6.56s | 33.4 MB | 33.4 MB |
-| nanogit | 1 | ✅ 100.0% | 105.2ms | 105.2ms | 5.3 MB | 5.3 MB |
+| git-cli | 1 | ✅ 100.0% | 2.43s | 2.43s | -1026344 B | -1026344 B |
+| go-git | 1 | ✅ 100.0% | 6.59s | 6.59s | 38.7 MB | 38.7 MB |
+| nanogit | 1 | ✅ 100.0% | 125.8ms | 125.8ms | 2.9 MB | 2.9 MB |
 
 ### BulkCreateFiles_bulk_100_files_small
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 1.29s | 1.29s | 1.3 MB | 1.3 MB |
-| go-git | 1 | ✅ 100.0% | 901.0ms | 901.0ms | 4.8 MB | 4.8 MB |
-| nanogit | 1 | ✅ 100.0% | 97.1ms | 97.1ms | 3.2 MB | 3.2 MB |
+| git-cli | 1 | ✅ 100.0% | 1.69s | 1.69s | -1023328 B | -1023328 B |
+| go-git | 1 | ✅ 100.0% | 907.4ms | 907.4ms | 5.2 MB | 5.2 MB |
+| nanogit | 1 | ✅ 100.0% | 124.2ms | 124.2ms | 971.5 KB | 971.5 KB |
 
 ### CompareCommits_adjacent_commits_large
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 1.38s | 1.38s | 72.8 KB | 72.8 KB |
-| go-git | 1 | ⚠️ 0.0% | 2.63s | 2.63s | 186.7 MB | 186.7 MB |
-| nanogit | 1 | ✅ 100.0% | 124.4ms | 124.4ms | 4.2 MB | 4.2 MB |
+| git-cli | 1 | ✅ 100.0% | 1.62s | 1.62s | 70.2 KB | 70.2 KB |
+| go-git | 1 | ⚠️ 0.0% | 2.64s | 2.64s | 210.8 MB | 210.8 MB |
+| nanogit | 1 | ✅ 100.0% | 115.3ms | 115.3ms | 3.3 MB | 3.3 MB |
 
 ### CompareCommits_adjacent_commits_medium
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 562.2ms | 562.2ms | 72.4 KB | 72.4 KB |
-| go-git | 1 | ⚠️ 0.0% | 416.4ms | 416.4ms | 38.6 MB | 38.6 MB |
-| nanogit | 1 | ✅ 100.0% | 102.1ms | 102.1ms | 1.5 MB | 1.5 MB |
+| git-cli | 1 | ✅ 100.0% | 861.3ms | 861.3ms | 70.2 KB | 70.2 KB |
+| go-git | 1 | ⚠️ 0.0% | 422.8ms | 422.8ms | 39.2 MB | 39.2 MB |
+| nanogit | 1 | ✅ 100.0% | 110.7ms | 110.7ms | 953.9 KB | 953.9 KB |
 
 ### CompareCommits_adjacent_commits_small
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 348.7ms | 348.7ms | 72.8 KB | 72.8 KB |
-| go-git | 1 | ⚠️ 0.0% | 69.5ms | 69.5ms | 3.7 MB | 3.7 MB |
-| nanogit | 1 | ✅ 100.0% | 82.2ms | 82.2ms | 544.3 KB | 544.3 KB |
+| git-cli | 1 | ✅ 100.0% | 443.3ms | 443.3ms | 70.6 KB | 70.6 KB |
+| go-git | 1 | ⚠️ 0.0% | 80.1ms | 80.1ms | 3.6 MB | 3.6 MB |
+| nanogit | 1 | ✅ 100.0% | 84.5ms | 84.5ms | 553.6 KB | 553.6 KB |
 
 ### CompareCommits_adjacent_commits_xlarge
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 5.60s | 5.60s | 73.7 KB | 73.7 KB |
-| go-git | 1 | ⚠️ 0.0% | 20.45s | 20.45s | 1.7 GB | 1.7 GB |
-| nanogit | 1 | ✅ 100.0% | 185.1ms | 185.1ms | 15.5 MB | 15.5 MB |
+| git-cli | 1 | ✅ 100.0% | 12.90s | 12.90s | 70.5 KB | 70.5 KB |
+| go-git | 1 | ⚠️ 0.0% | 20.76s | 20.76s | 1.5 GB | 1.5 GB |
+| nanogit | 1 | ✅ 100.0% | 183.2ms | 183.2ms | 15.4 MB | 15.4 MB |
 
 ### CompareCommits_few_commits_large
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 1.50s | 1.50s | 72.8 KB | 72.8 KB |
-| go-git | 1 | ⚠️ 0.0% | 2.62s | 2.62s | 209.3 MB | 209.3 MB |
-| nanogit | 1 | ✅ 100.0% | 221.7ms | 221.7ms | 3.7 MB | 3.7 MB |
+| git-cli | 1 | ✅ 100.0% | 3.85s | 3.85s | 70.2 KB | 70.2 KB |
+| go-git | 1 | ⚠️ 0.0% | 2.61s | 2.61s | 186.5 MB | 186.5 MB |
+| nanogit | 1 | ✅ 100.0% | 199.7ms | 199.7ms | 4.2 MB | 4.2 MB |
 
 ### CompareCommits_few_commits_medium
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 516.4ms | 516.4ms | 72.8 KB | 72.8 KB |
-| go-git | 1 | ⚠️ 0.0% | 418.9ms | 418.9ms | 39.3 MB | 39.3 MB |
-| nanogit | 1 | ✅ 100.0% | 183.6ms | 183.6ms | 1.8 MB | 1.8 MB |
+| git-cli | 1 | ✅ 100.0% | 960.1ms | 960.1ms | 70.5 KB | 70.5 KB |
+| go-git | 1 | ⚠️ 0.0% | 406.4ms | 406.4ms | 40.4 MB | 40.4 MB |
+| nanogit | 1 | ✅ 100.0% | 165.7ms | 165.7ms | 2.3 MB | 2.3 MB |
 
 ### CompareCommits_few_commits_small
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 351.1ms | 351.1ms | 72.8 KB | 72.8 KB |
-| go-git | 1 | ⚠️ 0.0% | 71.4ms | 71.4ms | 3.1 MB | 3.1 MB |
-| nanogit | 1 | ✅ 100.0% | 158.6ms | 158.6ms | 296.9 KB | 296.9 KB |
+| git-cli | 1 | ✅ 100.0% | 443.6ms | 443.6ms | 70.5 KB | 70.5 KB |
+| go-git | 1 | ⚠️ 0.0% | 68.5ms | 68.5ms | 3.3 MB | 3.3 MB |
+| nanogit | 1 | ✅ 100.0% | 167.7ms | 167.7ms | 258.9 KB | 258.9 KB |
 
 ### CompareCommits_few_commits_xlarge
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 5.71s | 5.71s | 72.8 KB | 72.8 KB |
-| go-git | 1 | ⚠️ 0.0% | 20.51s | 20.51s | 1.5 GB | 1.5 GB |
-| nanogit | 1 | ✅ 100.0% | 324.4ms | 324.4ms | 14.5 MB | 14.5 MB |
+| git-cli | 1 | ✅ 100.0% | 7.14s | 7.14s | 70.5 KB | 70.5 KB |
+| go-git | 1 | ⚠️ 0.0% | 20.66s | 20.66s | 1.7 GB | 1.7 GB |
+| nanogit | 1 | ✅ 100.0% | 360.0ms | 360.0ms | 17.5 MB | 17.5 MB |
 
 ### CompareCommits_max_commits_large
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 1.37s | 1.37s | 73.6 KB | 73.6 KB |
-| go-git | 1 | ⚠️ 0.0% | 2.61s | 2.61s | 209.2 MB | 209.2 MB |
-| nanogit | 1 | ✅ 100.0% | 324.7ms | 324.7ms | 3.1 MB | 3.1 MB |
+| git-cli | 1 | ✅ 100.0% | 3.89s | 3.89s | 70.2 KB | 70.2 KB |
+| go-git | 1 | ⚠️ 0.0% | 2.66s | 2.66s | 207.5 MB | 207.5 MB |
+| nanogit | 1 | ✅ 100.0% | 316.1ms | 316.1ms | 4.1 MB | 4.1 MB |
 
 ### CompareCommits_max_commits_medium
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 480.7ms | 480.7ms | 73.2 KB | 73.2 KB |
-| go-git | 1 | ⚠️ 0.0% | 413.5ms | 413.5ms | 40.1 MB | 40.1 MB |
-| nanogit | 1 | ✅ 100.0% | 252.7ms | 252.7ms | 1.1 MB | 1.1 MB |
+| git-cli | 1 | ✅ 100.0% | 1.00s | 1.00s | 70.5 KB | 70.5 KB |
+| go-git | 1 | ⚠️ 0.0% | 425.9ms | 425.9ms | 38.7 MB | 38.7 MB |
+| nanogit | 1 | ✅ 100.0% | 270.2ms | 270.2ms | 1.8 MB | 1.8 MB |
 
 ### CompareCommits_max_commits_small
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 348.0ms | 348.0ms | 72.4 KB | 72.4 KB |
-| go-git | 1 | ⚠️ 0.0% | 74.1ms | 74.1ms | 3.1 MB | 3.1 MB |
-| nanogit | 1 | ✅ 100.0% | 226.5ms | 226.5ms | 581.4 KB | 581.4 KB |
+| git-cli | 1 | ✅ 100.0% | 440.0ms | 440.0ms | 70.5 KB | 70.5 KB |
+| go-git | 1 | ⚠️ 0.0% | 85.3ms | 85.3ms | 3.3 MB | 3.3 MB |
+| nanogit | 1 | ✅ 100.0% | 258.1ms | 258.1ms | 1.3 MB | 1.3 MB |
 
 ### CompareCommits_max_commits_xlarge
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 7.88s | 7.88s | 72.6 KB | 72.6 KB |
-| go-git | 1 | ⚠️ 0.0% | 20.91s | 20.91s | 1.5 GB | 1.5 GB |
-| nanogit | 1 | ✅ 100.0% | 520.5ms | 520.5ms | 15.0 MB | 15.0 MB |
+| git-cli | 1 | ✅ 100.0% | 10.04s | 10.04s | 70.2 KB | 70.2 KB |
+| go-git | 1 | ⚠️ 0.0% | 20.53s | 20.53s | 1.7 GB | 1.7 GB |
+| nanogit | 1 | ✅ 100.0% | 511.4ms | 511.4ms | 14.3 MB | 14.3 MB |
 
 ### CreateFile_large_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 1.76s | 1.79s | 139.4 KB | 139.4 KB |
-| go-git | 3 | ✅ 100.0% | 2.94s | 2.95s | 214.9 MB | 178.1 MB |
-| nanogit | 3 | ✅ 100.0% | 58.8ms | 63.0ms | 4.2 MB | 4.2 MB |
+| git-cli | 3 | ✅ 100.0% | 1.96s | 2.00s | 136.1 KB | 135.9 KB |
+| go-git | 3 | ✅ 100.0% | 2.96s | 2.98s | 178.5 MB | 178.1 MB |
+| nanogit | 3 | ✅ 100.0% | 60.7ms | 65.7ms | 5.0 MB | 5.0 MB |
 
 ### CreateFile_medium_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 967.7ms | 974.7ms | 139.6 KB | 139.4 KB |
-| go-git | 3 | ✅ 100.0% | 513.4ms | 518.9ms | 44.6 MB | 50.9 MB |
-| nanogit | 3 | ✅ 100.0% | 51.0ms | 53.4ms | 2.3 MB | 2.8 MB |
+| git-cli | 3 | ✅ 100.0% | 1.02s | 1.04s | 135.8 KB | 135.9 KB |
+| go-git | 3 | ✅ 100.0% | 508.0ms | 520.0ms | 36.5 MB | 32.6 MB |
+| nanogit | 3 | ✅ 100.0% | 52.6ms | 55.0ms | 3.3 MB | 3.6 MB |
 
 ### CreateFile_small_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 819.2ms | 889.9ms | 139.3 KB | 139.4 KB |
-| go-git | 3 | ✅ 100.0% | 111.9ms | 128.4ms | 5.0 MB | 5.0 MB |
-| nanogit | 3 | ✅ 100.0% | 51.1ms | 55.1ms | 1.6 MB | 1.7 MB |
+| git-cli | 3 | ✅ 100.0% | 872.2ms | 925.6ms | 136.2 KB | 136.2 KB |
+| go-git | 3 | ✅ 100.0% | 109.8ms | 129.0ms | 4.2 MB | 4.5 MB |
+| nanogit | 3 | ✅ 100.0% | 55.7ms | 75.3ms | 1.1 MB | 929.4 KB |
 
 ### CreateFile_xlarge_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 8.82s | 11.28s | 139.7 KB | 139.4 KB |
-| go-git | 3 | ✅ 100.0% | 22.65s | 22.70s | 2.1 GB | 2.0 GB |
-| nanogit | 3 | ✅ 100.0% | 86.4ms | 89.4ms | 10.8 MB | 9.7 MB |
+| git-cli | 3 | ✅ 100.0% | 12.77s | 20.26s | 136.2 KB | 135.9 KB |
+| go-git | 3 | ✅ 100.0% | 22.65s | 22.82s | 2.1 GB | 2.1 GB |
+| nanogit | 3 | ✅ 100.0% | 88.6ms | 91.4ms | 12.5 MB | 12.9 MB |
 
 ### DeleteFile_large_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 1.75s | 1.83s | 139.4 KB | 139.3 KB |
-| go-git | 3 | ✅ 100.0% | 2.95s | 2.98s | 253.4 MB | 291.4 MB |
-| nanogit | 3 | ✅ 100.0% | 58.9ms | 60.0ms | 3.9 MB | 4.2 MB |
+| git-cli | 3 | ✅ 100.0% | 1.90s | 1.99s | 136.1 KB | 135.8 KB |
+| go-git | 3 | ✅ 100.0% | 2.95s | 2.99s | 176.5 MB | 176.7 MB |
+| nanogit | 3 | ✅ 100.0% | 57.2ms | 59.4ms | 3.4 MB | 3.4 MB |
 
 ### DeleteFile_medium_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 965.4ms | 972.6ms | 139.3 KB | 139.3 KB |
-| go-git | 3 | ✅ 100.0% | 505.5ms | 520.0ms | 43.3 MB | 50.1 MB |
-| nanogit | 3 | ✅ 100.0% | 50.5ms | 55.4ms | 2.1 MB | 2.1 MB |
+| git-cli | 3 | ✅ 100.0% | 1.03s | 1.04s | 135.8 KB | 135.8 KB |
+| go-git | 3 | ✅ 100.0% | 498.9ms | 499.9ms | 33.3 MB | 29.6 MB |
+| nanogit | 3 | ✅ 100.0% | 53.7ms | 56.3ms | 2.3 MB | 2.0 MB |
 
 ### DeleteFile_small_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 790.2ms | 798.4ms | 139.9 KB | 139.3 KB |
-| go-git | 3 | ✅ 100.0% | 105.0ms | 108.0ms | 3.4 MB | 3.7 MB |
-| nanogit | 3 | ✅ 100.0% | 46.7ms | 49.6ms | 1.2 MB | 936.6 KB |
+| git-cli | 3 | ✅ 100.0% | 853.1ms | 869.2ms | 136.6 KB | 135.8 KB |
+| go-git | 3 | ✅ 100.0% | 105.0ms | 110.1ms | 4.1 MB | 4.0 MB |
+| nanogit | 3 | ✅ 100.0% | 48.0ms | 51.4ms | 2.2 MB | 2.5 MB |
 
 ### DeleteFile_xlarge_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 6.86s | 8.28s | 139.4 KB | 139.3 KB |
-| go-git | 3 | ✅ 100.0% | 22.56s | 22.64s | 2.1 GB | 2.1 GB |
-| nanogit | 3 | ✅ 100.0% | 83.9ms | 93.3ms | 10.0 MB | 9.0 MB |
+| git-cli | 3 | ✅ 100.0% | 10.45s | 10.84s | 136.1 KB | 136.2 KB |
+| go-git | 3 | ✅ 100.0% | 22.69s | 22.82s | 2.1 GB | 2.1 GB |
+| nanogit | 3 | ✅ 100.0% | 91.1ms | 100.9ms | 12.1 MB | 12.1 MB |
 
 ### GetFlatTree_large_tree
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 1.14s | 1.14s | 3.2 MB | 3.2 MB |
-| go-git | 1 | ✅ 100.0% | 2.79s | 2.79s | 206.7 MB | 206.7 MB |
-| nanogit | 1 | ✅ 100.0% | 39.8ms | 39.8ms | 2.0 MB | 2.0 MB |
+| git-cli | 1 | ✅ 100.0% | 1.69s | 1.69s | 3.2 MB | 3.2 MB |
+| go-git | 1 | ✅ 100.0% | 2.72s | 2.72s | 280.6 MB | 280.6 MB |
+| nanogit | 1 | ✅ 100.0% | 56.9ms | 56.9ms | 2.3 MB | 2.3 MB |
 
 ### GetFlatTree_medium_tree
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 506.0ms | 506.0ms | 743.1 KB | 743.1 KB |
-| go-git | 1 | ✅ 100.0% | 455.5ms | 455.5ms | 47.9 MB | 47.9 MB |
-| nanogit | 1 | ✅ 100.0% | 34.5ms | 34.5ms | 1.0 MB | 1.0 MB |
+| git-cli | 1 | ✅ 100.0% | 566.1ms | 566.1ms | 740.9 KB | 740.9 KB |
+| go-git | 1 | ✅ 100.0% | 467.0ms | 467.0ms | 44.9 MB | 44.9 MB |
+| nanogit | 1 | ✅ 100.0% | 50.4ms | 50.4ms | 611.4 KB | 611.4 KB |
 
 ### GetFlatTree_small_tree
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 395.7ms | 395.7ms | 157.6 KB | 157.6 KB |
-| go-git | 1 | ✅ 100.0% | 73.2ms | 73.2ms | 3.2 MB | 3.2 MB |
-| nanogit | 1 | ✅ 100.0% | 44.6ms | 44.6ms | 35.5 KB | 35.5 KB |
+| git-cli | 1 | ✅ 100.0% | 397.0ms | 397.0ms | 155.8 KB | 155.8 KB |
+| go-git | 1 | ✅ 100.0% | 79.7ms | 79.7ms | 4.0 MB | 4.0 MB |
+| nanogit | 1 | ✅ 100.0% | 46.7ms | 46.7ms | 366.7 KB | 366.7 KB |
 
 ### GetFlatTree_xlarge_tree
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 1 | ✅ 100.0% | 5.21s | 5.21s | 18.7 MB | 18.7 MB |
-| go-git | 1 | ✅ 100.0% | 20.47s | 20.47s | 1.7 GB | 1.7 GB |
-| nanogit | 1 | ✅ 100.0% | 67.6ms | 67.6ms | 12.7 MB | 12.7 MB |
+| git-cli | 1 | ✅ 100.0% | 8.28s | 8.28s | 18.7 MB | 18.7 MB |
+| go-git | 1 | ✅ 100.0% | 20.72s | 20.72s | 1.7 GB | 1.7 GB |
+| nanogit | 1 | ✅ 100.0% | 81.8ms | 81.8ms | 10.2 MB | 10.2 MB |
 
 ### UpdateFile_large_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 1.77s | 1.93s | 138.8 KB | 138.6 KB |
-| go-git | 3 | ✅ 100.0% | 2.96s | 2.98s | 216.1 MB | 181.4 MB |
-| nanogit | 3 | ✅ 100.0% | 59.1ms | 62.1ms | 4.2 MB | 4.2 MB |
+| git-cli | 3 | ✅ 100.0% | 1.88s | 1.97s | 135.4 KB | 135.6 KB |
+| go-git | 3 | ✅ 100.0% | 2.95s | 2.96s | 254.4 MB | 291.0 MB |
+| nanogit | 3 | ✅ 100.0% | 56.7ms | 58.6ms | 4.2 MB | 4.2 MB |
 
 ### UpdateFile_medium_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 950.8ms | 958.9ms | 138.6 KB | 138.6 KB |
-| go-git | 3 | ✅ 100.0% | 503.1ms | 515.0ms | 50.1 MB | 50.3 MB |
-| nanogit | 3 | ✅ 100.0% | 49.2ms | 51.6ms | 2.9 MB | 2.9 MB |
+| git-cli | 3 | ✅ 100.0% | 1.03s | 1.04s | 135.0 KB | 135.1 KB |
+| go-git | 3 | ✅ 100.0% | 501.9ms | 515.9ms | 38.9 MB | 32.3 MB |
+| nanogit | 3 | ✅ 100.0% | 52.7ms | 59.3ms | 2.6 MB | 2.8 MB |
 
 ### UpdateFile_small_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 789.0ms | 793.8ms | 138.8 KB | 138.9 KB |
-| go-git | 3 | ✅ 100.0% | 107.6ms | 113.2ms | 3.4 MB | 3.2 MB |
-| nanogit | 3 | ✅ 100.0% | 48.7ms | 48.8ms | 1.9 MB | 2.5 MB |
+| git-cli | 3 | ✅ 100.0% | 853.1ms | 872.9ms | 135.4 KB | 135.1 KB |
+| go-git | 3 | ✅ 100.0% | 106.2ms | 112.0ms | 3.5 MB | 3.6 MB |
+| nanogit | 3 | ✅ 100.0% | 47.3ms | 47.8ms | 1.4 MB | 930.4 KB |
 
 ### UpdateFile_xlarge_repo
 
 | Client | Runs | Success | Avg Duration | P95 Duration | Avg Memory | Median Memory |
 |--------|------|---------|--------------|--------------|------------|---------------|
-| git-cli | 3 | ✅ 100.0% | 8.59s | 9.05s | 138.5 KB | 138.6 KB |
-| go-git | 3 | ✅ 100.0% | 22.52s | 22.53s | 2.1 GB | 2.1 GB |
-| nanogit | 3 | ✅ 100.0% | 81.8ms | 85.0ms | 11.9 MB | 12.9 MB |
+| git-cli | 3 | ✅ 100.0% | 10.15s | 10.76s | 135.4 KB | 135.6 KB |
+| go-git | 3 | ✅ 100.0% | 22.63s | 22.65s | 2.1 GB | 2.1 GB |
+| nanogit | 3 | ✅ 100.0% | 86.4ms | 91.0ms | 10.8 MB | 9.7 MB |
 

--- a/protocol/client/rawclient.go
+++ b/protocol/client/rawclient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -20,7 +21,7 @@ type RawClient interface {
 	IsAuthorized(ctx context.Context) (bool, error)
 	SmartInfo(ctx context.Context, service string) ([]byte, error)
 	UploadPack(ctx context.Context, data []byte) ([]byte, error)
-	ReceivePack(ctx context.Context, data []byte) ([]byte, error)
+	ReceivePack(ctx context.Context, data io.Reader) ([]byte, error)
 	Fetch(ctx context.Context, opts FetchOptions) (map[string]*protocol.PackfileObject, error)
 	LsRefs(ctx context.Context, opts LsRefsOptions) ([]protocol.RefLine, error)
 }

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -12,17 +11,15 @@ import (
 
 // ReceivePack sends a POST request to the git-receive-pack endpoint.
 // This endpoint is used to send objects to the remote repository.
-func (c *rawClient) ReceivePack(ctx context.Context, data []byte) ([]byte, error) {
-	body := bytes.NewReader(data)
+func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, error) {
 
 	// NOTE: This path is defined in the protocol-v2 spec as required under $GIT_URL/git-receive-pack.
 	// See: https://git-scm.com/docs/protocol-v2#_http_transport
 	u := c.base.JoinPath("git-receive-pack")
 	logger := log.FromContext(ctx)
 	logger.Debug("Receive-pack", "url", u.String())
-	logger.Debug("Receive-pack raw request", "requestBody", string(data))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), data)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +47,6 @@ func (c *rawClient) ReceivePack(ctx context.Context, data []byte) ([]byte, error
 	logger.Debug("Receive-pack response",
 		"status", res.StatusCode,
 		"statusText", res.Status,
-		"requestSize", len(data),
 		"responseSize", len(responseBody))
 	logger.Debug("Receive-pack raw response", "responseBody", string(responseBody))
 

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"net"
 	"net/http"
@@ -123,7 +124,7 @@ func TestReceivePack(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			response, err := client.ReceivePack(context.Background(), []byte("test data"))
+			response, err := client.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)

--- a/protocol/packfile_cleanup_test.go
+++ b/protocol/packfile_cleanup_test.go
@@ -1,0 +1,74 @@
+package protocol
+
+import (
+	"crypto"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/grafana/nanogit/protocol/hash"
+)
+
+func TestPackfileWriterCleanup(t *testing.T) {
+	t.Run("cleanup prevents further operations", func(t *testing.T) {
+		writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMemory)
+		
+		// Verify operations work before cleanup
+		_, err := writer.AddBlob([]byte("test content"))
+		require.NoError(t, err)
+		
+		assert.True(t, writer.HasObjects())
+		
+		// Cleanup the writer
+		err = writer.Cleanup()
+		require.NoError(t, err)
+		
+		// Verify all operations now fail with ErrPackfileWriterCleanedUp
+		_, err = writer.AddBlob([]byte("more content"))
+		require.ErrorIs(t, err, ErrPackfileWriterCleanedUp)
+		
+		// HasObjects should return false after cleanup
+		assert.False(t, writer.HasObjects())
+		
+		// AddObject should silently fail (no error returned by design)
+		writer.AddObject(PackfileObject{Type: ObjectTypeBlob, Data: []byte("test")})
+		assert.False(t, writer.HasObjects())
+		
+		// WritePackfile should fail
+		err = writer.WritePackfile(nil, "refs/heads/main", hash.Zero)
+		require.ErrorIs(t, err, ErrPackfileWriterCleanedUp)
+	})
+	
+	t.Run("cleanup can only be called once", func(t *testing.T) {
+		writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMemory)
+		
+		// First cleanup should succeed
+		err := writer.Cleanup()
+		require.NoError(t, err)
+		
+		// Second cleanup should fail
+		err = writer.Cleanup()
+		require.ErrorIs(t, err, ErrPackfileWriterCleanedUp)
+	})
+	
+	t.Run("cleanup removes temporary files", func(t *testing.T) {
+		writer := NewPackfileWriter(crypto.SHA1, PackfileStorageDisk)
+		
+		// Add enough data to trigger file storage
+		for i := 0; i < 20; i++ {
+			_, err := writer.AddBlob([]byte("large content to trigger file storage"))
+			require.NoError(t, err)
+		}
+		
+		// Verify temp file exists
+		require.NotNil(t, writer.tempFile)
+		
+		// Cleanup should remove the temp file
+		err := writer.Cleanup()
+		require.NoError(t, err)
+		
+		// File should be removed (checking this might be OS-dependent)
+		// The important thing is that cleanup completed without error
+		assert.True(t, writer.isCleanedUp)
+	})
+}

--- a/protocol/packfile_storage_test.go
+++ b/protocol/packfile_storage_test.go
@@ -1,0 +1,184 @@
+package protocol
+
+import (
+	"crypto"
+	"os"
+	"testing"
+
+	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackfileStorageMode(t *testing.T) {
+	t.Run("constants have expected values", func(t *testing.T) {
+		assert.Equal(t, PackfileStorageMode(0), PackfileStorageAuto)
+		assert.Equal(t, PackfileStorageMode(1), PackfileStorageMemory)
+		assert.Equal(t, PackfileStorageMode(2), PackfileStorageDisk)
+	})
+}
+
+func TestNewPackfileWriter(t *testing.T) {
+	tests := []struct {
+		name        string
+		storageMode PackfileStorageMode
+	}{
+		{"auto mode", PackfileStorageAuto},
+		{"memory mode", PackfileStorageMemory},
+		{"disk mode", PackfileStorageDisk},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := NewPackfileWriter(crypto.SHA1, tt.storageMode)
+			assert.NotNil(t, writer)
+			assert.Equal(t, crypto.SHA1, writer.algo)
+			assert.Equal(t, tt.storageMode, writer.storageMode)
+			assert.NotNil(t, writer.objectHashes)
+			assert.NotNil(t, writer.memoryObjects)
+			assert.Nil(t, writer.tempFile)
+		})
+	}
+}
+
+func TestPackfileWriter_StorageMode_Memory(t *testing.T) {
+	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMemory)
+	defer writer.Cleanup()
+
+	// Add multiple objects - should all go to memory
+	for i := 0; i < 20; i++ {
+		obj := PackfileObject{
+			Type: ObjectTypeBlob,
+			Data: []byte("test data"),
+			Hash: hash.Hash{}, // Hash will be computed in real usage
+		}
+		err := writer.addObject(obj)
+		require.NoError(t, err)
+	}
+
+	// Should have objects in memory, no temp file
+	assert.Len(t, writer.memoryObjects, 20)
+	assert.Nil(t, writer.tempFile)
+}
+
+func TestPackfileWriter_StorageMode_Disk(t *testing.T) {
+	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageDisk)
+	defer writer.Cleanup()
+
+	// Add single object - should go to disk
+	obj := PackfileObject{
+		Type: ObjectTypeBlob,
+		Data: []byte("test data"),
+		Hash: hash.Hash{}, // Hash will be computed in real usage
+	}
+	err := writer.addObject(obj)
+	require.NoError(t, err)
+
+	// Should have temp file, no objects in memory
+	assert.Empty(t, writer.memoryObjects)
+	assert.NotNil(t, writer.tempFile)
+
+	// Check temp file exists
+	_, err = os.Stat(writer.tempFile.Name())
+	assert.NoError(t, err)
+}
+
+func TestPackfileWriter_StorageMode_Auto(t *testing.T) {
+	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageAuto)
+	defer writer.Cleanup()
+
+	// Add objects below threshold - should use memory
+	// We test the behavior as if objects were added through normal flow
+	for i := 0; i < MemoryThreshold-1; i++ {
+		obj := PackfileObject{
+			Type: ObjectTypeBlob,
+			Data: []byte("test data"),
+			Hash: hash.Hash{}, // Hash will be computed in real usage
+		}
+		hashStr := string(rune('a' + i)) // Create unique hash strings
+		
+		// Add to hash map to simulate normal object addition
+		writer.objectHashes[hashStr] = true
+		
+		// Call addObject - at this point len(objectHashes) should be < MemoryThreshold
+		err := writer.addObject(obj)
+		require.NoError(t, err)
+		
+		// Should be in memory
+		assert.Len(t, writer.memoryObjects, i+1, "Object %d should be in memory", i)
+		assert.Nil(t, writer.tempFile, "No temp file should exist yet for object %d", i)
+	}
+
+	// Now add one more object to reach the threshold
+	obj := PackfileObject{
+		Type: ObjectTypeBlob,
+		Data: []byte("test data"),
+		Hash: hash.Hash{}, // Hash will be computed in real usage
+	}
+	writer.objectHashes["final"] = true // Now len(objectHashes) == MemoryThreshold
+	
+	err := writer.addObject(obj)
+	require.NoError(t, err)
+
+	// At this point, the condition len(objectHashes) < MemoryThreshold should be false
+	// So it should trigger migration to file
+	assert.NotNil(t, writer.tempFile, "Temp file should exist after reaching threshold")
+	assert.Empty(t, writer.memoryObjects, "Objects should have been migrated to file")
+
+	// Check temp file exists
+	_, err = os.Stat(writer.tempFile.Name())
+	assert.NoError(t, err)
+}
+
+func TestPackfileWriter_StorageMode_UnknownMode(t *testing.T) {
+	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMode(999))
+	defer writer.Cleanup()
+
+	obj := PackfileObject{
+		Type: ObjectTypeBlob,
+		Data: []byte("test data"),
+		Hash: hash.Hash{}, // Hash will be computed in real usage
+	}
+	
+	err := writer.addObject(obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown storage mode")
+}
+
+func TestPackfileWriter_Cleanup(t *testing.T) {
+	t.Run("cleanup with temp file", func(t *testing.T) {
+		writer := NewPackfileWriter(crypto.SHA1, PackfileStorageDisk)
+		
+		// Add object to create temp file
+		obj := PackfileObject{
+			Type: ObjectTypeBlob,
+			Data: []byte("test data"),
+			Hash: hash.Hash{}, // Hash will be computed in real usage
+		}
+		err := writer.addObject(obj)
+		require.NoError(t, err)
+		require.NotNil(t, writer.tempFile)
+		
+		tempFileName := writer.tempFile.Name()
+		
+		// File should exist
+		_, err = os.Stat(tempFileName)
+		require.NoError(t, err)
+		
+		// Cleanup should remove file
+		err = writer.Cleanup()
+		assert.NoError(t, err)
+		
+		// File should be gone
+		_, err = os.Stat(tempFileName)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("cleanup without temp file", func(t *testing.T) {
+		writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMemory)
+		
+		// Should not error when no temp file exists
+		err := writer.Cleanup()
+		assert.NoError(t, err)
+	})
+}

--- a/protocol/packfile_storage_test.go
+++ b/protocol/packfile_storage_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestPackfileStorageMode(t *testing.T) {
 	t.Run("constants have expected values", func(t *testing.T) {
-		assert.Equal(t, PackfileStorageMode(0), PackfileStorageAuto)
-		assert.Equal(t, PackfileStorageMode(1), PackfileStorageMemory)
-		assert.Equal(t, PackfileStorageMode(2), PackfileStorageDisk)
+		assert.Equal(t, PackfileStorageAuto, PackfileStorageMode(0))
+		assert.Equal(t, PackfileStorageMemory, PackfileStorageMode(1))
+		assert.Equal(t, PackfileStorageDisk, PackfileStorageMode(2))
 	})
 }
 
@@ -43,7 +43,7 @@ func TestNewPackfileWriter(t *testing.T) {
 
 func TestPackfileWriter_StorageMode_Memory(t *testing.T) {
 	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMemory)
-	defer writer.Cleanup()
+	defer func() { _ = writer.Cleanup() }()
 
 	// Add multiple objects - should all go to memory
 	for i := 0; i < 20; i++ {
@@ -63,7 +63,7 @@ func TestPackfileWriter_StorageMode_Memory(t *testing.T) {
 
 func TestPackfileWriter_StorageMode_Disk(t *testing.T) {
 	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageDisk)
-	defer writer.Cleanup()
+	defer func() { _ = writer.Cleanup() }()
 
 	// Add single object - should go to disk
 	obj := PackfileObject{
@@ -85,7 +85,7 @@ func TestPackfileWriter_StorageMode_Disk(t *testing.T) {
 
 func TestPackfileWriter_StorageMode_Auto(t *testing.T) {
 	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageAuto)
-	defer writer.Cleanup()
+	defer func() { _ = writer.Cleanup() }()
 
 	// Add objects below threshold - should use memory
 	// We test the behavior as if objects were added through normal flow
@@ -132,7 +132,7 @@ func TestPackfileWriter_StorageMode_Auto(t *testing.T) {
 
 func TestPackfileWriter_StorageMode_UnknownMode(t *testing.T) {
 	writer := NewPackfileWriter(crypto.SHA1, PackfileStorageMode(999))
-	defer writer.Cleanup()
+	defer func() { _ = writer.Cleanup() }()
 
 	obj := PackfileObject{
 		Type: ObjectTypeBlob,
@@ -167,7 +167,7 @@ func TestPackfileWriter_Cleanup(t *testing.T) {
 		
 		// Cleanup should remove file
 		err = writer.Cleanup()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		
 		// File should be gone
 		_, err = os.Stat(tempFileName)

--- a/refs.go
+++ b/refs.go
@@ -1,8 +1,8 @@
 package nanogit
 
 import (
+	"bytes"
 	"context"
-
 	"errors"
 	"fmt"
 
@@ -163,7 +163,7 @@ func (c *httpClient) CreateRef(ctx context.Context, ref Ref) error {
 		return fmt.Errorf("format ref create request for %q: %w", ref.Name, err)
 	}
 
-	_, err = c.ReceivePack(ctx, pkt)
+	_, err = c.ReceivePack(ctx, bytes.NewReader(pkt))
 	if err != nil {
 		return fmt.Errorf("send ref create request for %q: %w", ref.Name, err)
 	}
@@ -219,7 +219,7 @@ func (c *httpClient) UpdateRef(ctx context.Context, ref Ref) error {
 		return fmt.Errorf("format ref update request for %q: %w", ref.Name, err)
 	}
 
-	_, err = c.ReceivePack(ctx, pkt)
+	_, err = c.ReceivePack(ctx, bytes.NewReader(pkt))
 	if err != nil {
 		return fmt.Errorf("send ref update request for %q: %w", ref.Name, err)
 	}
@@ -272,7 +272,7 @@ func (c *httpClient) DeleteRef(ctx context.Context, refName string) error {
 		return fmt.Errorf("format ref delete request for %q: %w", refName, err)
 	}
 
-	_, err = c.ReceivePack(ctx, pkt)
+	_, err = c.ReceivePack(ctx, bytes.NewReader(pkt))
 	if err != nil {
 		return fmt.Errorf("send ref delete request for %q: %w", refName, err)
 	}

--- a/writer.go
+++ b/writer.go
@@ -1071,7 +1071,10 @@ func (w *stagedWriter) removeTreeEntry(ctx context.Context, treeObj *protocol.Pa
 //   - Resets the writer state
 //
 // After calling Cleanup, the writer should not be used for further operations.
-func (w *stagedWriter) Cleanup() error {
+func (w *stagedWriter) Cleanup(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	logger.Debug("Cleaning up staged writer")
+
 	// Clean up the packfile writer (removes temp files)
 	if err := w.writer.Cleanup(); err != nil {
 		return fmt.Errorf("cleanup packfile writer: %w", err)
@@ -1083,5 +1086,6 @@ func (w *stagedWriter) Cleanup() error {
 	// Reset writer state
 	w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode)
 	
+	logger.Debug("Staged writer cleanup completed")
 	return nil
 }

--- a/writer.go
+++ b/writer.go
@@ -1063,3 +1063,25 @@ func (w *stagedWriter) removeTreeEntry(ctx context.Context, treeObj *protocol.Pa
 
 	return &newObj, nil
 }
+
+// Cleanup releases all resources held by the writer and clears staged changes.
+// This method:
+//   - Cleans up the underlying PackfileWriter (removes temp files)
+//   - Clears all staged tree entries from memory
+//   - Resets the writer state
+//
+// After calling Cleanup, the writer should not be used for further operations.
+func (w *stagedWriter) Cleanup() error {
+	// Clean up the packfile writer (removes temp files)
+	if err := w.writer.Cleanup(); err != nil {
+		return fmt.Errorf("cleanup packfile writer: %w", err)
+	}
+
+	// Clear all staged changes from memory
+	w.treeEntries = make(map[string]*FlatTreeEntry)
+	
+	// Reset writer state
+	w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode)
+	
+	return nil
+}

--- a/writer_options.go
+++ b/writer_options.go
@@ -1,0 +1,76 @@
+package nanogit
+
+// PackfileStorageMode defines how packfile objects are stored during staging.
+type PackfileStorageMode int
+
+const (
+	// PackfileStorageAuto automatically chooses between memory and disk based on object count.
+	// Uses memory for small operations (<=10 objects) and disk for larger operations.
+	PackfileStorageAuto PackfileStorageMode = iota
+	
+	// PackfileStorageMemory always stores objects in memory for maximum performance.
+	// Best for small operations but can use significant memory for bulk operations.
+	PackfileStorageMemory
+	
+	// PackfileStorageDisk always stores objects in temporary files on disk.
+	// Best for bulk operations to minimize memory usage.
+	PackfileStorageDisk
+)
+
+// WriterOptions holds configuration options for StagedWriter.
+type WriterOptions struct {
+	// StorageMode determines how packfile objects are stored during staging.
+	// Default is PackfileStorageAuto.
+	StorageMode PackfileStorageMode
+}
+
+// WriterOption is a function type for configuring WriterOptions.
+type WriterOption func(*WriterOptions) error
+
+// WithMemoryStorage configures the writer to always use in-memory storage for packfile objects.
+// This provides the best performance but can use significant memory for bulk operations.
+func WithMemoryStorage() WriterOption {
+	return func(opts *WriterOptions) error {
+		opts.StorageMode = PackfileStorageMemory
+		return nil
+	}
+}
+
+// WithDiskStorage configures the writer to always use disk storage for packfile objects.
+// This minimizes memory usage but may be slightly slower due to disk I/O.
+func WithDiskStorage() WriterOption {
+	return func(opts *WriterOptions) error {
+		opts.StorageMode = PackfileStorageDisk
+		return nil
+	}
+}
+
+// WithAutoStorage configures the writer to automatically choose between memory and disk
+// based on the number of objects. This is the default behavior.
+func WithAutoStorage() WriterOption {
+	return func(opts *WriterOptions) error {
+		opts.StorageMode = PackfileStorageAuto
+		return nil
+	}
+}
+
+// defaultWriterOptions returns the default configuration for StagedWriter.
+func defaultWriterOptions() *WriterOptions {
+	return &WriterOptions{
+		StorageMode: PackfileStorageAuto, // Default to auto mode
+	}
+}
+
+// applyWriterOptions applies a list of WriterOption functions to WriterOptions.
+func applyWriterOptions(options []WriterOption) (*WriterOptions, error) {
+	opts := defaultWriterOptions()
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}

--- a/writer_options_integration_test.go
+++ b/writer_options_integration_test.go
@@ -1,0 +1,153 @@
+package nanogit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStagedWriter_StorageOptions demonstrates how to use storage options
+// when creating a StagedWriter
+func TestStagedWriter_StorageOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Example showing how users can configure storage modes
+	examples := []struct {
+		name        string
+		options     []nanogit.WriterOption
+		description string
+	}{
+		{
+			name:        "default auto mode",
+			options:     nil, // No options = auto mode
+			description: "Uses memory for small operations, file for bulk operations",
+		},
+		{
+			name:        "explicit auto mode",
+			options:     []nanogit.WriterOption{nanogit.WithAutoStorage()},
+			description: "Explicitly enables auto mode",
+		},
+		{
+			name:        "memory mode",
+			options:     []nanogit.WriterOption{nanogit.WithMemoryStorage()},
+			description: "Always uses memory storage for best performance",
+		},
+		{
+			name:        "disk mode",
+			options:     []nanogit.WriterOption{nanogit.WithDiskStorage()},
+			description: "Always uses disk storage to minimize memory usage",
+		},
+	}
+
+	for _, example := range examples {
+		t.Run(example.name, func(t *testing.T) {
+			t.Logf("Testing %s: %s", example.name, example.description)
+
+			// This test demonstrates the API usage - we can't easily test
+			// the actual storage behavior without a real Git server,
+			// but we can verify the options are accepted
+			ctx := context.Background()
+			
+			// Create a dummy ref for testing
+			ref := nanogit.Ref{
+				Name: "refs/heads/test",
+				Hash: hash.Hash{}, // Empty hash for this demo
+			}
+
+			// This would normally work with a real client, but for this test
+			// we just verify the options pattern works
+			options := example.options
+			
+			// Verify the options can be applied
+			if options != nil {
+				writerOpts, err := applyWriterOptionsHelper(options)
+				require.NoError(t, err)
+				assert.NotNil(t, writerOpts)
+				
+				// Verify the expected storage mode based on options
+				switch example.name {
+				case "explicit auto mode":
+					assert.Equal(t, nanogit.PackfileStorageAuto, writerOpts.StorageMode)
+				case "memory mode":
+					assert.Equal(t, nanogit.PackfileStorageMemory, writerOpts.StorageMode)
+				case "disk mode":
+					assert.Equal(t, nanogit.PackfileStorageDisk, writerOpts.StorageMode)
+				}
+			}
+
+			t.Logf("✓ Options for %s work correctly", example.name)
+			
+			// Example of how users would call this in real code:
+			// client, err := nanogit.NewHTTPClient("https://github.com/user/repo")
+			// writer, err := client.NewStagedWriter(ctx, ref, example.options...)
+			_ = ctx
+			_ = ref
+		})
+	}
+}
+
+// Helper function to test option application (since we can't access the internal function from test)
+func applyWriterOptionsHelper(options []nanogit.WriterOption) (*nanogit.WriterOptions, error) {
+	// This simulates the internal applyWriterOptions function for testing
+	opts := &nanogit.WriterOptions{
+		StorageMode: nanogit.PackfileStorageAuto, // Default
+	}
+	
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option(opts); err != nil {
+			return nil, err
+		}
+	}
+	
+	return opts, nil
+}
+
+// TestWriterOptionsUsageExamples shows example usage patterns
+func TestWriterOptionsUsageExamples(t *testing.T) {
+	t.Run("memory storage for performance", func(t *testing.T) {
+		// Example: High-performance scenario where memory usage is not a concern
+		opts, err := applyWriterOptionsHelper([]nanogit.WriterOption{
+			nanogit.WithMemoryStorage(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, nanogit.PackfileStorageMemory, opts.StorageMode)
+		
+		// In real usage:
+		// writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithMemoryStorage())
+	})
+
+	t.Run("disk storage for bulk operations", func(t *testing.T) {
+		// Example: Bulk operation where memory conservation is important
+		opts, err := applyWriterOptionsHelper([]nanogit.WriterOption{
+			nanogit.WithDiskStorage(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, nanogit.PackfileStorageDisk, opts.StorageMode)
+		
+		// In real usage:
+		// writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithDiskStorage())
+	})
+
+	t.Run("auto storage for balanced approach", func(t *testing.T) {
+		// Example: Balanced approach that adapts to the workload
+		opts, err := applyWriterOptionsHelper([]nanogit.WriterOption{
+			nanogit.WithAutoStorage(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, nanogit.PackfileStorageAuto, opts.StorageMode)
+		
+		// In real usage:
+		// writer, err := client.NewStagedWriter(ctx, ref, nanogit.WithAutoStorage())
+		// or simply:
+		// writer, err := client.NewStagedWriter(ctx, ref) // Auto is the default
+	})
+}

--- a/writer_options_test.go
+++ b/writer_options_test.go
@@ -74,9 +74,9 @@ func TestMultipleOptions(t *testing.T) {
 
 func TestPackfileStorageMode(t *testing.T) {
 	t.Run("constants have expected values", func(t *testing.T) {
-		assert.Equal(t, PackfileStorageMode(0), PackfileStorageAuto)
-		assert.Equal(t, PackfileStorageMode(1), PackfileStorageMemory)
-		assert.Equal(t, PackfileStorageMode(2), PackfileStorageDisk)
+		assert.Equal(t, PackfileStorageAuto, PackfileStorageMode(0))
+		assert.Equal(t, PackfileStorageMemory, PackfileStorageMode(1))
+		assert.Equal(t, PackfileStorageDisk, PackfileStorageMode(2))
 	})
 }
 

--- a/writer_options_test.go
+++ b/writer_options_test.go
@@ -1,0 +1,99 @@
+package nanogit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		opts := defaultWriterOptions()
+		assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+	})
+
+	t.Run("apply nil options", func(t *testing.T) {
+		opts, err := applyWriterOptions(nil)
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+	})
+
+	t.Run("apply empty options", func(t *testing.T) {
+		opts, err := applyWriterOptions([]WriterOption{})
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+	})
+
+	t.Run("apply nil option in slice", func(t *testing.T) {
+		opts, err := applyWriterOptions([]WriterOption{nil})
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+	})
+}
+
+func TestWithMemoryStorage(t *testing.T) {
+	opts, err := applyWriterOptions([]WriterOption{WithMemoryStorage()})
+	require.NoError(t, err)
+	assert.Equal(t, PackfileStorageMemory, opts.StorageMode)
+}
+
+func TestWithDiskStorage(t *testing.T) {
+	opts, err := applyWriterOptions([]WriterOption{WithDiskStorage()})
+	require.NoError(t, err)
+	assert.Equal(t, PackfileStorageDisk, opts.StorageMode)
+}
+
+func TestWithAutoStorage(t *testing.T) {
+	opts, err := applyWriterOptions([]WriterOption{WithAutoStorage()})
+	require.NoError(t, err)
+	assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+}
+
+func TestMultipleOptions(t *testing.T) {
+	t.Run("last option wins", func(t *testing.T) {
+		opts, err := applyWriterOptions([]WriterOption{
+			WithMemoryStorage(),
+			WithDiskStorage(),
+			WithAutoStorage(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+	})
+
+	t.Run("mixed with nil", func(t *testing.T) {
+		opts, err := applyWriterOptions([]WriterOption{
+			WithMemoryStorage(),
+			nil,
+			WithDiskStorage(),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageDisk, opts.StorageMode)
+	})
+}
+
+func TestPackfileStorageMode(t *testing.T) {
+	t.Run("constants have expected values", func(t *testing.T) {
+		assert.Equal(t, PackfileStorageMode(0), PackfileStorageAuto)
+		assert.Equal(t, PackfileStorageMode(1), PackfileStorageMemory)
+		assert.Equal(t, PackfileStorageMode(2), PackfileStorageDisk)
+	})
+}
+
+func TestWriterOptionFunction(t *testing.T) {
+	t.Run("option function modifies options correctly", func(t *testing.T) {
+		opts := &WriterOptions{StorageMode: PackfileStorageAuto}
+		
+		err := WithMemoryStorage()(opts)
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageMemory, opts.StorageMode)
+		
+		err = WithDiskStorage()(opts)
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageDisk, opts.StorageMode)
+		
+		err = WithAutoStorage()(opts)
+		require.NoError(t, err)
+		assert.Equal(t, PackfileStorageAuto, opts.StorageMode)
+	})
+}


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Add writer streaming and storage modes.

## Why

<!-- Explain the motivation behind these changes -->

We have a memory bottleneck in the Bulk tree updates map and also we have all the blobs in memory until they are pushed.

## How

<!-- Describe how these changes were implemented -->

- Ignore perf directory from Codecov
- Fix memory bottleneck on Bulk tree updates map.
- Stream packfile writer to avoid memory issues.
- Add writer storage modes: automatic, file and memory.
- Revamp README.md

## Remarks

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

