### PR TITLE
fix: configure Git safe directory in container environment

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -31,6 +31,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.tag || github.ref }}
 
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Fetch all tags
         run: git fetch --force --tags
 


### PR DESCRIPTION
## Summary

Fixes the "dubious ownership" error when running the manual release workflow in a Docker container.

## Problem

The goreleaser.yml workflow runs in a Docker container (), and Git detects that the repository directory is owned by a different user, causing it to fail with:

```
fatal: detected dubious ownership in repository at '/__w/nanogit/nanogit'
```

## Solution

Added a step to configure Git to trust the workspace directory before attempting to fetch tags:

```bash
git config --global --add safe.directory "$GITHUB_WORKSPACE"
```

This is the standard fix for Git operations in containerized GitHub Actions environments.

## Testing

This can be tested by triggering the workflow manually via workflow_dispatch.