### PR TITLE
Add batch blob fetching for Clone operations

### DIFF
--- a/perf/clone_perf_test.go
+++ b/perf/clone_perf_test.go
@@ -90,6 +90,7 @@ func TestCloneGrafanaGrafana(t *testing.T) {
 				Path:         clonePath,
 				Hash:         commitHash,
 				IncludePaths: scenario.includePaths,
+				BatchSize:    100, // Use a reasonable batch size for performance
 			})
 
 			duration := time.Since(startTime)
@@ -186,8 +187,9 @@ func TestCloneGrafanaGrafanaFullRepository(t *testing.T) {
 	startTime := time.Now()
 
 	result, err := client.Clone(ctx, nanogit.CloneOptions{
-		Path: clonePath,
-		Hash: commitHash,
+		Path:      clonePath,
+		Hash:      commitHash,
+		BatchSize: 100, // Use batch size of 100 for performance
 		// No include/exclude paths - clone everything
 	})
 


### PR DESCRIPTION
## Summary

This PR implements batch blob fetching to significantly improve clone performance by fetching multiple blobs in a single request instead of individually.

Part of #93

## Changes

- **Add `BatchSize` field to `CloneOptions`** (backward compatible)
  - `BatchSize = 0` or `1`: fetch blobs individually (default behavior) 
  - `BatchSize > 1`: fetch blobs in batches with automatic fallback
- **Implement batch fetching logic** with robust error handling
  - `writeFilesInBatches()`: processes blobs in configurable batches
  - `fetchBlobBatch()`: fetches multiple blobs in one request
  - Automatic fallback to individual fetching for missing blobs
- **7 comprehensive integration tests** covering various batch sizes and edge cases
- **Performance tests updated** to use `BatchSize: 100`

## Performance Results

Tested against `grafana/grafana` repository (commit `13b6f53`):

| **Test Scenario** | **Before (1 at a time)** | **After (Batch size 100)** | **Improvement** |
| --- | --- | --- | --- |
| pkg/api subpath (159 files) | Duration: 23.5s<br/>Files/second: 6.77 | Duration: 2.95s<br/>Files/second: 53.99 | **~8x faster**<br/>~8x throughput |
| docs/sources (630 files) | Duration: 1m40.7s (100.7s)<br/>Files/second: 6.26 | Duration: 3.32s<br/>Files/second: 189.77 | **~30x faster**<br/>~30x throughput |
| go_files_root (4 files) | Duration: 2.69s<br/>Files/second: 1.49 | Duration: 1.17s<br/>Files/second: 3.43 | **~2.3x faster**<br/>~2.3x throughput |
| scripts/makefile (142 files) | Duration: 22.26s<br/>Files/second: 6.38 | Duration: 2.27s<br/>Files/second: 62.64 | **~9.8x faster**<br/>~9.8x throughput |
| **Total Test Suite** | **149.25s** | **9.78s** | **~15x faster overall** |

## Usage Example

```go
// Clone with batch size of 100 blobs per request
result, err := client.Clone(ctx, nanogit.CloneOptions{
    Path:      "/tmp/repo",
    Hash:      commitHash,
    BatchSize: 100,  // Fetch 100 blobs per request
    IncludePaths: []string{"src/**"},  // Works with path filtering
})
```

## Testing

- ✅ 7 new integration tests covering batch fetching scenarios
- ✅ All existing tests pass (no regression)
- ✅ Backward compatible (default behavior unchanged)
- ✅ Works seamlessly with path filtering

## Implementation Notes

The implementation follows the same pattern as tree batching in `tree.go`:
- Processes entries in batches of specified size
- Tracks missing blobs and retries individually
- Maintains full backward compatibility with `BatchSize = 0` or `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)