### PR TITLE
feat(cli): add check command to verify server protocol compatibility

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -77,9 +77,7 @@ nanogit --username myuser --token YOUR_TOKEN <command> [args...]
 
 ### Requirements
 
-nanogit requires **Git Smart HTTP Protocol v2**. Supported providers:
-- ✅ GitHub, GitLab, Bitbucket, Gitea (recent versions)
-- ❌ Azure DevOps (protocol v1 only), older Git servers
+nanogit requires **Git Smart HTTP Protocol v2**. Most modern Git hosting providers support protocol v2, but some older servers or certain cloud providers may only support protocol v1.
 
 Use `nanogit check <repository>` to verify compatibility.
 
@@ -91,13 +89,13 @@ Check if a Git server supports protocol v2 and is compatible with nanogit.
 
 ```bash
 # Check compatibility
-nanogit check https://github.com/grafana/nanogit.git
+nanogit check https://example.com/repo.git
 
 # Check with authentication
-nanogit check https://github.com/user/private-repo.git --token <token>
+nanogit check https://example.com/private-repo.git --token <token>
 
 # Output as JSON
-nanogit --json check https://dev.azure.com/org/project/_git/repo
+nanogit --json check https://example.com/repo.git
 ```
 
 #### ls-remote

--- a/cli/cmd/nanogit/check.go
+++ b/cli/cmd/nanogit/check.go
@@ -23,21 +23,18 @@ var checkCmd = &cobra.Command{
 This command helps you determine if a Git repository URL is compatible with nanogit
 before attempting other operations. nanogit requires Git Smart HTTP Protocol v2.
 
-Supported providers: GitHub, GitLab, Bitbucket, and others with protocol v2 support.
-Not supported: Azure DevOps (protocol v1 only), older Git servers.
+Many modern Git hosting providers support protocol v2, but some older servers or
+certain cloud providers may only support protocol v1.
 
 Examples:
-  # Check GitHub repository
-  nanogit check https://github.com/grafana/nanogit.git
+  # Check repository compatibility
+  nanogit check https://example.com/repo.git
 
   # Check with authentication
-  nanogit check https://github.com/user/private-repo.git --token <token>
-
-  # Check Azure DevOps (will show as incompatible)
-  nanogit check https://dev.azure.com/org/project/_git/repo
+  nanogit check https://example.com/private-repo.git --token <token>
 
   # Output as JSON
-  nanogit --json check https://github.com/grafana/nanogit.git`,
+  nanogit --json check https://example.com/repo.git`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCheck,
 }
@@ -105,7 +102,7 @@ func outputCheckJSON(repoURL string, compatible bool) error {
 		result.Message = "Server supports Git protocol v2 and is compatible with nanogit"
 	} else {
 		result.Protocol = "v1"
-		result.Message = "Server only supports Git protocol v1. nanogit requires protocol v2. Please use a different Git provider (GitHub, GitLab, Bitbucket) or standard git CLI for this repository."
+		result.Message = "Server only supports Git protocol v1. nanogit requires protocol v2. Please use a Git provider with v2 support or use standard git CLI for this repository."
 	}
 
 	encoder := json.NewEncoder(os.Stdout)
@@ -129,15 +126,11 @@ func outputCheckHuman(repoURL string, compatible bool) error {
 	// Incompatible
 	fmt.Printf("❌ Not Compatible - Server only supports Git protocol v1\n\n")
 	fmt.Printf("nanogit requires Git Smart HTTP Protocol v2, which this server does not support.\n\n")
-	fmt.Printf("Supported providers:\n")
-	fmt.Printf("  ✅ GitHub\n")
-	fmt.Printf("  ✅ GitLab\n")
-	fmt.Printf("  ✅ Bitbucket\n")
-	fmt.Printf("  ✅ Gitea (recent versions)\n\n")
-	fmt.Printf("Not supported:\n")
-	fmt.Printf("  ❌ Azure DevOps (protocol v1 only)\n")
-	fmt.Printf("  ❌ Older Git servers without v2 support\n\n")
-	fmt.Printf("For this repository, please use standard git CLI instead.\n")
+	fmt.Printf("Options:\n")
+	fmt.Printf("  • Use a Git hosting provider with protocol v2 support\n")
+	fmt.Printf("  • Use standard git CLI for this repository\n\n")
+	fmt.Printf("Note: Most modern Git hosting providers support protocol v2.\n")
+	fmt.Printf("Older servers or certain cloud providers may only support v1.\n")
 
 	return nil
 }

--- a/cli/cmd/nanogit/check_test.go
+++ b/cli/cmd/nanogit/check_test.go
@@ -67,7 +67,7 @@ func TestOutputCheckJSON(t *testing.T) {
 		},
 		{
 			name:       "incompatible server",
-			repoURL:    "https://dev.azure.com/org/project/_git/repo",
+			repoURL:    "https://example.com/repo.git",
 			compatible: false,
 		},
 	}
@@ -125,9 +125,9 @@ func TestOutputCheckHuman(t *testing.T) {
 		},
 		{
 			name:       "incompatible output",
-			repoURL:    "https://dev.azure.com/org/project/_git/repo",
+			repoURL:    "https://example.com/repo.git",
 			compatible: false,
-			contains:   []string{"❌", "Not Compatible", "protocol v1", "Azure DevOps", "git CLI"},
+			contains:   []string{"❌", "Not Compatible", "protocol v1", "git CLI", "protocol v2"},
 		},
 	}
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -126,15 +126,7 @@ nanogit --version
 
 ## Requirements
 
-nanogit requires **Git Smart HTTP Protocol v2**, which is supported by:
-- ✅ GitHub
-- ✅ GitLab
-- ✅ Bitbucket
-- ✅ Gitea (recent versions)
-
-**Not supported:**
-- ❌ Azure DevOps (only supports protocol v1)
-- ❌ Older Git servers without protocol v2
+nanogit requires **Git Smart HTTP Protocol v2**. Most modern Git hosting providers support protocol v2, but some older servers or certain cloud providers may only support protocol v1.
 
 Use the `check` command to verify if your Git server is compatible before attempting other operations.
 
@@ -153,24 +145,19 @@ No command-specific flags (uses global flags only).
 
 **Examples**:
 
-Check GitHub repository (compatible):
+Check repository compatibility:
 ```bash
-nanogit check https://github.com/grafana/nanogit.git
-```
-
-Check Azure DevOps repository (will show as incompatible):
-```bash
-nanogit check https://dev.azure.com/org/project/_git/repo
+nanogit check https://example.com/repo.git
 ```
 
 Output as JSON:
 ```bash
-nanogit --json check https://github.com/grafana/nanogit.git
+nanogit --json check https://example.com/repo.git
 ```
 
 Check with authentication:
 ```bash
-nanogit check https://github.com/user/private-repo.git --token <token>
+nanogit check https://example.com/private-repo.git --token <token>
 ```
 
 ### ls-remote


### PR DESCRIPTION
## Summary

Adds a new `nanogit check` command to verify if a Git server supports Git Smart HTTP Protocol v2, which is required by nanogit.

## Motivation

Users attempting to use nanogit with protocol v1-only servers get confusing 400 errors. This command provides a clear, upfront way to check compatibility before attempting operations.

## Changes

**New Command:**
```bash
nanogit check <repository>
```

**Features:**
- ✅ Checks if server supports Git protocol v2
- ✅ Human-readable output with clear compatibility status
- ✅ JSON output for automation (`--json` flag)
- ✅ Generic messaging focused on protocol requirements
- ✅ Works with or without authentication
- ✅ Comprehensive test coverage

**Example Output:**

Compatible server:
```
$ nanogit check https://example.com/repo.git

Checking compatibility for: https://example.com/repo.git

✅ Compatible - Server supports Git protocol v2

This server is compatible with nanogit. You can use:
  • nanogit ls-remote
  • nanogit ls-tree
  • nanogit cat-file
  • nanogit clone
```

Incompatible server:
```
$ nanogit check https://example.com/repo.git

Checking compatibility for: https://example.com/repo.git

❌ Not Compatible - Server only supports Git protocol v1

nanogit requires Git Smart HTTP Protocol v2, which this server does not support.

Options:
  • Use a Git hosting provider with protocol v2 support
  • Use standard git CLI for this repository

Note: Most modern Git hosting providers support protocol v2.
Older servers or certain cloud providers may only support v1.
```

## Documentation

- Updated `docs/getting-started/cli.md` with Requirements section and check command documentation
- Updated `cli/README.md` with compatibility requirements and check command examples
- Documentation focuses on protocol requirements rather than specific providers

## Testing

- ✅ Unit tests for command argument validation
- ✅ Unit tests for JSON output
- ✅ Unit tests for human-readable output
- ✅ Manual testing with protocol v2 and v1 servers

## Design Decisions

- Avoids mentioning specific providers to keep messaging neutral and reduce maintenance
- Focuses on protocol version as the key compatibility factor
- Provides actionable guidance without being prescriptive about which providers to use