### PR TITLE
refactor(cli): make --token, --username, and --json global flags

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -44,14 +44,34 @@ make cli-build
 ## Usage
 
 ```bash
-nanogit [flags]
-nanogit [command]
+nanogit [global flags] <command> [command flags] [arguments]
 ```
 
 ### Global Flags
 
+Available for all commands:
+
 - `-h, --help` - Show help information
 - `-v, --version` - Show version information
+- `--username <string>` - Authentication username (defaults to 'git', can also use `NANOGIT_USERNAME` env var)
+- `--token <string>` - Authentication token (can also use `NANOGIT_TOKEN` env var)
+- `--json` - Output results in JSON format (where applicable)
+
+### Authentication
+
+For private repositories, use the `--token` flag or set the `NANOGIT_TOKEN` environment variable:
+
+```bash
+# Using global flag
+nanogit --token YOUR_TOKEN <command> [args...]
+
+# Using environment variable (recommended)
+export NANOGIT_TOKEN=YOUR_TOKEN
+nanogit <command> [args...]
+
+# Custom username (defaults to 'git')
+nanogit --username myuser --token YOUR_TOKEN <command> [args...]
+```
 
 ### Commands
 
@@ -70,13 +90,7 @@ nanogit ls-remote https://github.com/grafana/nanogit.git --heads
 nanogit ls-remote https://github.com/grafana/nanogit.git --tags
 
 # Output as JSON
-nanogit ls-remote https://github.com/grafana/nanogit.git --json
-
-# With authentication (username defaults to 'git')
-NANOGIT_TOKEN=token nanogit ls-remote https://github.com/user/private-repo.git
-
-# With custom username
-nanogit ls-remote https://github.com/user/private-repo.git --username myuser --token token
+nanogit --json ls-remote https://github.com/grafana/nanogit.git
 ```
 
 #### ls-tree
@@ -97,10 +111,7 @@ nanogit ls-tree https://github.com/grafana/nanogit.git main --recursive
 nanogit ls-tree https://github.com/grafana/nanogit.git main --long
 
 # Output as JSON
-nanogit ls-tree https://github.com/grafana/nanogit.git main --json
-
-# With authentication
-NANOGIT_TOKEN=token nanogit ls-tree https://github.com/user/private-repo.git main
+nanogit --json ls-tree https://github.com/grafana/nanogit.git main
 ```
 
 #### cat-file
@@ -115,10 +126,7 @@ nanogit cat-file https://github.com/grafana/nanogit.git main README.md
 nanogit cat-file https://github.com/grafana/nanogit.git v1.0.0 docs/api.md
 
 # Output as JSON with metadata
-nanogit cat-file https://github.com/grafana/nanogit.git main README.md --json
-
-# With authentication
-NANOGIT_TOKEN=token nanogit cat-file https://github.com/user/private-repo.git main file.txt
+nanogit --json cat-file https://github.com/grafana/nanogit.git main README.md
 ```
 
 #### clone
@@ -143,9 +151,6 @@ nanogit clone https://github.com/grafana/nanogit.git v1.0.0 ./my-repo
 
 # Adjust performance (defaults: batch-size=50, concurrency=10)
 nanogit clone https://github.com/grafana/nanogit.git main ./my-repo --batch-size 100 --concurrency 20
-
-# With authentication
-NANOGIT_TOKEN=token nanogit clone https://github.com/user/private-repo.git main ./my-repo
 ```
 
 For more details, see the [CLI documentation](https://grafana.github.io/nanogit/getting-started/cli/).

--- a/cli/cmd/nanogit/cat_file.go
+++ b/cli/cmd/nanogit/cat_file.go
@@ -11,18 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	catFileJSON     bool
-	catFileUsername string
-	catFileToken    string
-)
-
 func init() {
 	rootCmd.AddCommand(catFileCmd)
-
-	catFileCmd.Flags().BoolVar(&catFileJSON, "json", false, "Output file metadata in JSON format")
-	catFileCmd.Flags().StringVar(&catFileUsername, "username", "", "Authentication username (can also use NANOGIT_USERNAME env var, defaults to 'git')")
-	catFileCmd.Flags().StringVar(&catFileToken, "token", "", "Authentication token (can also use NANOGIT_TOKEN env var)")
 }
 
 var catFileCmd = &cobra.Command{
@@ -60,12 +50,12 @@ func runCatFile(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Get authentication credentials from flags or environment
-	token := catFileToken
+	token := globalToken
 	if token == "" {
 		token = os.Getenv("NANOGIT_TOKEN")
 	}
 
-	username := catFileUsername
+	username := globalUsername
 	if username == "" {
 		username = os.Getenv("NANOGIT_USERNAME")
 	}
@@ -106,7 +96,7 @@ func runCatFile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Output the file contents
-	if catFileJSON {
+	if globalJSON {
 		return outputBlobJSON(blob, filePath)
 	}
 	return outputBlobRaw(blob)

--- a/cli/cmd/nanogit/cat_file_test.go
+++ b/cli/cmd/nanogit/cat_file_test.go
@@ -111,9 +111,9 @@ func TestCatFileCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset flags
-			catFileJSON = false
-			catFileUsername = ""
-			catFileToken = ""
+			globalJSON = false
+			globalUsername = ""
+			globalToken = ""
 
 			// Test argument validation
 			catFileCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/clone.go
+++ b/cli/cmd/nanogit/clone.go
@@ -13,8 +13,6 @@ import (
 var (
 	cloneInclude     []string
 	cloneExclude     []string
-	cloneUsername    string
-	cloneToken       string
 	cloneBatchSize   int
 	cloneConcurrency int
 )
@@ -24,8 +22,6 @@ func init() {
 
 	cloneCmd.Flags().StringSliceVar(&cloneInclude, "include", nil, "Include paths (glob patterns, e.g., 'src/**', '*.go')")
 	cloneCmd.Flags().StringSliceVar(&cloneExclude, "exclude", nil, "Exclude paths (glob patterns, e.g., 'node_modules/**', '*.tmp')")
-	cloneCmd.Flags().StringVar(&cloneUsername, "username", "", "Authentication username (can also use NANOGIT_USERNAME env var, defaults to 'git')")
-	cloneCmd.Flags().StringVar(&cloneToken, "token", "", "Authentication token (can also use NANOGIT_TOKEN env var)")
 	cloneCmd.Flags().IntVar(&cloneBatchSize, "batch-size", 50, "Number of blobs to fetch per request (default 50)")
 	cloneCmd.Flags().IntVar(&cloneConcurrency, "concurrency", 10, "Number of parallel blob fetches (default 10)")
 }
@@ -71,12 +67,12 @@ func runClone(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Get authentication credentials from flags or environment
-	token := cloneToken
+	token := globalToken
 	if token == "" {
 		token = os.Getenv("NANOGIT_TOKEN")
 	}
 
-	username := cloneUsername
+	username := globalUsername
 	if username == "" {
 		username = os.Getenv("NANOGIT_USERNAME")
 	}

--- a/cli/cmd/nanogit/clone_test.go
+++ b/cli/cmd/nanogit/clone_test.go
@@ -85,8 +85,8 @@ func TestCloneCommand(t *testing.T) {
 			// Reset flags
 			cloneInclude = nil
 			cloneExclude = nil
-			cloneUsername = ""
-			cloneToken = ""
+			globalUsername = ""
+			globalToken = ""
 			cloneBatchSize = 50
 			cloneConcurrency = 10
 
@@ -147,8 +147,8 @@ func TestCloneFlagsValidation(t *testing.T) {
 			// Reset flags
 			cloneInclude = nil
 			cloneExclude = nil
-			cloneUsername = ""
-			cloneToken = ""
+			globalUsername = ""
+			globalToken = ""
 			cloneBatchSize = tt.batchSize
 			cloneConcurrency = tt.concurrency
 

--- a/cli/cmd/nanogit/ls_remote.go
+++ b/cli/cmd/nanogit/ls_remote.go
@@ -13,11 +13,8 @@ import (
 )
 
 var (
-	lsRemoteHeads    bool
-	lsRemoteTags     bool
-	lsRemoteJSON     bool
-	lsRemoteToken    string
-	lsRemoteUsername string
+	lsRemoteHeads bool
+	lsRemoteTags  bool
 )
 
 func init() {
@@ -25,9 +22,6 @@ func init() {
 
 	lsRemoteCmd.Flags().BoolVar(&lsRemoteHeads, "heads", false, "Show only branch references (refs/heads/*)")
 	lsRemoteCmd.Flags().BoolVar(&lsRemoteTags, "tags", false, "Show only tag references (refs/tags/*)")
-	lsRemoteCmd.Flags().BoolVar(&lsRemoteJSON, "json", false, "Output results in JSON format")
-	lsRemoteCmd.Flags().StringVar(&lsRemoteUsername, "username", "", "Authentication username (can also use NANOGIT_USERNAME env var, defaults to 'git')")
-	lsRemoteCmd.Flags().StringVar(&lsRemoteToken, "token", "", "Authentication token (can also use NANOGIT_TOKEN env var)")
 }
 
 var lsRemoteCmd = &cobra.Command{
@@ -64,12 +58,12 @@ func runLsRemote(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Get authentication credentials from flags or environment
-	token := lsRemoteToken
+	token := globalToken
 	if token == "" {
 		token = os.Getenv("NANOGIT_TOKEN")
 	}
 
-	username := lsRemoteUsername
+	username := globalUsername
 	if username == "" {
 		username = os.Getenv("NANOGIT_USERNAME")
 	}
@@ -102,7 +96,7 @@ func runLsRemote(cmd *cobra.Command, args []string) error {
 	filteredRefs := filterRefs(refs)
 
 	// Output results
-	if lsRemoteJSON {
+	if globalJSON {
 		return outputJSON(filteredRefs)
 	}
 	return outputHuman(filteredRefs)

--- a/cli/cmd/nanogit/ls_remote_test.go
+++ b/cli/cmd/nanogit/ls_remote_test.go
@@ -182,8 +182,9 @@ func TestLsRemoteCommand(t *testing.T) {
 			// Reset flags
 			lsRemoteHeads = false
 			lsRemoteTags = false
-			lsRemoteJSON = false
-			lsRemoteToken = ""
+			globalJSON = false
+			globalToken = ""
+			globalUsername = ""
 
 			// Test argument validation
 			lsRemoteCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/ls_tree.go
+++ b/cli/cmd/nanogit/ls_tree.go
@@ -17,9 +17,6 @@ import (
 var (
 	lsTreeRecursive bool
 	lsTreeLong      bool
-	lsTreeJSON      bool
-	lsTreeUsername  string
-	lsTreeToken     string
 	lsTreePath      string
 )
 
@@ -28,10 +25,7 @@ func init() {
 
 	lsTreeCmd.Flags().BoolVarP(&lsTreeRecursive, "recursive", "r", false, "List tree contents recursively")
 	lsTreeCmd.Flags().BoolVarP(&lsTreeLong, "long", "l", false, "Show detailed information (mode, type, hash)")
-	lsTreeCmd.Flags().BoolVar(&lsTreeJSON, "json", false, "Output results in JSON format")
 	lsTreeCmd.Flags().StringVar(&lsTreePath, "path", "", "Path within the tree to list (defaults to root)")
-	lsTreeCmd.Flags().StringVar(&lsTreeUsername, "username", "", "Authentication username (can also use NANOGIT_USERNAME env var, defaults to 'git')")
-	lsTreeCmd.Flags().StringVar(&lsTreeToken, "token", "", "Authentication token (can also use NANOGIT_TOKEN env var)")
 }
 
 var lsTreeCmd = &cobra.Command{
@@ -70,12 +64,12 @@ func runLsTree(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	// Get authentication credentials from flags or environment
-	token := lsTreeToken
+	token := globalToken
 	if token == "" {
 		token = os.Getenv("NANOGIT_TOKEN")
 	}
 
-	username := lsTreeUsername
+	username := globalUsername
 	if username == "" {
 		username = os.Getenv("NANOGIT_USERNAME")
 	}
@@ -134,7 +128,7 @@ func listTree(ctx context.Context, client nanogit.Client, treeHash hash.Hash, pa
 		}
 	}
 
-	if lsTreeJSON {
+	if globalJSON {
 		return outputTreeJSON(tree.Entries)
 	}
 	return outputTreeHuman(tree.Entries)
@@ -152,7 +146,7 @@ func listRecursiveTree(ctx context.Context, client nanogit.Client, commitHash ha
 		entries = filterEntriesByPath(entries, path)
 	}
 
-	if lsTreeJSON {
+	if globalJSON {
 		return outputFlatTreeJSON(entries)
 	}
 	return outputFlatTreeHuman(entries)

--- a/cli/cmd/nanogit/ls_tree_test.go
+++ b/cli/cmd/nanogit/ls_tree_test.go
@@ -295,10 +295,10 @@ func TestLsTreeCommand(t *testing.T) {
 			// Reset flags
 			lsTreeRecursive = false
 			lsTreeLong = false
-			lsTreeJSON = false
+			globalJSON = false
 			lsTreePath = ""
-			lsTreeUsername = ""
-			lsTreeToken = ""
+			globalUsername = ""
+			globalToken = ""
 
 			// Test argument validation
 			lsTreeCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/main.go
+++ b/cli/cmd/nanogit/main.go
@@ -14,7 +14,19 @@ var (
 	Commit = "unknown"
 	// Date is the build date (set by GoReleaser)
 	Date = "unknown"
+
+	// Global flags available to all commands
+	globalUsername string
+	globalToken    string
+	globalJSON     bool
 )
+
+func init() {
+	// Add persistent flags that are available to all subcommands
+	rootCmd.PersistentFlags().StringVar(&globalUsername, "username", "", "Authentication username (can also use NANOGIT_USERNAME env var, defaults to 'git')")
+	rootCmd.PersistentFlags().StringVar(&globalToken, "token", "", "Authentication token (can also use NANOGIT_TOKEN env var)")
+	rootCmd.PersistentFlags().BoolVar(&globalJSON, "json", false, "Output results in JSON format")
+}
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -81,8 +81,39 @@ Usage:
   nanogit [flags]
 
 Flags:
-  -h, --help      help for nanogit
-  -v, --version   version for nanogit
+  -h, --help              help for nanogit
+  -v, --version           version for nanogit
+      --username string   Authentication username (can also use NANOGIT_USERNAME env var, defaults to 'git')
+      --token string      Authentication token (can also use NANOGIT_TOKEN env var)
+      --json              Output results in JSON format
+```
+
+### Global Flags
+
+The following flags are available for all commands:
+
+- `--username` - Authentication username (defaults to 'git' if not specified)
+- `--token` - Authentication token for private repositories
+- `--json` - Output results in JSON format (where applicable)
+
+These flags can also be set via environment variables:
+- `NANOGIT_USERNAME` - Authentication username
+- `NANOGIT_TOKEN` - Authentication token
+
+## Authentication
+
+For private repositories, use the `--token` global flag or set the `NANOGIT_TOKEN` environment variable:
+
+```bash
+# Using global flag (can be placed before or after command)
+nanogit --token YOUR_TOKEN <command> [args...]
+
+# Using environment variable (recommended for repeated use)
+export NANOGIT_TOKEN=YOUR_TOKEN
+nanogit <command> [args...]
+
+# Custom username (defaults to 'git')
+nanogit --username myuser --token YOUR_TOKEN <command> [args...]
 ```
 
 ### Check Version
@@ -105,9 +136,6 @@ nanogit ls-remote <repository> [flags]
 **Flags**:
 - `--heads` - Show only branch references (refs/heads/*)
 - `--tags` - Show only tag references (refs/tags/*)
-- `--json` - Output results in JSON format
-- `--username` - Authentication username (defaults to 'git')
-- `--token` - Authentication token
 
 **Examples**:
 
@@ -128,27 +156,8 @@ nanogit ls-remote https://github.com/grafana/nanogit.git --tags
 
 Output as JSON:
 ```bash
-nanogit ls-remote https://github.com/grafana/nanogit.git --json
+nanogit --json ls-remote https://github.com/grafana/nanogit.git
 ```
-
-With authentication (for private repositories):
-```bash
-# Using token (username defaults to 'git')
-nanogit ls-remote https://github.com/user/private-repo.git --token YOUR_TOKEN
-
-# Using environment variable
-NANOGIT_TOKEN=YOUR_TOKEN nanogit ls-remote https://github.com/user/private-repo.git
-
-# With custom username
-nanogit ls-remote https://github.com/user/private-repo.git --username myuser --token YOUR_TOKEN
-
-# Using environment variables for both
-NANOGIT_USERNAME=myuser NANOGIT_TOKEN=YOUR_TOKEN nanogit ls-remote https://github.com/user/private-repo.git
-```
-
-**Environment Variables**:
-- `NANOGIT_TOKEN` - Authentication token
-- `NANOGIT_USERNAME` - Authentication username (defaults to 'git' if not set)
 
 ### ls-tree
 
@@ -162,10 +171,7 @@ nanogit ls-tree <repository> <ref> [flags]
 **Flags**:
 - `-r, --recursive` - List tree contents recursively
 - `-l, --long` - Show detailed information (mode, type, hash)
-- `--json` - Output results in JSON format
 - `--path` - Path within the tree to list (defaults to root)
-- `--username` - Authentication username (defaults to 'git')
-- `--token` - Authentication token
 
 **Examples**:
 
@@ -191,16 +197,7 @@ nanogit ls-tree https://github.com/grafana/nanogit.git v1.0.0 --long
 
 Output as JSON:
 ```bash
-nanogit ls-tree https://github.com/grafana/nanogit.git main --json
-```
-
-With authentication:
-```bash
-# Using token (username defaults to 'git')
-nanogit ls-tree https://github.com/user/private-repo.git main --token YOUR_TOKEN
-
-# Using environment variables
-NANOGIT_TOKEN=YOUR_TOKEN nanogit ls-tree https://github.com/user/private-repo.git main
+nanogit --json ls-tree https://github.com/grafana/nanogit.git main
 ```
 
 ### cat-file
@@ -212,10 +209,7 @@ Display the contents of a file from a repository.
 nanogit cat-file <repository> <ref> <path> [flags]
 ```
 
-**Flags**:
-- `--json` - Output file metadata in JSON format
-- `--username` - Authentication username (defaults to 'git')
-- `--token` - Authentication token
+No command-specific flags (uses global flags only).
 
 **Examples**:
 
@@ -236,16 +230,7 @@ nanogit cat-file https://github.com/grafana/nanogit.git abc123def456 src/main.go
 
 Output with metadata in JSON format:
 ```bash
-nanogit cat-file https://github.com/grafana/nanogit.git main README.md --json
-```
-
-With authentication:
-```bash
-# Using token (username defaults to 'git')
-nanogit cat-file https://github.com/user/private-repo.git main file.txt --token YOUR_TOKEN
-
-# Using environment variables
-NANOGIT_TOKEN=YOUR_TOKEN nanogit cat-file https://github.com/user/private-repo.git main file.txt
+nanogit --json cat-file https://github.com/grafana/nanogit.git main README.md
 ```
 
 ### clone
@@ -262,8 +247,6 @@ nanogit clone <repository> <ref> <destination> [flags]
 - `--exclude` - Exclude paths (glob patterns, can be specified multiple times)
 - `--batch-size` - Number of blobs to fetch per request (default: 50)
 - `--concurrency` - Number of parallel blob fetches (default: 10)
-- `--username` - Authentication username (defaults to 'git')
-- `--token` - Authentication token
 
 **Examples**:
 
@@ -299,15 +282,6 @@ nanogit clone https://github.com/grafana/nanogit.git main ./my-repo --batch-size
 
 # Sequential mode for constrained environments
 nanogit clone https://github.com/grafana/nanogit.git main ./my-repo --batch-size 1 --concurrency 1
-```
-
-With authentication:
-```bash
-# Using token (username defaults to 'git')
-nanogit clone https://github.com/user/private-repo.git main ./my-repo --token YOUR_TOKEN
-
-# Using environment variables
-NANOGIT_TOKEN=YOUR_TOKEN nanogit clone https://github.com/user/private-repo.git main ./my-repo
 ```
 
 **Path Filtering**:


### PR DESCRIPTION
## Summary
Refactor CLI to use global persistent flags for authentication and output formatting, improving consistency and reducing duplication.

## Changes
- Move `--username`, `--token`, and `--json` from individual commands to global persistent flags
- Update all commands (ls-remote, ls-tree, cat-file, clone) to use global flags
- Update all tests to work with global flag variables
- Simplify documentation by explaining authentication once at the top
- Remove repetitive auth examples from individual command sections
- Improve consistency between cli/README.md and docs/getting-started/cli.md

## Benefits
- **More intuitive**: Global flags can be placed before or after commands
- **Less duplication**: No need to define the same flags for each command
- **Consistent interface**: Same flag names work across all commands
- **Cleaner docs**: Authentication explained once, not repeated for each command
- **Easier maintenance**: Single source of truth for global flags

## Examples

Before (per-command flags):
```bash
nanogit ls-remote https://github.com/user/repo.git --token TOKEN --json
nanogit ls-tree https://github.com/user/repo.git main --token TOKEN --json
```

After (global flags):
```bash
nanogit --token TOKEN --json ls-remote https://github.com/user/repo.git
nanogit --token TOKEN --json ls-tree https://github.com/user/repo.git main

# Or after the command (both work)
nanogit ls-remote https://github.com/user/repo.git --token TOKEN --json
```

## Test plan
- [x] All unit tests pass
- [x] Code linting passes
- [x] Documentation updated for both cli/README.md and docs/getting-started/cli.md
- [ ] Manual testing: verify global flags work with all commands
- [ ] Manual testing: verify flags work when placed before or after command

🤖 Generated with [Claude Code](https://claude.com/claude-code)