### PR TITLE
Add move blob and tree operations

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,11 @@ type StagedWriter interface {
 	// Returns the hash of the tree after deletion.
 	DeleteBlob(ctx context.Context, path string) (hash.Hash, error)
 
+	// MoveBlob stages the move of a file from srcPath to destPath.
+	// This is equivalent to copying the file to the new location and deleting the original.
+	// Returns the hash of the moved blob.
+	MoveBlob(ctx context.Context, srcPath, destPath string) (hash.Hash, error)
+
 	// GetTree gets the tree object at the given path.
 	GetTree(ctx context.Context, path string) (*Tree, error)
 

--- a/mocks/staged_writer.go
+++ b/mocks/staged_writer.go
@@ -108,6 +108,21 @@ type FakeStagedWriter struct {
 		result1 *nanogit.Tree
 		result2 error
 	}
+	MoveBlobStub        func(context.Context, string, string) (hash.Hash, error)
+	moveBlobMutex       sync.RWMutex
+	moveBlobArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}
+	moveBlobReturns struct {
+		result1 hash.Hash
+		result2 error
+	}
+	moveBlobReturnsOnCall map[int]struct {
+		result1 hash.Hash
+		result2 error
+	}
 	PushStub        func(context.Context) error
 	pushMutex       sync.RWMutex
 	pushArgsForCall []struct {
@@ -597,6 +612,72 @@ func (fake *FakeStagedWriter) GetTreeReturnsOnCall(i int, result1 *nanogit.Tree,
 	}{result1, result2}
 }
 
+func (fake *FakeStagedWriter) MoveBlob(arg1 context.Context, arg2 string, arg3 string) (hash.Hash, error) {
+	fake.moveBlobMutex.Lock()
+	ret, specificReturn := fake.moveBlobReturnsOnCall[len(fake.moveBlobArgsForCall)]
+	fake.moveBlobArgsForCall = append(fake.moveBlobArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.MoveBlobStub
+	fakeReturns := fake.moveBlobReturns
+	fake.recordInvocation("MoveBlob", []interface{}{arg1, arg2, arg3})
+	fake.moveBlobMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStagedWriter) MoveBlobCallCount() int {
+	fake.moveBlobMutex.RLock()
+	defer fake.moveBlobMutex.RUnlock()
+	return len(fake.moveBlobArgsForCall)
+}
+
+func (fake *FakeStagedWriter) MoveBlobCalls(stub func(context.Context, string, string) (hash.Hash, error)) {
+	fake.moveBlobMutex.Lock()
+	defer fake.moveBlobMutex.Unlock()
+	fake.MoveBlobStub = stub
+}
+
+func (fake *FakeStagedWriter) MoveBlobArgsForCall(i int) (context.Context, string, string) {
+	fake.moveBlobMutex.RLock()
+	defer fake.moveBlobMutex.RUnlock()
+	argsForCall := fake.moveBlobArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeStagedWriter) MoveBlobReturns(result1 hash.Hash, result2 error) {
+	fake.moveBlobMutex.Lock()
+	defer fake.moveBlobMutex.Unlock()
+	fake.MoveBlobStub = nil
+	fake.moveBlobReturns = struct {
+		result1 hash.Hash
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStagedWriter) MoveBlobReturnsOnCall(i int, result1 hash.Hash, result2 error) {
+	fake.moveBlobMutex.Lock()
+	defer fake.moveBlobMutex.Unlock()
+	fake.MoveBlobStub = nil
+	if fake.moveBlobReturnsOnCall == nil {
+		fake.moveBlobReturnsOnCall = make(map[int]struct {
+			result1 hash.Hash
+			result2 error
+		})
+	}
+	fake.moveBlobReturnsOnCall[i] = struct {
+		result1 hash.Hash
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeStagedWriter) Push(arg1 context.Context) error {
 	fake.pushMutex.Lock()
 	ret, specificReturn := fake.pushReturnsOnCall[len(fake.pushArgsForCall)]
@@ -746,6 +827,8 @@ func (fake *FakeStagedWriter) Invocations() map[string][][]interface{} {
 	defer fake.deleteTreeMutex.RUnlock()
 	fake.getTreeMutex.RLock()
 	defer fake.getTreeMutex.RUnlock()
+	fake.moveBlobMutex.RLock()
+	defer fake.moveBlobMutex.RUnlock()
 	fake.pushMutex.RLock()
 	defer fake.pushMutex.RUnlock()
 	fake.updateBlobMutex.RLock()


### PR DESCRIPTION
## What

<!-- Describe the changes in this PR -->

Add `MoveTree` and `MoveBlob` operations.

## Why

<!-- Explain the motivation behind these changes -->

This is a convenience for users who want to move trees and blobs within the repository without needing to manually copy and delete them.

## How

<!-- Describe how these changes were implemented -->

- Add `MoveTree` operation to move a tree from one path to another.
- Add `MoveBlob` operation to move a blob from one path to another.
- Add integration and provider test coverage for both operations.

Fixes <https://github.com/grafana/git-ui-sync-project/issues/366>

<!-- Any additional notes, considerations, or potential impacts -->

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changes have been tested locally.

