### PR TITLE
fix(ci): configure Renovate to ignore internal workspace modules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "ignoreDeps": [
+    "github.com/grafana/nanogit",
+    "github.com/grafana/nanogit/cli",
+    "github.com/grafana/nanogit/gittest",
+    "github.com/grafana/nanogit/tests",
+    "github.com/grafana/nanogit/perf"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["go"],
+      "matchPackagePatterns": ["^github\\.com/grafana/nanogit"],
+      "enabled": false,
+      "description": "Ignore internal workspace modules - these are managed via go.work and replace directives"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds Renovate configuration to prevent updates for internal workspace modules
- Fixes issue where Renovate attempts to update `github.com/grafana/nanogit/*` dependencies within the workspace
- Uses both `ignoreDeps` and `packageRules` for comprehensive coverage

## Problem
Renovate was creating PRs like #215 to update internal workspace modules (e.g., `github.com/grafana/nanogit/gittest`) to published versions, even though these are managed locally via `go.work` and `replace` directives.

## Solution
Created `.github/renovate.json` with:
1. **ignoreDeps**: Explicitly lists all internal workspace modules to ignore
2. **packageRules**: Pattern-based rule to disable all `github.com/grafana/nanogit*` dependencies

## Testing
- Close PR #215 and verify it's not recreated
- Monitor next Renovate run to ensure no PRs for internal modules
- Only external dependencies should be updated

## Related
- Closes #215 (indirectly - prevents recreation of similar PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)