### PR TITLE
Fix bug for multiple prefixes

### DIFF
--- a/refs.go
+++ b/refs.go
@@ -104,7 +104,16 @@ func (c *httpClient) GetRef(ctx context.Context, refName string) (Ref, error) {
 	}
 
 	if len(lines) > 1 {
-		return Ref{}, fmt.Errorf("multiple refs found for %q", refName)
+		// Multiple refs found, try to find exact match
+		for _, line := range lines {
+			if line.RefName == refName {
+				logger.Debug("Ref found via exact match",
+					"ref_name", refName,
+					"ref_hash", line.Hash.String())
+				return Ref{Name: line.RefName, Hash: line.Hash}, nil
+			}
+		}
+		return Ref{}, NewRefNotFoundError(refName)
 	}
 
 	refLine := lines[0]


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Fix bug with multiple refs

## Why

<!-- Explain the motivation behind these changes -->

The way `LsRef` is by passing a prefix which could lead to multiple results.

## How

<!-- Describe how these changes were implemented -->

- Add filter logic to match the specific one manually.
- Add integration test case for this scenario.

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

