### PR TITLE
Use secrets from Vault for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     name: Test Coverage
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24-ubuntu
     # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,18 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: golang:1.24-bullseye
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          repo_secrets: |
+            GH_REPO_USER=github:GH_REPO_USER
+            GH_REPO_TOKEN=github:GH_REPO_TOKEN
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
@@ -202,7 +213,18 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: golang:1.24-bullseye
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          repo_secrets: |
+            GITLAB_REPO_USER=gitlab:GITLAB_REPO_USER
+            GITLAB_REPO_TOKEN=gitlab:GITLAB_REPO_TOKEN
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
@@ -223,8 +245,8 @@ jobs:
           CGO_ENABLED: 1
           GOFLAGS: -mod=vendor
           TEST_REPO: ${{ vars.GITLAB_REPO_NAME }}
-          TEST_USER: ${{ secrets.GITLAB_REPO_USER }}
-          TEST_TOKEN: ${{ secrets.GITLAB_REPO_TOKEN }}
+          TEST_USER: ${{ env.GITLAB_REPO_USER }}
+          TEST_TOKEN: ${{ env.GITLAB_REPO_TOKEN }}
         run: |
           if [ -z "$TEST_REPO" ] || [ -z "$TEST_TOKEN" ] || [ -z "$TEST_USER" ]; then
             echo "Skipping provider tests: TEST_REPO or TEST_TOKEN or TEST_USER not set"
@@ -237,7 +259,18 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: golang:1.24-bullseye
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          repo_secrets: |
+            BITBUCKET_REPO_USER=bitbucket:BITBUCKET_REPO_USER
+            BITBUCKET_REPO_TOKEN=bitbucket:BITBUCKET_REPO_TOKEN
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
@@ -258,8 +291,8 @@ jobs:
           CGO_ENABLED: 1
           GOFLAGS: -mod=vendor
           TEST_REPO: ${{ vars.BITBUCKET_REPO_NAME }}
-          TEST_USER: ${{ secrets.BITBUCKET_REPO_USER }}
-          TEST_TOKEN: ${{ secrets.BITBUCKET_REPO_TOKEN }}
+          TEST_USER: ${{ env.BITBUCKET_REPO_USER }}
+          TEST_TOKEN: ${{ env.BITBUCKET_REPO_TOKEN }}
         run: |
           if [ -z "$TEST_REPO" ] || [ -z "$TEST_TOKEN" ] || [ -z "$TEST_USER" ]; then
             echo "Skipping provider tests: TEST_REPO or TEST_TOKEN or TEST_USER not set"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     if: github.repository == 'grafana/nanogit'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24-bullseye
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
@@ -201,7 +201,7 @@ jobs:
     if: github.repository == 'grafana/nanogit'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24-bullseye
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
@@ -236,7 +236,7 @@ jobs:
     if: github.repository == 'grafana/nanogit'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-alpine
+      image: golang:1.24-bullseye
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,22 +94,22 @@ jobs:
     name: Test Coverage
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-bullseye
+      image: golang:1.24-alpine
     # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache git make gcc musl-dev bash curl gpg
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
           repo_secrets: |
             CODECOV_TOKEN=codecov:CODECOV_TOKEN
-      - uses: actions/checkout@v4
-      - name: Install build dependencies
-        run: |
-          apk add --no-cache git make gcc musl-dev bash curl gpg
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -165,12 +165,16 @@ jobs:
     if: github.repository == 'grafana/nanogit'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-bullseye
+      image: golang:1.24-alpine
     # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache git make gcc musl-dev bash curl gpg
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
@@ -178,10 +182,6 @@ jobs:
           repo_secrets: |
             GH_REPO_USER=github:GH_REPO_USER
             GH_REPO_TOKEN=github:GH_REPO_TOKEN
-      - uses: actions/checkout@v4
-      - name: Install build dependencies
-        run: |
-          apk add --no-cache git make gcc musl-dev bash curl gpg
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -212,12 +212,16 @@ jobs:
     if: github.repository == 'grafana/nanogit'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-bullseye
+      image: golang:1.24-alpine
     # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache git make gcc musl-dev bash curl gpg
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
@@ -225,10 +229,6 @@ jobs:
           repo_secrets: |
             GITLAB_REPO_USER=gitlab:GITLAB_REPO_USER
             GITLAB_REPO_TOKEN=gitlab:GITLAB_REPO_TOKEN
-      - uses: actions/checkout@v4
-      - name: Install build dependencies
-        run: |
-          apk add --no-cache git make gcc musl-dev bash curl gpg
       - name: Cache Go modules
         uses: actions/cache@v4
         with:
@@ -258,12 +258,16 @@ jobs:
     if: github.repository == 'grafana/nanogit'
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-bullseye
+      image: golang:1.24-alpine
     # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache git make gcc musl-dev bash curl gpg
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
@@ -271,10 +275,6 @@ jobs:
           repo_secrets: |
             BITBUCKET_REPO_USER=bitbucket:BITBUCKET_REPO_USER
             BITBUCKET_REPO_TOKEN=bitbucket:BITBUCKET_REPO_TOKEN
-      - uses: actions/checkout@v4
-      - name: Install build dependencies
-        run: |
-          apk add --no-cache git make gcc musl-dev bash curl gpg
       - name: Cache Go modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     name: Test Coverage
     runs-on: ubuntu-latest
     container:
-      image: golang:1.24-ubuntu
+      image: golang:1.24-bullseye
     # These permissions are needed to assume roles from Github's OIDC.
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,17 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: golang:1.24-alpine
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          repo_secrets: |
+            CODECOV_TOKEN=codecov:CODECOV_TOKEN
       - uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
@@ -121,7 +131,7 @@ jobs:
         with:
           fail_ci_if_error: true
           files: ./coverage.txt
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
 
   test-integration:
     name: Integration Tests


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Use secrets for CI from Vault

## Why

<!-- Explain the motivation behind these changes -->

We had an incident due to Github Secrets we don't want to repeat plus all repositories should now use Vault for secrets management. This change will ensure that all CI secrets are managed through Vault, enhancing security and consistency across our projects.

## How

<!-- Describe how these changes were implemented -->

- Update the workflow to fetch the secrets from Vault instead of using GitHub Secrets.

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

