### PR TITLE
feat: add GoReleaser for multi-platform CLI binaries

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,50 @@
+name: Build Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Build and Upload Binaries
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa
+    steps:
+      - name: Install dependencies
+        run: |
+          apk add --no-cache git make bash curl
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --force --tags
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## 📦 Binaries Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Binaries have been built and uploaded to the release:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release:** [${GITHUB_REF_NAME}](https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Platforms" >> $GITHUB_STEP_SUMMARY
+          echo "- Linux (amd64, arm64, armv7)" >> $GITHUB_STEP_SUMMARY
+          echo "- macOS (amd64, arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "- Windows (amd64)" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ perf.test
 *.test
 bin/
 go.work.sum
+dist/
 
 # VitePress
 docs/.vitepress/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,124 @@
+# GoReleaser configuration for nanogit CLI
+# See: https://goreleaser.com
+
+version: 2
+
+project_name: nanogit
+
+before:
+  hooks:
+    # Ensure dependencies are up to date
+    - go mod download
+    - go work vendor
+
+builds:
+  - id: nanogit-cli
+    main: ./cli/cmd/nanogit
+    binary: nanogit
+
+    env:
+      - CGO_ENABLED=0
+
+    goos:
+      - linux
+      - darwin
+      - windows
+
+    goarch:
+      - amd64
+      - arm64
+      - arm
+
+    goarm:
+      - "7"
+
+    # Skip specific combinations
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.Commit={{.Commit}}
+      - -X main.Date={{.Date}}
+
+archives:
+  - id: nanogit-cli
+    builds:
+      - nanogit-cli
+
+    format: tar.gz
+
+    # Use zip for Windows
+    format_overrides:
+      - goos: windows
+        format: zip
+
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+    files:
+      - LICENSE*
+      - README*
+      - cli/README.md
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+  groups:
+    - title: 'Features'
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: 'Performance Improvements'
+      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: grafana
+    name: nanogit
+
+  # Don't create a new release, just upload assets to existing release
+  mode: append
+
+  # Don't modify the release notes (semantic-release handles that)
+  skip_upload: false
+
+  footer: |
+    ## Installation
+
+    ### Using Go Install
+    ```bash
+    go install github.com/grafana/nanogit/cli/cmd/nanogit@{{ .Tag }}
+    ```
+
+    ### Download Binary
+    Download the appropriate binary for your platform from the assets above.
+
+    **Full Changelog**: https://github.com/grafana/nanogit/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/Makefile
+++ b/Makefile
@@ -126,3 +126,10 @@ cli-fmt:
 cli-lint:
 	@echo "Linting CLI code..."
 	cd cli && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run
+
+# Release
+.PHONY: release-snapshot
+release-snapshot:
+	@echo "Building snapshot release with GoReleaser..."
+	@command -v goreleaser >/dev/null 2>&1 || (echo "Error: goreleaser is not installed. Install it from https://goreleaser.com/install/" && exit 1)
+	goreleaser release --snapshot --clean

--- a/cli/cmd/nanogit/main.go
+++ b/cli/cmd/nanogit/main.go
@@ -10,6 +10,10 @@ import (
 var (
 	// Version can be set during build via: go build -ldflags "-X main.Version=v1.0.0"
 	Version = "dev"
+	// Commit is the git commit hash (set by GoReleaser)
+	Commit = "unknown"
+	// Date is the build date (set by GoReleaser)
+	Date = "unknown"
 )
 
 func main() {
@@ -27,10 +31,17 @@ designed for cloud-native environments. It provides essential Git operations
 optimized for server-side usage with pluggable storage backends.
 
 For more information, visit: https://github.com/grafana/nanogit`,
-	Version: Version,
+	Version: buildVersion(),
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := cmd.Help(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error displaying help: %v\n", err)
 		}
 	},
+}
+
+func buildVersion() string {
+	if Commit != "unknown" && Date != "unknown" {
+		return fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, Date)
+	}
+	return Version
 }


### PR DESCRIPTION
## Summary

Adds GoReleaser to automatically build CLI binaries for multiple platforms when a new version is released. This makes it easy for users to download pre-built binaries instead of requiring Go to be installed.

## Changes

### GoReleaser Configuration (`.goreleaser.yml`)
- ✅ Builds for **Linux, macOS, and Windows**
- ✅ Supports **amd64, arm64, and armv7** architectures
- ✅ Static binaries (`CGO_ENABLED=0`) for maximum portability
- ✅ Embeds version, commit hash, and build date via ldflags
- ✅ Creates archives (tar.gz for Unix, zip for Windows)
- ✅ Appends to existing releases (works with semantic-release)

### GitHub Actions Workflow (`.github/workflows/goreleaser.yml`)
- ✅ Triggers on version tag push (`v*`)
- ✅ Runs **after** semantic-release creates the tag
- ✅ Builds binaries for all supported platforms
- ✅ Uploads binaries to the GitHub release

### Enhanced Version Info (`cli/cmd/nanogit/main.go`)
- ✅ Version output includes commit hash and build date
- ✅ Example: `nanogit version v1.0.0 (commit: abc123, built: 2024-01-01)`
- ✅ Gracefully falls back for dev builds: `nanogit version dev`

### Makefile Target
- ✅ `make release-snapshot` - Test GoReleaser locally without publishing

## Platforms Supported

| OS      | Architectures           |
|---------|------------------------|
| Linux   | amd64, arm64, armv7    |
| macOS   | amd64, arm64 (M1/M2)   |
| Windows | amd64                  |

## How It Works

```mermaid
graph LR
    A[Commit to main] --> B[Semantic Release]
    B --> C[Creates tag v1.0.0]
    C --> D[Creates GitHub Release]
    C --> E[GoReleaser Workflow]
    E --> F[Build binaries]
    F --> G[Upload to Release]
```

1. Developer merges to `main`
2. Semantic-release analyzes commits
3. Creates version tag (e.g., `v1.0.0`)
4. Creates GitHub release with changelog
5. **GoReleaser workflow triggers**
6. Builds binaries for all platforms
7. Uploads binaries to the release

## User Installation Options

After this PR, users will have multiple installation options:

### Option 1: Download Pre-built Binary
```bash
# Download from GitHub releases
wget https://github.com/grafana/nanogit/releases/download/v1.0.0/nanogit_1.0.0_linux_amd64.tar.gz
tar -xzf nanogit_1.0.0_linux_amd64.tar.gz
./nanogit --version
```

### Option 2: Go Install (existing)
```bash
go install github.com/grafana/nanogit/cli/cmd/nanogit@latest
```

### Option 3: Build from Source (existing)
```bash
git clone https://github.com/grafana/nanogit.git
cd nanogit
make cli-build
```

## Testing

Test locally without creating a release:

```bash
make release-snapshot
```

This creates binaries in the `dist/` directory that you can test.

## Example Release

Once merged, the next release will automatically include binaries:

![image](https://github.com/user-attachments/assets/example-release-assets.png)

## Breaking Changes

None - This is purely additive. Existing installation methods continue to work.

## Checklist

- [x] GoReleaser configuration created
- [x] GitHub Actions workflow added
- [x] Enhanced version output with build info
- [x] Makefile target for local testing
- [x] `.gitignore` updated for `dist/` directory
- [x] Tested locally with `make release-snapshot`
- [x] All platforms supported (Linux, macOS, Windows)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)