### PR TITLE
Handle Git Server errors

### DIFF
--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -53,9 +53,7 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, er
 	// Check for Git protocol errors in receive-pack response
 	if _, _, err := protocol.ParsePack(responseBody); err != nil {
 		logger.Debug("Protocol error detected in receive-pack response", "error", err.Error())
-		return nil, fmt.Errorf("parse pack: %w", err)
-	} else {
-		logger.Debug("Receive-pack response parsed successfully", "responseSize", len(responseBody), "error", err)
+		return responseBody, err
 	}
 
 	return responseBody, nil

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -51,7 +51,6 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, er
 		"statusText", res.Status,
 		"responseSize", len(responseBody))
 	logger.Debug("Receive-pack raw response", "responseBody", string(responseBody))
-	logger.Debug("Response bytes details", "length", len(responseBody), "hex", fmt.Sprintf("%x", responseBody))
 
 	// Check for Git protocol errors in receive-pack response
 	if protocolErr := checkReceivePackErrors(responseBody); protocolErr != nil {

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/grafana/nanogit/log"
 	"github.com/grafana/nanogit/protocol"
@@ -14,7 +13,6 @@ import (
 // ReceivePack sends a POST request to the git-receive-pack endpoint.
 // This endpoint is used to send objects to the remote repository.
 func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, error) {
-
 	// NOTE: This path is defined in the protocol-v2 spec as required under $GIT_URL/git-receive-pack.
 	// See: https://git-scm.com/docs/protocol-v2#_http_transport
 	u := c.base.JoinPath("git-receive-pack")
@@ -53,58 +51,10 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, er
 	logger.Debug("Receive-pack raw response", "responseBody", string(responseBody))
 
 	// Check for Git protocol errors in receive-pack response
-	if protocolErr := checkReceivePackErrors(responseBody); protocolErr != nil {
-		logger.Debug("Protocol error detected in receive-pack response", "error", protocolErr.Error())
-		return responseBody, protocolErr
+	if _, _, err := protocol.ParsePack(responseBody); err != nil {
+		logger.Debug("Protocol error detected in receive-pack response", "error", err.Error())
+		return responseBody, err
 	}
 
 	return responseBody, nil
-}
-
-// checkReceivePackErrors checks a receive-pack response for Git protocol errors.
-// This function specifically looks for error patterns that can appear in receive-pack
-// responses, including side-band error messages and reference update failures.
-func checkReceivePackErrors(responseBody []byte) error {
-	// Look for specific patterns in the response that indicate errors
-	responseStr := string(responseBody)
-	
-	// Check for "error:" messages (which might be in side-band packets)
-	if strings.Contains(responseStr, "error: cannot lock ref") {
-		// Extract the error message
-		lines := strings.Split(responseStr, "\n")
-		for _, line := range lines {
-			if strings.Contains(line, "error: cannot lock ref") {
-				// Find the actual error message by skipping packet length and side-band channel
-				if idx := strings.Index(line, "error:"); idx >= 0 {
-					message := strings.TrimSpace(line[idx+6:]) // Remove "error:" prefix
-					return protocol.NewGitServerError([]byte(line), "error", message)
-				}
-			}
-		}
-	}
-	
-	// Check for "ng" (no good) reference update failures
-	if strings.Contains(responseStr, "ng refs/") {
-		lines := strings.Split(responseStr, "\n")
-		for _, line := range lines {
-			if strings.Contains(line, "ng refs/") {
-				// Find the ng message by skipping packet length
-				if idx := strings.Index(line, "ng "); idx >= 0 {
-					parts := strings.SplitN(line[idx+3:], " ", 2)
-					var refName, reason string
-					if len(parts) >= 1 {
-						refName = strings.TrimSpace(parts[0])
-					}
-					if len(parts) >= 2 {
-						reason = strings.TrimSpace(parts[1])
-					} else {
-						reason = "update failed"
-					}
-					return protocol.NewGitReferenceUpdateError([]byte(line), refName, reason)
-				}
-			}
-		}
-	}
-	
-	return nil
 }

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -53,7 +53,9 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, er
 	// Check for Git protocol errors in receive-pack response
 	if _, _, err := protocol.ParsePack(responseBody); err != nil {
 		logger.Debug("Protocol error detected in receive-pack response", "error", err.Error())
-		return responseBody, err
+		return nil, fmt.Errorf("parse pack: %w", err)
+	} else {
+		logger.Debug("Receive-pack response parsed successfully", "responseSize", len(responseBody), "error", err)
 	}
 
 	return responseBody, nil

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/grafana/nanogit/log"
+	"github.com/grafana/nanogit/protocol"
 )
 
 // ReceivePack sends a POST request to the git-receive-pack endpoint.
@@ -49,6 +51,61 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) ([]byte, er
 		"statusText", res.Status,
 		"responseSize", len(responseBody))
 	logger.Debug("Receive-pack raw response", "responseBody", string(responseBody))
+	logger.Debug("Response bytes details", "length", len(responseBody), "hex", fmt.Sprintf("%x", responseBody))
+
+	// Check for Git protocol errors in receive-pack response
+	if protocolErr := checkReceivePackErrors(responseBody); protocolErr != nil {
+		logger.Debug("Protocol error detected in receive-pack response", "error", protocolErr.Error())
+		return responseBody, protocolErr
+	}
 
 	return responseBody, nil
+}
+
+// checkReceivePackErrors checks a receive-pack response for Git protocol errors.
+// This function specifically looks for error patterns that can appear in receive-pack
+// responses, including side-band error messages and reference update failures.
+func checkReceivePackErrors(responseBody []byte) error {
+	// Look for specific patterns in the response that indicate errors
+	responseStr := string(responseBody)
+	
+	// Check for "error:" messages (which might be in side-band packets)
+	if strings.Contains(responseStr, "error: cannot lock ref") {
+		// Extract the error message
+		lines := strings.Split(responseStr, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "error: cannot lock ref") {
+				// Find the actual error message by skipping packet length and side-band channel
+				if idx := strings.Index(line, "error:"); idx >= 0 {
+					message := strings.TrimSpace(line[idx+6:]) // Remove "error:" prefix
+					return protocol.NewGitServerError([]byte(line), "error", message)
+				}
+			}
+		}
+	}
+	
+	// Check for "ng" (no good) reference update failures
+	if strings.Contains(responseStr, "ng refs/") {
+		lines := strings.Split(responseStr, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "ng refs/") {
+				// Find the ng message by skipping packet length
+				if idx := strings.Index(line, "ng "); idx >= 0 {
+					parts := strings.SplitN(line[idx+3:], " ", 2)
+					var refName, reason string
+					if len(parts) >= 1 {
+						refName = strings.TrimSpace(parts[0])
+					}
+					if len(parts) >= 2 {
+						reason = strings.TrimSpace(parts[1])
+					} else {
+						reason = "update failed"
+					}
+					return protocol.NewGitReferenceUpdateError([]byte(line), refName, reason)
+				}
+			}
+		}
+	}
+	
+	return nil
 }

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/nanogit/options"
+	"github.com/grafana/nanogit/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,9 +26,9 @@ func TestReceivePack(t *testing.T) {
 		{
 			name:           "successful response",
 			statusCode:     http.StatusOK,
-			responseBody:   "refs data",
+			responseBody:   "000dunpack ok0000", // Valid Git packet format: unpack ok + flush
 			expectedError:  "",
-			expectedResult: "refs data",
+			expectedResult: "000dunpack ok0000",
 			setupClient:    nil,
 		},
 		{

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -141,13 +141,13 @@ func TestReceivePack(t *testing.T) {
 
 func TestCheckReceivePackErrors(t *testing.T) {
 	tests := []struct {
-		name             string
-		responseBody     string
-		expectError      bool
+		name              string
+		responseBody      string
+		expectError       bool
 		expectedErrorType string
-		expectedMessage  string
-		expectedRefName  string
-		expectedReason   string
+		expectedMessage   string
+		expectedRefName   string
+		expectedReason    string
 	}{
 		{
 			name:         "no error - successful response",
@@ -160,83 +160,83 @@ func TestCheckReceivePackErrors(t *testing.T) {
 			expectError:  false,
 		},
 		{
-			name: "error - cannot lock ref with side-band",
-			responseBody: "0094error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456\n0043000eunpack ok\n002cng refs/heads/main failed to update ref\n00000000",
-			expectError:  true,
+			name:              "error - cannot lock ref with side-band",
+			responseBody:      "0094error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456\n0043000eunpack ok\n002cng refs/heads/main failed to update ref\n00000000",
+			expectError:       true,
 			expectedErrorType: "GitServerError",
-			expectedMessage: "cannot lock ref 'refs/heads/main': is at abc123 but expected def456",
+			expectedMessage:   "cannot lock ref 'refs/heads/main': is at abc123 but expected def456",
 		},
 		{
-			name: "error - reference update failure ng packet",
-			responseBody: "0043000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
-			expectError:  true,
+			name:              "error - reference update failure ng packet",
+			responseBody:      "0043000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
+			expectError:       true,
 			expectedErrorType: "GitReferenceUpdateError",
-			expectedRefName: "refs/heads/main",
-			expectedReason: "failed to update ref",
+			expectedRefName:   "refs/heads/main",
+			expectedReason:    "failed to update ref",
 		},
 		{
-			name: "error - reference update failure ng packet with simple reason",
-			responseBody: "0043000eunpack ok\n001eng refs/heads/main failed\n0000",
-			expectError:  true,
+			name:              "error - reference update failure ng packet with simple reason",
+			responseBody:      "0043000eunpack ok\n001eng refs/heads/main failed\n0000",
+			expectError:       true,
 			expectedErrorType: "GitReferenceUpdateError",
-			expectedRefName: "refs/heads/main",
-			expectedReason: "failed",
+			expectedRefName:   "refs/heads/main",
+			expectedReason:    "failed",
 		},
 		{
-			name: "error - reference update failure ng packet minimal",
-			responseBody: "0043000eunpack ok\n0015ng refs/heads/main\n0000",
-			expectError:  true,
+			name:              "error - reference update failure ng packet minimal",
+			responseBody:      "0043000eunpack ok\n0015ng refs/heads/main\n0000",
+			expectError:       true,
 			expectedErrorType: "GitReferenceUpdateError",
-			expectedRefName: "refs/heads/main",
-			expectedReason: "update failed", // default reason
+			expectedRefName:   "refs/heads/main",
+			expectedReason:    "update failed", // default reason
 		},
 		{
-			name: "error - multiple refs with ng failure",
-			responseBody: "0043000eunpack ok\n0017ok refs/heads/feature\n002ang refs/heads/main rejected\n0000",
-			expectError:  true,
+			name:              "error - multiple refs with ng failure",
+			responseBody:      "0043000eunpack ok\n0017ok refs/heads/feature\n002ang refs/heads/main rejected\n0000",
+			expectError:       true,
 			expectedErrorType: "GitReferenceUpdateError",
-			expectedRefName: "refs/heads/main",
-			expectedReason: "rejected",
+			expectedRefName:   "refs/heads/main",
+			expectedReason:    "rejected",
 		},
 		{
-			name: "error - cannot lock ref in different format",
-			responseBody: "0089error: cannot lock ref 'refs/heads/feature': is at 123abc but expected 456def\n0043000eunpack ok\n0000",
-			expectError:  true,
-			expectedErrorType: "GitServerError", 
-			expectedMessage: "cannot lock ref 'refs/heads/feature': is at 123abc but expected 456def",
-		},
-		{
-			name: "error - cannot lock ref with complex hash",
-			responseBody: "00a2error: cannot lock ref 'refs/heads/main': is at e05cf8c9566dac359fcb7c095d5d121e984619c2 but expected 702a02239830a6c6cd45e8f6e5bbb1816f1f4cff\n0043000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
-			expectError:  true,
+			name:              "error - cannot lock ref in different format",
+			responseBody:      "0089error: cannot lock ref 'refs/heads/feature': is at 123abc but expected 456def\n0043000eunpack ok\n0000",
+			expectError:       true,
 			expectedErrorType: "GitServerError",
-			expectedMessage: "cannot lock ref 'refs/heads/main': is at e05cf8c9566dac359fcb7c095d5d121e984619c2 but expected 702a02239830a6c6cd45e8f6e5bbb1816f1f4cff",
+			expectedMessage:   "cannot lock ref 'refs/heads/feature': is at 123abc but expected 456def",
 		},
 		{
-			name: "no error - unpack ok only",
+			name:              "error - cannot lock ref with complex hash",
+			responseBody:      "00a2error: cannot lock ref 'refs/heads/main': is at e05cf8c9566dac359fcb7c095d5d121e984619c2 but expected 702a02239830a6c6cd45e8f6e5bbb1816f1f4cff\n0043000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
+			expectError:       true,
+			expectedErrorType: "GitServerError",
+			expectedMessage:   "cannot lock ref 'refs/heads/main': is at e05cf8c9566dac359fcb7c095d5d121e984619c2 but expected 702a02239830a6c6cd45e8f6e5bbb1816f1f4cff",
+		},
+		{
+			name:         "no error - unpack ok only",
 			responseBody: "000eunpack ok\n0000",
 			expectError:  false,
 		},
 		{
-			name: "no error - successful push with ok response",
+			name:         "no error - successful push with ok response",
 			responseBody: "000eunpack ok\n0017ok refs/heads/main\n0000",
 			expectError:  false,
 		},
 		{
-			name: "error - ng with tag reference",
-			responseBody: "000eunpack ok\n001fng refs/tags/v1.0.0 denied\n0000",
-			expectError:  true,
+			name:              "error - ng with tag reference",
+			responseBody:      "000eunpack ok\n001fng refs/tags/v1.0.0 denied\n0000",
+			expectError:       true,
 			expectedErrorType: "GitReferenceUpdateError",
-			expectedRefName: "refs/tags/v1.0.0", 
-			expectedReason: "denied",
+			expectedRefName:   "refs/tags/v1.0.0",
+			expectedReason:    "denied",
 		},
 		{
-			name: "no error - contains error text but not error pattern",
+			name:         "no error - contains error text but not error pattern",
 			responseBody: "0023Some message with error word\n0000",
 			expectError:  false,
 		},
 		{
-			name: "no error - contains ng but not ng refs pattern",
+			name:         "no error - contains ng but not ng refs pattern",
 			responseBody: "001cSome ng message here\n0000",
 			expectError:  false,
 		},
@@ -246,12 +246,12 @@ func TestCheckReceivePackErrors(t *testing.T) {
 		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			err := checkReceivePackErrors([]byte(tt.responseBody))
-			
+
 			if tt.expectError {
 				require.Error(t, err, "Expected an error but got none")
-				
+
 				switch tt.expectedErrorType {
 				case "GitServerError":
 					var gitServerErr *protocol.GitServerError
@@ -261,7 +261,7 @@ func TestCheckReceivePackErrors(t *testing.T) {
 						require.Contains(t, gitServerErr.Message, tt.expectedMessage)
 					}
 					require.Equal(t, "error", gitServerErr.ErrorType)
-					
+
 				case "GitReferenceUpdateError":
 					var gitRefErr *protocol.GitReferenceUpdateError
 					require.True(t, errors.As(err, &gitRefErr), "Expected GitReferenceUpdateError but got %T", err)
@@ -272,70 +272,9 @@ func TestCheckReceivePackErrors(t *testing.T) {
 					if tt.expectedReason != "" {
 						require.Equal(t, tt.expectedReason, gitRefErr.Reason)
 					}
-					
+
 				default:
 					t.Errorf("Unknown expected error type: %s", tt.expectedErrorType)
-				}
-			} else {
-				require.NoError(t, err, "Expected no error but got: %v", err)
-			}
-		})
-	}
-}
-
-func TestReceivePackWithProtocolErrors(t *testing.T) {
-	tests := []struct {
-		name             string
-		responseBody     string
-		expectError      bool
-		expectedErrorType string
-	}{
-		{
-			name:         "successful response without errors",
-			responseBody: "000eunpack ok\n0017ok refs/heads/main\n0000",
-			expectError:  false,
-		},
-		{
-			name:             "response with reference update failure",
-			responseBody:     "000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
-			expectError:      true,
-			expectedErrorType: "GitReferenceUpdateError",
-		},
-		{
-			name:             "response with cannot lock ref error",
-			responseBody:     "0089error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456\n000eunpack ok\n0000",
-			expectError:      true,
-			expectedErrorType: "GitServerError",
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // capture range variable
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				if _, err := w.Write([]byte(tt.responseBody)); err != nil {
-					t.Errorf("failed to write response: %v", err)
-					return
-				}
-			}))
-			defer server.Close()
-
-			client, err := NewRawClient(server.URL)
-			require.NoError(t, err)
-
-			_, err = client.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
-			
-			if tt.expectError {
-				require.Error(t, err, "Expected an error but got none")
-				
-				switch tt.expectedErrorType {
-				case "GitServerError":
-					require.True(t, protocol.IsGitServerError(err), "Expected GitServerError")
-				case "GitReferenceUpdateError":
-					require.True(t, protocol.IsGitReferenceUpdateError(err), "Expected GitReferenceUpdateError")
 				}
 			} else {
 				require.NoError(t, err, "Expected no error but got: %v", err)

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -71,6 +71,78 @@ func TestReceivePack(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name:       "git server error response",
+			statusCode: http.StatusOK,
+			responseBody: func() string {
+				message := "error: cannot lock ref 'refs/heads/main': is at d346cc9cd80dd0bbda023bb29a7ff2d887c75b19 but expected b6ce559b8c2e4834e075696cac5522b379448c13"
+				pkt, _ := protocol.PackLine(message).Marshal()
+				return string(pkt)
+			}(),
+			expectedError:  "git server error:",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:       "git reference update error",
+			statusCode: http.StatusOK,
+			responseBody: func() string {
+				message := "ng refs/heads/main failed to update ref"
+				pkt, _ := protocol.PackLine(message).Marshal()
+				return string(pkt)
+			}(),
+			expectedError:  "reference update failed for refs/heads/main:",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:       "git unpack error",
+			statusCode: http.StatusOK,
+			responseBody: func() string {
+				message := "unpack index-pack failed"
+				pkt, _ := protocol.PackLine(message).Marshal()
+				return string(pkt)
+			}(),
+			expectedError:  "pack unpack failed:",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:       "git fatal error with unpack keyword",
+			statusCode: http.StatusOK,
+			responseBody: func() string {
+				message := "fatal: unpack failed due to corrupt data"
+				pkt, _ := protocol.PackLine(message).Marshal()
+				return string(pkt)
+			}(),
+			expectedError:  "pack unpack failed:",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:       "git ERR packet",
+			statusCode: http.StatusOK,
+			responseBody: func() string {
+				message := "ERR push declined due to email policy"
+				pkt, _ := protocol.PackLine(message).Marshal()
+				return string(pkt)
+			}(),
+			expectedError:  "git server ERR:",
+			expectedResult: "",
+			setupClient:    nil,
+		},
+		{
+			name:       "multi-line error like user's first example",
+			statusCode: http.StatusOK,
+			responseBody: func() string {
+				message := "error: object 457e2462aee3d41d1a2832f10419213e10091bdc: treeNotSorted: not properly sorted\nfatal: fsck error in packed object\n"
+				pkt, _ := protocol.PackLine(message).Marshal()
+				return string(pkt)
+			}(),
+			expectedError:  "git server error:",
+			expectedResult: "",
+			setupClient:    nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -129,7 +201,16 @@ func TestReceivePack(t *testing.T) {
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
-				require.Empty(t, response)
+				
+				// For Git protocol errors, we should still get the response body
+				// even when there's an error, since it contains the error details
+				if tt.statusCode == http.StatusOK && tt.responseBody != "" {
+					require.NotEmpty(t, response, "should have response body even with Git protocol errors")
+					require.Equal(t, tt.responseBody, string(response))
+				} else {
+					// For transport errors (non-200 status), response should be empty
+					require.Empty(t, response)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedResult, string(response))

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/grafana/nanogit/options"
+	"github.com/grafana/nanogit/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,6 +134,211 @@ func TestReceivePack(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedResult, string(response))
+			}
+		})
+	}
+}
+
+func TestCheckReceivePackErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		responseBody     string
+		expectError      bool
+		expectedErrorType string
+		expectedMessage  string
+		expectedRefName  string
+		expectedReason   string
+	}{
+		{
+			name:         "no error - successful response",
+			responseBody: "0043000eunpack ok\n0017ok refs/heads/main\n0000",
+			expectError:  false,
+		},
+		{
+			name:         "no error - empty response",
+			responseBody: "",
+			expectError:  false,
+		},
+		{
+			name: "error - cannot lock ref with side-band",
+			responseBody: "0094error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456\n0043000eunpack ok\n002cng refs/heads/main failed to update ref\n00000000",
+			expectError:  true,
+			expectedErrorType: "GitServerError",
+			expectedMessage: "cannot lock ref 'refs/heads/main': is at abc123 but expected def456",
+		},
+		{
+			name: "error - reference update failure ng packet",
+			responseBody: "0043000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
+			expectError:  true,
+			expectedErrorType: "GitReferenceUpdateError",
+			expectedRefName: "refs/heads/main",
+			expectedReason: "failed to update ref",
+		},
+		{
+			name: "error - reference update failure ng packet with simple reason",
+			responseBody: "0043000eunpack ok\n001eng refs/heads/main failed\n0000",
+			expectError:  true,
+			expectedErrorType: "GitReferenceUpdateError",
+			expectedRefName: "refs/heads/main",
+			expectedReason: "failed",
+		},
+		{
+			name: "error - reference update failure ng packet minimal",
+			responseBody: "0043000eunpack ok\n0015ng refs/heads/main\n0000",
+			expectError:  true,
+			expectedErrorType: "GitReferenceUpdateError",
+			expectedRefName: "refs/heads/main",
+			expectedReason: "update failed", // default reason
+		},
+		{
+			name: "error - multiple refs with ng failure",
+			responseBody: "0043000eunpack ok\n0017ok refs/heads/feature\n002ang refs/heads/main rejected\n0000",
+			expectError:  true,
+			expectedErrorType: "GitReferenceUpdateError",
+			expectedRefName: "refs/heads/main",
+			expectedReason: "rejected",
+		},
+		{
+			name: "error - cannot lock ref in different format",
+			responseBody: "0089error: cannot lock ref 'refs/heads/feature': is at 123abc but expected 456def\n0043000eunpack ok\n0000",
+			expectError:  true,
+			expectedErrorType: "GitServerError", 
+			expectedMessage: "cannot lock ref 'refs/heads/feature': is at 123abc but expected 456def",
+		},
+		{
+			name: "error - cannot lock ref with complex hash",
+			responseBody: "00a2error: cannot lock ref 'refs/heads/main': is at e05cf8c9566dac359fcb7c095d5d121e984619c2 but expected 702a02239830a6c6cd45e8f6e5bbb1816f1f4cff\n0043000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
+			expectError:  true,
+			expectedErrorType: "GitServerError",
+			expectedMessage: "cannot lock ref 'refs/heads/main': is at e05cf8c9566dac359fcb7c095d5d121e984619c2 but expected 702a02239830a6c6cd45e8f6e5bbb1816f1f4cff",
+		},
+		{
+			name: "no error - unpack ok only",
+			responseBody: "000eunpack ok\n0000",
+			expectError:  false,
+		},
+		{
+			name: "no error - successful push with ok response",
+			responseBody: "000eunpack ok\n0017ok refs/heads/main\n0000",
+			expectError:  false,
+		},
+		{
+			name: "error - ng with tag reference",
+			responseBody: "000eunpack ok\n001fng refs/tags/v1.0.0 denied\n0000",
+			expectError:  true,
+			expectedErrorType: "GitReferenceUpdateError",
+			expectedRefName: "refs/tags/v1.0.0", 
+			expectedReason: "denied",
+		},
+		{
+			name: "no error - contains error text but not error pattern",
+			responseBody: "0023Some message with error word\n0000",
+			expectError:  false,
+		},
+		{
+			name: "no error - contains ng but not ng refs pattern",
+			responseBody: "001cSome ng message here\n0000",
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			err := checkReceivePackErrors([]byte(tt.responseBody))
+			
+			if tt.expectError {
+				require.Error(t, err, "Expected an error but got none")
+				
+				switch tt.expectedErrorType {
+				case "GitServerError":
+					var gitServerErr *protocol.GitServerError
+					require.True(t, errors.As(err, &gitServerErr), "Expected GitServerError but got %T", err)
+					require.True(t, protocol.IsGitServerError(err), "IsGitServerError should return true")
+					if tt.expectedMessage != "" {
+						require.Contains(t, gitServerErr.Message, tt.expectedMessage)
+					}
+					require.Equal(t, "error", gitServerErr.ErrorType)
+					
+				case "GitReferenceUpdateError":
+					var gitRefErr *protocol.GitReferenceUpdateError
+					require.True(t, errors.As(err, &gitRefErr), "Expected GitReferenceUpdateError but got %T", err)
+					require.True(t, protocol.IsGitReferenceUpdateError(err), "IsGitReferenceUpdateError should return true")
+					if tt.expectedRefName != "" {
+						require.Equal(t, tt.expectedRefName, gitRefErr.RefName)
+					}
+					if tt.expectedReason != "" {
+						require.Equal(t, tt.expectedReason, gitRefErr.Reason)
+					}
+					
+				default:
+					t.Errorf("Unknown expected error type: %s", tt.expectedErrorType)
+				}
+			} else {
+				require.NoError(t, err, "Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestReceivePackWithProtocolErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		responseBody     string
+		expectError      bool
+		expectedErrorType string
+	}{
+		{
+			name:         "successful response without errors",
+			responseBody: "000eunpack ok\n0017ok refs/heads/main\n0000",
+			expectError:  false,
+		},
+		{
+			name:             "response with reference update failure",
+			responseBody:     "000eunpack ok\n002cng refs/heads/main failed to update ref\n0000",
+			expectError:      true,
+			expectedErrorType: "GitReferenceUpdateError",
+		},
+		{
+			name:             "response with cannot lock ref error",
+			responseBody:     "0089error: cannot lock ref 'refs/heads/main': is at abc123 but expected def456\n000eunpack ok\n0000",
+			expectError:      true,
+			expectedErrorType: "GitServerError",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(tt.responseBody)); err != nil {
+					t.Errorf("failed to write response: %v", err)
+					return
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewRawClient(server.URL)
+			require.NoError(t, err)
+
+			_, err = client.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+			
+			if tt.expectError {
+				require.Error(t, err, "Expected an error but got none")
+				
+				switch tt.expectedErrorType {
+				case "GitServerError":
+					require.True(t, protocol.IsGitServerError(err), "Expected GitServerError")
+				case "GitReferenceUpdateError":
+					require.True(t, protocol.IsGitReferenceUpdateError(err), "Expected GitReferenceUpdateError")
+				}
+			} else {
+				require.NoError(t, err, "Expected no error but got: %v", err)
 			}
 		})
 	}

--- a/protocol/pack.go
+++ b/protocol/pack.go
@@ -389,6 +389,7 @@ func ParsePack(b []byte) (lines [][]byte, remainder []byte, err error) {
 			message := string(b[8:length])
 			return lines, b[length:], NewGitServerError(b[:length], "ERR", message)
 
+
 		case bytes.HasPrefix(b[4:], []byte("error:")) || bytes.HasPrefix(b[4:], []byte("fatal:")):
 			// Handle Git error and fatal messages.
 			// These can appear in responses when the server encounters errors during processing.

--- a/tests/protocol_errors_integration_test.go
+++ b/tests/protocol_errors_integration_test.go
@@ -1,0 +1,442 @@
+package integration_test
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Protocol Error Scenarios", func() {
+	var (
+		testAuthor = nanogit.Author{
+			Name:  "Protocol Test Author",
+			Email: "protocol-test@example.com",
+			Time:  time.Now(),
+		}
+		testCommitter = nanogit.Committer{
+			Name:  "Protocol Test Committer",
+			Email: "protocol-test@example.com",
+			Time:  time.Now(),
+		}
+	)
+
+	Context("Reference Update Failures", func() {
+		It("should handle old hash reference update failure", func() {
+			client, _, local, _ := QuickSetup()
+
+			By("Setting up initial state with a commit")
+			local.CreateFile("initial.txt", "initial content")
+			local.Git("add", "initial.txt")
+			local.Git("commit", "-m", "Initial commit")
+			local.Git("branch", "-M", "main")
+			local.Git("push", "-u", "origin", "main", "--force")
+
+			By("Getting the initial commit hash")
+			initialHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a new commit locally to advance the remote")
+			local.Git("commit", "--allow-empty", "-m", "Second commit")
+			local.Git("push", "origin", "main")
+
+			By("Creating a writer with the old (stale) hash")
+			ref := nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: initialHash, // This is now outdated
+			}
+			writer, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Attempting to create and commit a new file")
+			_, err = writer.CreateBlob(ctx, "newfile.txt", []byte("new content"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.Commit(ctx, "Add new file with stale ref", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Attempting to push with stale reference - should fail")
+			err = writer.Push(ctx)
+			Expect(err).To(HaveOccurred())
+
+			By("Push failed as expected - analyzing error type")
+			if protocol.IsGitReferenceUpdateError(err) {
+				var refUpdateErr *protocol.GitReferenceUpdateError
+				Expect(errors.As(err, &refUpdateErr)).To(BeTrue())
+				Expect(refUpdateErr.RefName).To(Equal("refs/heads/main"))
+				logger.Info("Reference update failed as expected", "ref", refUpdateErr.RefName, "reason", refUpdateErr.Reason)
+			} else if protocol.IsGitServerError(err) {
+				var serverErr *protocol.GitServerError
+				Expect(errors.As(err, &serverErr)).To(BeTrue())
+				logger.Info("Push failed with Git server error as expected", "type", serverErr.ErrorType, "message", serverErr.Message)
+			} else {
+				logger.Info("Push failed with other error type", "error", err.Error(), "type", fmt.Sprintf("%T", err))
+				// Still consider this a valid test result - any error shows conflict detection works
+			}
+		})
+
+		It("should handle non-fast-forward reference update failure", func() {
+			client, _, local, _ := QuickSetup()
+
+			By("Setting up initial state")
+			local.CreateFile("file1.txt", "content 1")
+			local.Git("add", "file1.txt")
+			local.Git("commit", "-m", "First commit")
+			local.Git("branch", "-M", "main")
+			local.Git("push", "-u", "origin", "main", "--force")
+
+			firstCommitHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a divergent commit history locally")
+			local.Git("commit", "--allow-empty", "-m", "Local commit")
+			local.Git("push", "origin", "main")
+
+			By("Resetting local to first commit and creating conflicting commit")
+			local.Git("reset", "--hard", firstCommitHash.String())
+			local.CreateFile("file2.txt", "conflicting content")
+			local.Git("add", "file2.txt")
+			local.Git("commit", "-m", "Conflicting commit")
+
+			By("Attempting to push non-fast-forward update")
+			cmd := exec.Command("git", "push", "origin", "main", "--force-with-lease")
+			cmd.Dir = local.Path
+			pushErr := cmd.Run()
+			if pushErr != nil {
+				// This is expected - Git itself prevents non-fast-forward pushes
+				logger.Info("Git prevented non-fast-forward push as expected", "error", pushErr.Error())
+			}
+
+			By("Using nanogit writer to test protocol error handling")
+			// Get the current remote state
+			currentRef, err := client.GetRef(ctx, "refs/heads/main")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create writer with the actual current state
+			writer, err := client.NewStagedWriter(ctx, currentRef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// This should work since we're using the correct reference
+			_, err = writer.CreateBlob(ctx, "valid.txt", []byte("valid content"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.Commit(ctx, "Valid commit", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = writer.Push(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			logger.Info("Valid push succeeded as expected")
+		})
+	})
+
+	Context("Git Server Error Messages", func() {
+		It("should handle server-side validation errors", func() {
+			client, remote, local, _ := QuickSetup()
+
+			By("Setting up competing operations to trigger server validation errors")
+			
+			// Get current state
+			currentHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a commit locally to advance the remote
+			local.CreateFile("server-test.txt", "server test content")
+			local.Git("add", "server-test.txt")
+			local.Git("commit", "-m", "Server test commit")
+			local.Git("push", "origin", "main")
+
+			By("Attempting push with outdated reference to trigger server validation error")
+			// Use the old hash before the server-side update
+			ref := nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: currentHash, // This is now stale
+			}
+			writer, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create content that would be valid if the reference was current
+			_, err = writer.CreateBlob(ctx, "validation-test.txt", []byte("validation test content"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.Commit(ctx, "Commit with stale ref", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Pushing with stale reference - expecting server validation error")
+			err = writer.Push(ctx)
+			Expect(err).To(HaveOccurred(), "Server should reject push with stale reference")
+
+			By("Verifying error is a Git protocol error")
+			if protocol.IsGitServerError(err) {
+				var serverErr *protocol.GitServerError
+				Expect(errors.As(err, &serverErr)).To(BeTrue())
+				logger.Info("Git server error detected as expected", "type", serverErr.ErrorType, "message", serverErr.Message)
+			} else if protocol.IsGitReferenceUpdateError(err) {
+				var refUpdateErr *protocol.GitReferenceUpdateError
+				Expect(errors.As(err, &refUpdateErr)).To(BeTrue())
+				logger.Info("Reference update error detected as expected", "ref", refUpdateErr.RefName, "reason", refUpdateErr.Reason)
+			} else {
+				logger.Info("Server validation failed with other error type", "error", err.Error(), "type", fmt.Sprintf("%T", err))
+			}
+
+			By("Verifying repository remains accessible after error")
+			refs, err := client.ListRefs(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(refs)).To(BeNumerically(">", 0))
+			logger.Info("Repository remains accessible after validation error", "refs_count", len(refs), "repo_name", remote.RepoName)
+		})
+
+		It("should handle protocol errors during concurrent pushes", func() {
+			client, _, local, _ := QuickSetup()
+
+			By("Setting up concurrent operations that could trigger protocol conflicts")
+			currentHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create two writers with the same starting reference
+			ref := nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: currentHash,
+			}
+			
+			writer1, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+			
+			writer2, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating conflicting commits")
+			// Writer 1 creates a commit
+			_, err = writer1.CreateBlob(ctx, "conflict1.txt", []byte("content from writer 1"))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = writer1.Commit(ctx, "Commit from writer 1", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Writer 2 creates a different commit
+			_, err = writer2.CreateBlob(ctx, "conflict2.txt", []byte("content from writer 2"))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = writer2.Commit(ctx, "Commit from writer 2", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("First push should succeed")
+			err = writer1.Push(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			logger.Info("First writer push succeeded")
+
+			By("Second push should fail with protocol error")
+			err = writer2.Push(ctx)
+			Expect(err).To(HaveOccurred(), "Second push should fail due to reference conflict")
+
+			By("Verifying error is a Git protocol error")
+			if protocol.IsGitReferenceUpdateError(err) {
+				var refUpdateErr *protocol.GitReferenceUpdateError
+				Expect(errors.As(err, &refUpdateErr)).To(BeTrue())
+				logger.Info("Reference update error detected as expected", "ref", refUpdateErr.RefName, "reason", refUpdateErr.Reason)
+			} else if protocol.IsGitServerError(err) {
+				var serverErr *protocol.GitServerError
+				Expect(errors.As(err, &serverErr)).To(BeTrue())
+				logger.Info("Git server error during concurrent push", "type", serverErr.ErrorType, "message", serverErr.Message)
+			} else {
+				logger.Info("Concurrent push failed with other error type", "error", err.Error(), "type", fmt.Sprintf("%T", err))
+			}
+		})
+	})
+
+	Context("Protocol Error Recovery", func() {
+		It("should handle transient errors gracefully", func() {
+			client, _, local, _ := QuickSetup()
+
+			By("Setting up repository")
+			local.CreateFile("recovery-test.txt", "recovery test")
+			local.Git("add", "recovery-test.txt")
+			local.Git("commit", "-m", "Recovery test commit")
+			local.Git("branch", "-M", "main")
+			local.Git("push", "-u", "origin", "main", "--force")
+
+			By("Getting current state")
+			currentHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			ref := nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: currentHash,
+			}
+
+			By("Creating multiple writers to simulate concurrent operations")
+			writer1, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			writer2, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Making changes with first writer")
+			_, err = writer1.CreateBlob(ctx, "file1.txt", []byte("content from writer 1"))
+			Expect(err).NotTo(HaveOccurred())
+
+			commit1, err := writer1.Commit(ctx, "Commit from writer 1", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Making changes with second writer")
+			_, err = writer2.CreateBlob(ctx, "file2.txt", []byte("content from writer 2"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer2.Commit(ctx, "Commit from writer 2", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("First writer pushes successfully")
+			err = writer1.Push(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			logger.Info("First writer pushed successfully", "commit", commit1.Hash.String())
+
+			By("Second writer should fail due to stale reference")
+			err = writer2.Push(ctx)
+			Expect(err).To(HaveOccurred(), "Second writer should fail when reference is stale")
+
+			By("Verifying the error type and recovery information")
+			if protocol.IsGitReferenceUpdateError(err) {
+				var refUpdateErr *protocol.GitReferenceUpdateError
+				Expect(errors.As(err, &refUpdateErr)).To(BeTrue())
+				logger.Info("Reference update error as expected", "ref", refUpdateErr.RefName, "reason", refUpdateErr.Reason)
+			} else if protocol.IsGitServerError(err) {
+				var serverErr *protocol.GitServerError
+				Expect(errors.As(err, &serverErr)).To(BeTrue())
+				logger.Info("Git server error during concurrent push", "type", serverErr.ErrorType, "message", serverErr.Message)
+			} else {
+				logger.Info("Concurrent push failed with other error type", "error", err.Error(), "type", fmt.Sprintf("%T", err))
+			}
+
+			By("Demonstrating recovery by getting updated reference")
+			updatedRef, err := client.GetRef(ctx, "refs/heads/main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedRef.Hash).To(Equal(commit1.Hash))
+			logger.Info("Successfully retrieved updated reference for recovery", "new_hash", updatedRef.Hash.String())
+
+			By("Verifying repository state after conflict")
+			refs, err := client.ListRefs(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(refs)).To(BeNumerically(">", 0))
+
+			finalRef, err := client.GetRef(ctx, "refs/heads/main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(finalRef.Hash).To(Equal(commit1.Hash))
+			logger.Info("Repository state is consistent", "final_commit", finalRef.Hash.String())
+		})
+	})
+
+	Context("Protocol Error Edge Cases", func() {
+		It("should handle invalid object scenarios", func() {
+			client, _, local, _ := QuickSetup()
+
+			By("Setting up repository")
+			local.CreateFile("edge-case.txt", "edge case test")
+			local.Git("add", "edge-case.txt")
+			local.Git("commit", "-m", "Edge case test")
+			local.Git("branch", "-M", "main")
+			local.Git("push", "-u", "origin", "main", "--force")
+
+			By("Testing with valid operations that might trigger edge cases")
+			currentHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			ref := nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: currentHash,
+			}
+			writer, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a file with maximum allowed content size")
+			// Create content approaching reasonable limits (not actually max to avoid timeouts)
+			largeContent := make([]byte, 1024*1024) // 1MB
+			for i := range largeContent {
+				largeContent[i] = byte('A' + (i % 26))
+			}
+
+			_, err = writer.CreateBlob(ctx, "large-file.txt", largeContent)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.Commit(ctx, "Add large file", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Pushing large content - checking for pack/unpack errors")
+			err = writer.Push(ctx)
+			if err != nil {
+				By("Analyzing large content push error")
+				if protocol.IsGitUnpackError(err) {
+					var unpackErr *protocol.GitUnpackError
+					Expect(errors.As(err, &unpackErr)).To(BeTrue())
+					logger.Info("Unpack error with large content", "message", unpackErr.Message)
+				} else if protocol.IsGitServerError(err) {
+					var serverErr *protocol.GitServerError
+					Expect(errors.As(err, &serverErr)).To(BeTrue())
+					logger.Info("Server error with large content", "type", serverErr.ErrorType, "message", serverErr.Message)
+				} else {
+					logger.Info("Large content push failed with other error", "error", err.Error())
+				}
+			} else {
+				logger.Info("Large content push succeeded")
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should handle empty and boundary condition operations", func() {
+			client, _, local, _ := QuickSetup()
+
+			By("Setting up repository")
+			local.CreateFile("boundary.txt", "boundary test")
+			local.Git("add", "boundary.txt")
+			local.Git("commit", "-m", "Boundary test")
+			local.Git("branch", "-M", "main")
+			local.Git("push", "-u", "origin", "main", "--force")
+
+			By("Testing boundary conditions")
+			currentHash, err := hash.FromHex(local.Git("rev-parse", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+
+			ref := nanogit.Ref{
+				Name: "refs/heads/main",
+				Hash: currentHash,
+			}
+			writer, err := client.NewStagedWriter(ctx, ref)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating an empty file")
+			_, err = writer.CreateBlob(ctx, "empty-file.txt", []byte{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a file with single byte")
+			_, err = writer.CreateBlob(ctx, "single-byte.txt", []byte{'x'})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating files with special characters in names")
+			_, err = writer.CreateBlob(ctx, "file-with-unicode-🚀.txt", []byte("unicode content"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.Commit(ctx, "Add boundary condition files", testAuthor, testCommitter)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Pushing boundary condition content")
+			err = writer.Push(ctx)
+			if err != nil {
+				By("Analyzing boundary condition errors")
+				if protocol.IsGitServerError(err) {
+					var serverErr *protocol.GitServerError
+					Expect(errors.As(err, &serverErr)).To(BeTrue())
+					logger.Info("Server error with boundary conditions", "type", serverErr.ErrorType, "message", serverErr.Message)
+				} else {
+					logger.Info("Boundary condition push failed", "error", err.Error())
+				}
+			} else {
+				logger.Info("Boundary condition push succeeded")
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	})
+})


### PR DESCRIPTION

## What
<!-- Describe the changes in this PR -->

Handle different types of Git server errors.

## Why
<!-- Explain the motivation behind these changes -->

The HTTP server responds with http status code 200 even with errors. The errors are within the message themselves. Example: 

```
0083error: object 457e2462aee3d41d1a2832f10419213e10091bdc: treeNotSorted: not properly sorted\nfatal: fsck error in packed object\n0022001dunpack index-pack failed\n0030002bng refs/heads/robertoonboarding failed\n000900000000"
```

## How
<!-- Describe how these changes were implemented -->

- Improve response parser to catch more errors. 
- Parse response on `ReceivePack`.
- Add integration tests for those error scenarios. 
- Add support for side-band responses.

## Remarks
<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist
- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.