### PR TITLE
fix: enable CI checks on CHANGELOG PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
 
           # Commit CHANGELOG
           git add CHANGELOG.md
-          git commit -m "chore: update CHANGELOG for ${NEW_VERSION} [skip ci]"
+          git commit -m "chore: update CHANGELOG for ${NEW_VERSION}"
 
           # Push branch
           git push origin "${BRANCH_NAME}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -146,7 +146,7 @@ A release won't be created if:
 3. **Check branch protection**: Ensure branch protection allows auto-merge
 4. **Manual merge**: If needed, manually merge the CHANGELOG PR
 
-**Note**: The CHANGELOG PR uses `[skip ci]` in its commit message to prevent triggering another release cycle. However, `[skip ci]` may not reliably skip all workflow types in GitHub Actions. Even if the workflow runs for the CHANGELOG PR, it is safe because `chore:` commits do not trigger releases per the semantic-release configuration, and no new tag will be created.
+**Note**: The CHANGELOG PR runs full CI checks (including zizmor and other security scans). This is safe because `chore:` commits do not trigger releases per the semantic-release configuration, so no new release cycle is created. All branch protection requirements will be satisfied before auto-merge.
 
 ## Manual Release (Emergency)
 


### PR DESCRIPTION
## Problem

CHANGELOG PRs were using `[skip ci]` in commit messages, which prevented CI checks (including zizmor) from running. This caused auto-merge to be blocked because branch protection requires zizmor to pass.

## Solution

Removed `[skip ci]` from the CHANGELOG commit message. Now CI runs normally on CHANGELOG PRs.

## Why This Is Safe

- `chore:` commits do not trigger releases per semantic-release configuration
- No infinite loop: CHANGELOG PR merging won't create another release
- All security checks (zizmor, etc.) will run and must pass
- Auto-merge will work correctly with branch protection

## Changes

1. Removed `[skip ci]` from workflow commit message
2. Updated documentation to reflect that CI runs on CHANGELOG PRs

## Testing

After merging:
- Next release will create a CHANGELOG PR
- CI (including zizmor) will run on that PR
- Auto-merge will succeed once all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)