### PR TITLE
docs: add GitHub stars badge to documentation homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 
 <p style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; justify-content: center; margin-bottom: 2rem;">
   <a href="https://github.com/grafana/nanogit/releases"><img src="https://img.shields.io/github/v/release/grafana/nanogit" alt="GitHub Release"></a>
+  <a href="https://github.com/grafana/nanogit/stargazers"><img src="https://img.shields.io/github/stars/grafana/nanogit?style=social" alt="GitHub Stars"></a>
   <a href="https://github.com/grafana/nanogit/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/grafana/nanogit" alt="License"></a>
   <a href="https://goreportcard.com/report/github.com/grafana/nanogit"><img src="https://goreportcard.com/badge/github.com/grafana/nanogit" alt="Go Report Card"></a>
   <a href="https://godoc.org/github.com/grafana/nanogit"><img src="https://godoc.org/github.com/grafana/nanogit?status.svg" alt="GoDoc"></a>


### PR DESCRIPTION
## Summary

Adds a GitHub stars badge to the documentation homepage to encourage community engagement and showcase project popularity.

## Changes

- Added GitHub stars badge to `docs/index.md` badge section
- Badge uses the social style to match GitHub's native star button
- Links to the stargazers page on GitHub

## Visual

The badge appears in the badge row on the homepage at https://grafana.github.io/nanogit, positioned right after the release badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)