### PR TITLE
Add CI job for full clone performance test with 1-minute timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,3 +387,33 @@ jobs:
         run: |
           cd perf
           make test-clone-perf
+
+  test-clone-perf-full:
+    name: Full Clone Performance Test (1 minute limit)
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.24-alpine
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          apk add --no-cache git make gcc musl-dev bash curl
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-perf-${{ hashFiles('perf/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-perf-
+      - name: Run full clone performance test with 1 minute timeout
+        env:
+          CGO_ENABLED: 1
+          RUN_CLONE_PERF_TESTS: true
+          RUN_FULL_CLONE_TEST: true
+        run: |
+          cd perf
+          echo "Running full repository clone test with 1 minute timeout..."
+          echo "Test will FAIL if clone takes more than 60 seconds"
+          go test -v -timeout 1m -run TestCloneGrafanaGrafanaFullRepository .


### PR DESCRIPTION
## Summary

- Adds new CI job `test-clone-perf-full` to test full repository clone performance
- Enforces strict 1-minute timeout for clone operations
- Fails build if clone takes longer than 60 seconds

## Details

This PR adds a new CI job that tests the full clone performance of the grafana/grafana repository with a strict time limit. This serves as a performance regression test to ensure that clone operations remain fast and efficient.

**New CI Job Configuration:**
- **Job Name**: `test-clone-perf-full` (Full Clone Performance Test - 1 minute limit)
- **Test**: `TestCloneGrafanaGrafanaFullRepository`
- **Timeout**: 1 minute (`go test -timeout 1m`)
- **Optimization Settings**: BatchSize=100, Concurrency=10
- **Trigger**: Runs on every PR and main branch push

**Why This Matters:**
- Validates that performance optimizations from #102 (batch fetching) and #103 (concurrent fetching) are maintained
- Ensures clone operations meet performance requirements for CI/CD environments
- Catches performance regressions early before they reach production
- Tests real-world performance against a large production repository (grafana/grafana)

**Expected Outcome:**
With the current optimizations (BatchSize=100, Concurrency=10), the full clone should complete well under 60 seconds. If the job fails, it indicates a performance regression that needs investigation.

## Test plan

- [x] Added new CI job configuration
- [x] Job uses appropriate environment variables (`RUN_CLONE_PERF_TESTS=true`, `RUN_FULL_CLONE_TEST=true`)
- [x] Timeout is correctly set to 1 minute
- [x] Job follows existing CI patterns and structure
- [x] CI job will run on this PR to validate it works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)