### PR TITLE
fix: add manual trigger support to GoReleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v0.8.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -23,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Fetch all tags
         run: git fetch --force --tags


### PR DESCRIPTION
## Problem

The GoReleaser workflow didn't trigger for v0.8.0 because the workflow was merged AFTER the tag was created. GitHub Actions workflows only trigger if the workflow file exists in the repository at the time of the event (tag push).

## Solution

Add `workflow_dispatch` trigger to allow manual execution for existing tags.

## Changes

```yaml
on:
  push:
    tags:
      - 'v*'
  workflow_dispatch:           # ← NEW
    inputs:
      tag:
        description: 'Tag to build (e.g., v0.8.0)'
        required: true
        type: string
```

### Updated checkout step
```yaml
- name: Checkout
  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
  with:
    fetch-depth: 0
    ref: ${{ inputs.tag || github.ref }}  # ← Use manual tag or automatic ref
```

## How to Use

### Build v0.8.0 Binaries (Retroactively)

Once this PR is merged:

1. Go to [Actions → Build Release Binaries](https://github.com/grafana/nanogit/actions/workflows/goreleaser.yml)
2. Click **"Run workflow"**
3. Select branch: `main`
4. Enter tag: `v0.8.0`
5. Click **"Run workflow"**

The workflow will:
- Check out the `v0.8.0` tag
- Build binaries for all platforms
- Upload them to the [v0.8.0 release](https://github.com/grafana/nanogit/releases/tag/v0.8.0)

### Future Releases

Automatic - workflow triggers when new tags are pushed (no manual action needed).

## Benefits

✅ **Fixes v0.8.0** - Can now build binaries for the existing release  
✅ **Future-proof** - Can manually trigger for any tag if needed  
✅ **Backward compatible** - Automatic triggering still works for new tags  
✅ **Simple** - Just enter the tag name in the GitHub UI  

## Testing

After merge, test by manually triggering for v0.8.0:
```
Actions → Build Release Binaries → Run workflow → tag: v0.8.0
```

Expected result: Binaries appear in [v0.8.0 release assets](https://github.com/grafana/nanogit/releases/tag/v0.8.0).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)