### PR TITLE
fix: clarify cleanup error comment in Push after successful push

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -949,8 +949,9 @@ func (w *stagedWriter) Push(ctx context.Context) error {
 		"new_hash", w.lastCommit.Hash.String())
 
 	if cleanupErr != nil {
-		// Cleanup failed, but the push succeeded and state is now consistent.
-		// Return the cleanup error for diagnostic purposes.
+		// Note: Cleanup failed, but the push succeeded and state is now consistent
+		// with the server. We return this error for diagnostic/logging purposes only.
+		// The push operation itself was successful.
 		return fmt.Errorf("cleanup after successful push: %w", cleanupErr)
 	}
 


### PR DESCRIPTION
## Summary

**This PR triggers the v0.3.9 release which includes the critical Push cleanup fixes from #175.**

The actual fixes are in PR #175 (commits 2cc9e1e, e5ccef3, f00e75d), but that PR was squash-merged with uppercase `Fix:` which didn't trigger a semantic release. This PR uses lowercase `fix:` to create the v0.3.9 release that Grafana needs.

## Context: Why This Release Matters for Grafana

**Grafana PR**: https://github.com/grafana/grafana/pull/118983

This version bump (v0.3.9) is required by Grafana's provisioning system to fix **critical issues with cleanup on failed pushes**.

### What's Actually Included in v0.3.9 (from #175):

1. **Fix retry semantics** - Removed premature cleanup so failed pushes can be retried without re-staging objects
2. **Git protocol compliance** - ReceivePack success is now treated as the source of truth (not WritePackfile)
3. **State consistency** - Writer state and ref always reset even when cleanup fails, maintaining consistency with server

### Why These Fixes Are Critical for Grafana:

These improvements are essential for Grafana's dashboard provisioning reliability:
- **Transient failures can be retried** - Network errors, auth timeouts no longer require full re-staging
- **No resource leaks** - Temp files and memory properly cleaned up in all paths
- **Correct Git semantics** - Once server accepts push, client state reflects that regardless of cleanup issues
- **High load handling** - Better behavior under concurrent provisioning operations

## Technical Details from #175

**Problem Fixed:**
- `WritePackfile()` was calling `finalizeWrite()` → `Cleanup()`, destroying all staged objects
- After a failed push, writer had no objects → retry impossible
- Resource leaks when writer reset without cleanup
- Inconsistent state if cleanup failed after successful push

**Solution:**
- `WritePackfile` no longer cleans up - objects persist for retry
- Cleanup only happens after **confirmed success** (both ReceivePack and WritePackfile succeed)
- On failure: keep writer intact with all staged objects
- Always reset writer/ref even if cleanup fails (maintain consistency with successful server-side push)

## Why This Separate PR?

PR #175 was squash-merged as:
```
Fix: Premature Clean up in Push (#175)
```

The uppercase `Fix:` doesn't trigger semantic-release (requires lowercase `fix:`). This PR ensures v0.3.9 is created with all the fixes from #175, unblocking the Grafana integration.

## What This PR Contains

A minor documentation improvement to clarify that cleanup errors after successful push are diagnostic only. This small change uses proper conventional commit format (`fix:`) to trigger the release.

## Related

- **Main fixes**: #175 (commits: 2cc9e1e, e5ccef3, f00e75d)
- **Grafana integration**: https://github.com/grafana/grafana/pull/118983
- **Copilot reviews**: Fixed two critical bugs identified in code review
  - https://github.com/grafana/nanogit/pull/175#discussion_r2852762981
  - https://github.com/grafana/nanogit/pull/175#discussion_r2853500369

🤖 Generated with [Claude Code](https://claude.com/claude-code)
