### PR TITLE
fix: use correct commit SHA for wait-on-check-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - name: Wait for CI checks
-        uses: lewagon/wait-on-check-action@595dabb27c9aa728f4615967b80f01ad76fa18c8 # v1.3.4
+        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
         with:
           ref: ${{ github.sha }}
           check-regexp: '.*'


### PR DESCRIPTION
## Summary

Fixes the failing release workflow by correcting the pinned commit SHA for the `lewagon/wait-on-check-action` action.

## Problem

The release workflow was failing with the error:
```
An action could not be found at the URI 'https://api.github.com/repos/lewagon/wait-on-check-action/tarball/595dabb27c9aa728f4615967b80f01ad76fa18c8'
```

The commit SHA used in PR #106 was incorrect.

## Solution

Updated the action reference to use the correct commit SHA for v1.3.4:
- **Incorrect SHA**: `595dabb27c9aa728f4615967b80f01ad76fa18c8`
- **Correct SHA**: `ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc`

Verified from the [official release page](https://github.com/lewagon/wait-on-check-action/releases/tag/v1.3.4).

## Changes

- Updated `.github/workflows/release.yml` with correct action commit SHA

## Test Plan

- [ ] Verify workflow runs successfully after merge
- [ ] Confirm wait-for-ci job completes
- [ ] Check that release job triggers correctly

## Related

- Fixes the issue introduced in #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)