### PR TITLE
fix(ci): update actions/setup-go to v6.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Setup Go
         if: steps.new_release.outputs.new_tag != 'none' && steps.new_release.outputs.new_tag != steps.last_release.outputs.last_tag
-        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973f74ed7 # v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: '1.25.8'
           # Disable cache to prevent cache poisoning attacks


### PR DESCRIPTION
## Problem
The release workflow is failing with:
```
Error: An action could not be found at the URI 'https://api.github.com/repos/actions/setup-go/tarball/41dfa10bad2bb2ae585af6ee5bb4d7d973f74ed7'
```

**Failed run:** https://github.com/grafana/nanogit/actions/runs/23152319103/job/67257889842

## Root Cause
The workflow was pinned to an invalid/outdated SHA (`41dfa10bad2bb2ae585af6ee5bb4d7d973f74ed7`) for `actions/setup-go@v6` that no longer exists or is inaccessible.

## Solution
Update to the correct SHA for the latest v6.3.0 release:
- **New SHA:** `4b73464bb391d4059bd26b0524d20df3927bd417`
- **Version:** v6.3.0 (released February 26, 2025)

## Changes in v6.3.0
- Update default Go module caching to use go.mod
- Fix golang download url to go.dev

## Testing
- [ ] Verify release workflow passes with new SHA
- [ ] Confirm Go 1.25.8 installs correctly

## References
- [actions/setup-go releases](https://github.com/actions/setup-go/releases)
- [v6.3.0 release notes](https://github.com/actions/setup-go/releases/tag/v6.3.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)