### PR TITLE
fix: unwrap side-band channel 1 and validate unpack ok on receive-pack

### DIFF
--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -12,14 +12,16 @@ import (
 	"github.com/grafana/nanogit/protocol"
 )
 
-// ErrMissingReportStatus is returned when a receive-pack response contains
-// non-trivial content but no "unpack ok" report-status sentinel. Empty or
-// flush-only responses are accepted silently — they correspond to clients
-// that legitimately omitted report-status / report-status-v2 from their
-// advertised capabilities (via WithReceivePackCapabilities), in which case
-// the server is not required to send a report-status reply. The
-// requirement only kicks in when the server sent something the parser
-// could not interpret as a successful sentinel, which is precisely the
+// ErrMissingReportStatus is returned when a receive-pack response
+// contains report-status content (a bare channel-0 line or a non-empty
+// channel-1 packet) but no "unpack ok" sentinel. Channel-2 progress
+// packets and an empty/flush-only body do NOT arm the requirement —
+// callers that legitimately omit report-status / report-status-v2 from
+// their advertised capabilities (via WithReceivePackCapabilities) can
+// still see progress messages from a server, and the server is not
+// required to reply with report-status in that configuration. The
+// requirement kicks in precisely when the server sent something the
+// parser could not interpret as a successful sentinel, which is the
 // silent-failure mode the side-band channel-1 wrapping bug exhibited.
 var ErrMissingReportStatus = errors.New("receive-pack response did not contain 'unpack ok' report-status line")
 
@@ -116,22 +118,42 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 func parseReceivePackResponse(body io.Reader) error {
 	parser := protocol.NewParser(body)
 	sawUnpackOk := false
-	sawAnyContent := false
+	// sawReportStatusContent tracks whether the server sent anything
+	// that could legitimately carry a report-status sentinel — i.e. a
+	// bare channel-0 line or a non-empty channel-1 packet. Channel-2
+	// (progress) and channel-3 (fatal — already converted to an error
+	// by detectError) do NOT arm the unpack-ok requirement, so callers
+	// that omit report-status from their advertised capabilities are
+	// not misreported as failed pushes when the server still streams
+	// progress.
+	sawReportStatusContent := false
 	var sideBandPackets [][]byte
 
 	for {
 		line, err := parser.Next()
 		if err == nil {
-			sawAnyContent = true
-			if len(line) > 0 && line[0] == 0x01 {
+			if len(line) == 0 {
+				continue
+			}
+			switch line[0] {
+			case 0x02, 0x03:
+				// Progress / fatal channels carry no report-status.
+				continue
+			case 0x01:
 				// Parser.Next() already returns a freshly allocated
 				// slice (see protocol.readPacketData), so a sub-slice
 				// of it is safe to retain across iterations.
-				sideBandPackets = append(sideBandPackets, line[1:])
-				continue
-			}
-			if isUnpackOkLine(line) {
-				sawUnpackOk = true
+				payload := line[1:]
+				sideBandPackets = append(sideBandPackets, payload)
+				if len(payload) > 0 {
+					sawReportStatusContent = true
+				}
+			default:
+				// Bare channel-0 report-status line.
+				sawReportStatusContent = true
+				if isUnpackOkLine(line) {
+					sawUnpackOk = true
+				}
 			}
 			continue
 		}
@@ -151,11 +173,12 @@ func parseReceivePackResponse(body io.Reader) error {
 		}
 	}
 
-	if !sawUnpackOk && sawAnyContent {
-		// The server sent something but no "unpack ok" was observed.
-		// This is the silent-failure shape: a rejection wrapped in a
-		// channel the parser could not interpret would otherwise
-		// leave the ref unadvanced with no error to the caller.
+	if !sawUnpackOk && sawReportStatusContent {
+		// The server sent report-status-shaped content but no
+		// "unpack ok" was observed. This is the silent-failure shape:
+		// a rejection wrapped in a channel the parser could not
+		// interpret would otherwise leave the ref unadvanced with no
+		// error to the caller.
 		return fmt.Errorf("git protocol error: %w", ErrMissingReportStatus)
 	}
 	return nil
@@ -163,9 +186,11 @@ func parseReceivePackResponse(body io.Reader) error {
 
 // scanSideBandReportStatus inspects channel-1 packets in arrival order
 // and reports whether an "unpack ok" success sentinel was seen. The
-// encoding is auto-detected from the first non-empty packet payload: a
-// leading pkt-line length header selects the nested-pkt-line path,
-// otherwise we fall back to raw text parsing.
+// encoding is auto-detected by peeking the first 4 bytes of the
+// channel-1 byte stream — accumulating across packets when the inner
+// pkt-line length header is fragmented — so servers that split the
+// header across outer side-band packets are still classified as
+// nested. Otherwise we fall back to raw text parsing.
 //
 // Raw mode is hybrid by design. Side-band framing is in principle a
 // chunked byte stream, so a status line can be split across packet
@@ -184,17 +209,27 @@ func parseReceivePackResponse(body io.Reader) error {
 //     recognized. Errors are intentionally not re-evaluated here to
 //     avoid spurious matches from cross-packet fragment merging.
 func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
-	var first []byte
+	// Detect format by peeking the first 4 bytes of the channel-1 byte
+	// stream, accumulating across packets if the inner pkt-line length
+	// header was fragmented across outer side-band packets. A server
+	// that sends e.g. "00" in one packet and "0eunpack ok\n0000" in
+	// the next must still be classified as nested.
+	var prefix []byte
 	for _, p := range packets {
-		if len(p) > 0 {
-			first = p
+		if len(prefix) >= 4 {
 			break
 		}
+		need := 4 - len(prefix)
+		if len(p) < need {
+			prefix = append(prefix, p...)
+		} else {
+			prefix = append(prefix, p[:need]...)
+		}
 	}
-	if first == nil {
+	if len(prefix) == 0 {
 		return false, nil
 	}
-	if looksLikePktLine(first) {
+	if looksLikePktLine(prefix) {
 		var buf bytes.Buffer
 		for _, p := range packets {
 			buf.Write(p)

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -124,11 +124,10 @@ func parseReceivePackResponse(body io.Reader) error {
 		if err == nil {
 			sawAnyContent = true
 			if len(line) > 0 && line[0] == 0x01 {
-				// Copy the payload so we own a stable slice; the
-				// parser's internal pool may reuse the underlying
-				// buffer between Next() calls.
-				payload := append([]byte(nil), line[1:]...)
-				sideBandPackets = append(sideBandPackets, payload)
+				// Parser.Next() already returns a freshly allocated
+				// slice (see protocol.readPacketData), so a sub-slice
+				// of it is safe to retain across iterations.
+				sideBandPackets = append(sideBandPackets, line[1:])
 				continue
 			}
 			if isUnpackOkLine(line) {
@@ -162,12 +161,28 @@ func parseReceivePackResponse(body io.Reader) error {
 	return nil
 }
 
-// scanSideBandReportStatus inspects channel-1 packets (in arrival
-// order, with original packet boundaries preserved) and reports whether
-// an "unpack ok" success sentinel was seen. The encoding is auto-
-// detected from the first non-empty packet payload: a leading pkt-line
-// length header selects the nested-pkt-line path, otherwise we fall
-// back to raw text parsing.
+// scanSideBandReportStatus inspects channel-1 packets in arrival order
+// and reports whether an "unpack ok" success sentinel was seen. The
+// encoding is auto-detected from the first non-empty packet payload: a
+// leading pkt-line length header selects the nested-pkt-line path,
+// otherwise we fall back to raw text parsing.
+//
+// Raw mode is hybrid by design. Side-band framing is in principle a
+// chunked byte stream, so a status line can be split across packet
+// boundaries; conversely, observed-in-the-wild servers send each
+// report-status line in its own channel-1 packet without a trailing
+// LF, so naively concatenating would merge distinct lines. We therefore
+// run two passes:
+//
+//  1. Per-packet pass — drives error detection (ng / unpack failure /
+//     ERR / error: / fatal:) and recognizes "unpack ok" when each line
+//     fits in a single packet. Fragment payloads that do not match any
+//     prefix do not produce false positives.
+//  2. Concatenated-stream fallback — only if the per-packet pass did
+//     not see "unpack ok" we re-scan the joined byte stream split on LF
+//     so a server that fragments "unpack ok\n" across packets is still
+//     recognized. Errors are intentionally not re-evaluated here to
+//     avoid spurious matches from cross-packet fragment merging.
 func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
 	var first []byte
 	for _, p := range packets {
@@ -186,7 +201,33 @@ func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
 		}
 		return scanNestedPktLineStream(buf.Bytes())
 	}
-	return scanRawReportStatusPackets(packets)
+
+	sawUnpackOk, err = scanRawReportStatusPackets(packets)
+	if err != nil {
+		return sawUnpackOk, err
+	}
+	if !sawUnpackOk && containsUnpackOkLine(packets) {
+		sawUnpackOk = true
+	}
+	return sawUnpackOk, nil
+}
+
+// containsUnpackOkLine concatenates the channel-1 payloads and reports
+// whether the resulting byte stream contains an "unpack ok" line
+// (LF-terminated or end-of-stream). Used as a fallback when per-packet
+// scanning misses a status line that was split across packet
+// boundaries.
+func containsUnpackOkLine(packets [][]byte) bool {
+	var buf bytes.Buffer
+	for _, p := range packets {
+		buf.Write(p)
+	}
+	for raw := range bytes.SplitSeq(buf.Bytes(), []byte("\n")) {
+		if bytes.Equal(bytes.TrimRight(raw, " \t\r"), unpackOkLine) {
+			return true
+		}
+	}
+	return false
 }
 
 // scanNestedPktLineStream parses payload as an inner pkt-line stream

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -192,28 +192,19 @@ func parseReceivePackResponse(body io.Reader) error {
 // header across outer side-band packets are still classified as
 // nested. Otherwise we fall back to raw text parsing.
 //
-// Raw mode is hybrid by design. Side-band framing is in principle a
-// chunked byte stream, so a status line can be split across packet
-// boundaries; conversely, observed-in-the-wild servers send each
-// report-status line in its own channel-1 packet without a trailing
-// LF, so naively concatenating would merge distinct lines. We therefore
-// run two passes:
-//
-//  1. Per-packet pass — drives error detection (ng / unpack failure /
-//     ERR / error: / fatal:) and recognizes "unpack ok" when each line
-//     fits in a single packet. Fragment payloads that do not match any
-//     prefix do not produce false positives.
-//  2. Concatenated-stream fallback — only if the per-packet pass did
-//     not see "unpack ok" we re-scan the joined byte stream split on LF
-//     so a server that fragments "unpack ok\n" across packets is still
-//     recognized. Errors are intentionally not re-evaluated here to
-//     avoid spurious matches from cross-packet fragment merging.
+// Both the nested and the raw paths concatenate the channel-1 byte
+// stream before running line-level analysis. Side-band framing is a
+// byte stream, so packet boundaries do NOT carry semantic meaning —
+// inner pkt-lines or raw text lines may be split arbitrarily across
+// outer packets, including in the middle of "unpack ok" or "ng <ref>".
+// Per gitprotocol-common, non-binary report-status lines SHOULD be
+// terminated by an LF; a non-conformant server that omits LF
+// separators will produce a single merged line, which surfaces as
+// ErrMissingReportStatus rather than a silent misclassification.
 func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
-	// Detect format by peeking the first 4 bytes of the channel-1 byte
-	// stream, accumulating across packets if the inner pkt-line length
-	// header was fragmented across outer side-band packets. A server
-	// that sends e.g. "00" in one packet and "0eunpack ok\n0000" in
-	// the next must still be classified as nested.
+	// Format detection: peek the first 4 bytes of the channel-1 byte
+	// stream, accumulating across packets so a fragmented inner
+	// pkt-line length header is still classified as nested.
 	var prefix []byte
 	for _, p := range packets {
 		if len(prefix) >= 4 {
@@ -229,40 +220,16 @@ func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
 	if len(prefix) == 0 {
 		return false, nil
 	}
-	if looksLikePktLine(prefix) {
-		var buf bytes.Buffer
-		for _, p := range packets {
-			buf.Write(p)
-		}
-		return scanNestedPktLineStream(buf.Bytes())
-	}
 
-	sawUnpackOk, err = scanRawReportStatusPackets(packets)
-	if err != nil {
-		return sawUnpackOk, err
-	}
-	if !sawUnpackOk && containsUnpackOkLine(packets) {
-		sawUnpackOk = true
-	}
-	return sawUnpackOk, nil
-}
-
-// containsUnpackOkLine concatenates the channel-1 payloads and reports
-// whether the resulting byte stream contains an "unpack ok" line
-// (LF-terminated or end-of-stream). Used as a fallback when per-packet
-// scanning misses a status line that was split across packet
-// boundaries.
-func containsUnpackOkLine(packets [][]byte) bool {
 	var buf bytes.Buffer
 	for _, p := range packets {
 		buf.Write(p)
 	}
-	for raw := range bytes.SplitSeq(buf.Bytes(), []byte("\n")) {
-		if bytes.Equal(bytes.TrimRight(raw, " \t\r"), unpackOkLine) {
-			return true
-		}
+
+	if looksLikePktLine(prefix) {
+		return scanNestedPktLineStream(buf.Bytes())
 	}
-	return false
+	return scanRawReportStatusStream(buf.Bytes())
 }
 
 // scanNestedPktLineStream parses payload as an inner pkt-line stream
@@ -285,30 +252,19 @@ func scanNestedPktLineStream(payload []byte) (sawUnpackOk bool, err error) {
 	}
 }
 
-// scanRawReportStatusPackets walks each channel-1 packet payload
-// independently. Within a single packet, lines are LF-separated; across
-// packets, the boundaries provided by the outer pkt-line length act as
-// implicit line terminators so two raw packets without trailing LF
-// (e.g. "unpack ok" + "ok refs/...") are not merged into a single
-// misclassified line.
-func scanRawReportStatusPackets(packets [][]byte) (sawUnpackOk bool, err error) {
-	for _, payload := range packets {
-		ok, e := scanRawReportStatusLines(payload)
-		if e != nil {
-			return sawUnpackOk, e
-		}
-		if ok {
-			sawUnpackOk = true
-		}
-	}
-	return sawUnpackOk, nil
-}
-
-// scanRawReportStatusLines splits a single packet payload on LF and
-// feeds each non-empty line through Parser so the same ng / unpack /
-// ERR / error: / fatal: detection that runs on the bare channel-0
-// stream applies here.
-func scanRawReportStatusLines(payload []byte) (sawUnpackOk bool, err error) {
+// scanRawReportStatusStream treats the concatenated channel-1 byte
+// stream as one or more LF-separated raw report-status lines. Each
+// non-empty line is wrapped in a synthetic pkt-line and fed to Parser
+// so the same ng / unpack failure / ERR / error: / fatal: detection
+// that runs on the bare channel-0 stream applies here.
+//
+// Reassembling across packet boundaries before classification matters:
+// side-band is a byte-stream framing layer, so a status line can be
+// split mid-token (e.g. "unpack o" then "k\n"). Running detectError on
+// the per-packet fragment "unpack o" would match the "unpack " prefix
+// and emit a spurious GitUnpackError on a successful push, so analysis
+// only fires on complete lines.
+func scanRawReportStatusStream(payload []byte) (sawUnpackOk bool, err error) {
 	for raw := range bytes.SplitSeq(payload, []byte("\n")) {
 		line := bytes.TrimRight(raw, " \t\r")
 		if len(line) == 0 {

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -87,13 +87,22 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 //
 // Side-band handling:
 //
-// When the client negotiates side-band-64k, the server may deliver the
-// report-status as a nested pkt-line stream multiplexed on channel 1
-// (each packet on the wire starts with a 0x01 byte followed by a
-// chunk of the inner stream). We accumulate the channel-1 bytes and
-// re-parse them as a secondary pkt-line stream so the positive-
-// validation check works for both bare and side-band-wrapped
-// report-status responses.
+// When the client negotiates side-band-64k, the server delivers the
+// report-status multiplexed on channel 1 (each outer packet starts with
+// 0x01). Different servers wrap the channel-1 payload differently:
+//
+//   - Gitea / GitLab (chunked): the channel-1 payload is itself a
+//     pkt-line stream of report-status lines, possibly chunked across
+//     multiple outer packets.
+//   - GitHub / others (raw):    each report-status line is sent in its
+//     own channel-1 outer packet as literal text (no inner length
+//     prefix).
+//
+// We accumulate all channel-1 payload, then dispatch on whether the
+// accumulated bytes start with a valid pkt-line length (4 hex digits).
+// Crucially, channel-1 unwrap is scoped to this function and does not
+// leak into the generic detectError path, where channel 1 also carries
+// binary packfile data during fetch/clone.
 func parseReceivePackResponse(body io.Reader) error {
 	parser := protocol.NewParser(body)
 	sawUnpackOk := false
@@ -103,9 +112,6 @@ func parseReceivePackResponse(body io.Reader) error {
 		line, err := parser.Next()
 		if err == nil {
 			if len(line) > 0 && line[0] == 0x01 {
-				// Accumulate channel-1 bytes; they form a nested
-				// pkt-line stream that we parse once the outer
-				// stream has ended.
 				sideBandBuf.Write(line[1:])
 				continue
 			}
@@ -120,23 +126,13 @@ func parseReceivePackResponse(body io.Reader) error {
 		return fmt.Errorf("git protocol error: %w", err)
 	}
 
-	// Re-parse any side-band-wrapped report-status content so we can
-	// detect push failures (ng) or success sentinels that the server
-	// delivered on channel 1.
 	if sideBandBuf.Len() > 0 {
-		innerParser := protocol.NewParser(&sideBandBuf)
-		for {
-			line, err := innerParser.Next()
-			if err == nil {
-				if isUnpackOkLine(line) {
-					sawUnpackOk = true
-				}
-				continue
-			}
-			if err == io.EOF {
-				break
-			}
-			return fmt.Errorf("git protocol error: %w", err)
+		ok, err := scanSideBandReportStatus(sideBandBuf.Bytes())
+		if err != nil {
+			return err
+		}
+		if ok {
+			sawUnpackOk = true
 		}
 	}
 
@@ -154,13 +150,90 @@ func parseReceivePackResponse(body io.Reader) error {
 	return nil
 }
 
-// isUnpackOkLine reports whether a parsed packet line is the
-// "unpack ok" report-status sentinel, tolerating a leading side-band
-// channel-1 byte (0x01) and any trailing whitespace per
-// gitprotocol-common.
-func isUnpackOkLine(line []byte) bool {
-	if len(line) > 0 && line[0] == 0x01 {
-		line = line[1:]
+// scanSideBandReportStatus inspects accumulated side-band channel-1
+// bytes and reports whether an "unpack ok" success sentinel was seen.
+// It auto-detects between two on-wire encodings of the channel-1
+// payload (nested pkt-line stream vs raw text lines) and returns any
+// protocol-level error (ng/unpack failure/ERR) detected by the
+// underlying parser.
+func scanSideBandReportStatus(payload []byte) (sawUnpackOk bool, err error) {
+	if looksLikePktLine(payload) {
+		return scanNestedPktLineStream(payload)
 	}
+	return scanRawReportStatusLines(payload)
+}
+
+// scanNestedPktLineStream parses payload as an inner pkt-line stream
+// and returns whether an "unpack ok" line was observed. Any protocol
+// error detected by the parser is returned wrapped.
+func scanNestedPktLineStream(payload []byte) (sawUnpackOk bool, err error) {
+	inner := protocol.NewParser(bytes.NewReader(payload))
+	for {
+		line, parseErr := inner.Next()
+		if parseErr == nil {
+			if isUnpackOkLine(line) {
+				sawUnpackOk = true
+			}
+			continue
+		}
+		if parseErr == io.EOF {
+			return sawUnpackOk, nil
+		}
+		return sawUnpackOk, fmt.Errorf("git protocol error: %w", parseErr)
+	}
+}
+
+// scanRawReportStatusLines treats payload as one or more LF-separated
+// raw report-status lines (the form some servers use when sending each
+// line in its own channel-1 packet). Each non-empty line is wrapped in
+// a synthetic pkt-line and fed to the parser so the same ng / unpack /
+// ERR / error: / fatal: detection that runs on the bare channel-0
+// stream applies here.
+func scanRawReportStatusLines(payload []byte) (sawUnpackOk bool, err error) {
+	for raw := range bytes.SplitSeq(payload, []byte("\n")) {
+		line := bytes.TrimRight(raw, " \t\r")
+		if len(line) == 0 {
+			continue
+		}
+		pkt, marshalErr := protocol.PackLine(line).Marshal()
+		if marshalErr != nil {
+			return sawUnpackOk, fmt.Errorf("git protocol error: %w", marshalErr)
+		}
+		inner := protocol.NewParser(bytes.NewReader(pkt))
+		parsed, parseErr := inner.Next()
+		if parseErr != nil && parseErr != io.EOF {
+			return sawUnpackOk, fmt.Errorf("git protocol error: %w", parseErr)
+		}
+		if isUnpackOkLine(parsed) {
+			sawUnpackOk = true
+		}
+	}
+	return sawUnpackOk, nil
+}
+
+// looksLikePktLine reports whether the first 4 bytes of data form a
+// valid pkt-line length header (4 ASCII hex digits). Used to
+// disambiguate the two channel-1 wire encodings of report-status.
+func looksLikePktLine(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+	for i := range 4 {
+		b := data[i]
+		switch {
+		case b >= '0' && b <= '9':
+		case b >= 'a' && b <= 'f':
+		case b >= 'A' && b <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isUnpackOkLine reports whether a parsed packet line is the
+// "unpack ok" report-status sentinel, tolerating any trailing
+// whitespace per gitprotocol-common.
+func isUnpackOkLine(line []byte) bool {
 	return bytes.Equal(bytes.TrimRight(line, " \t\r\n"), unpackOkLine)
 }

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +11,17 @@ import (
 	"github.com/grafana/nanogit/log"
 	"github.com/grafana/nanogit/protocol"
 )
+
+// ErrMissingReportStatus is returned when a receive-pack response completes
+// without an "unpack ok" report-status line. Historically, nanogit accepted
+// such responses as successful pushes, which hid server-side rejections when
+// the server silently closed the stream or wrapped the report-status in a
+// side-band channel the parser did not recognize. Requiring an explicit
+// "unpack ok" ensures push failures surface as errors.
+var ErrMissingReportStatus = errors.New("receive-pack response did not contain 'unpack ok' report-status line")
+
+// unpackOkLine is the Git report-status success sentinel (gitprotocol-pack).
+var unpackOkLine = []byte("unpack ok")
 
 // ReceivePack sends a POST request to the git-receive-pack endpoint.
 // This endpoint is used to send objects to the remote repository.
@@ -62,14 +75,92 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 		"status", res.StatusCode,
 		"statusText", res.Status)
 
-	parser := protocol.NewParser(res.Body)
-	for {
-		if _, err := parser.Next(); err != nil {
-			if err == io.EOF {
-				return nil
-			}
+	return parseReceivePackResponse(res.Body)
+}
 
+// parseReceivePackResponse consumes the pkt-line stream from a
+// git-receive-pack response and enforces that a successful response
+// contains an explicit "unpack ok" report-status line. Any protocol
+// error detected by the parser (ERR, ng, unpack failure, error:/fatal:
+// messages including side-band-wrapped ones) is surfaced as a wrapped
+// git protocol error.
+//
+// Side-band handling:
+//
+// When the client negotiates side-band-64k, the server may deliver the
+// report-status as a nested pkt-line stream multiplexed on channel 1
+// (each packet on the wire starts with a 0x01 byte followed by a
+// chunk of the inner stream). We accumulate the channel-1 bytes and
+// re-parse them as a secondary pkt-line stream so the positive-
+// validation check works for both bare and side-band-wrapped
+// report-status responses.
+func parseReceivePackResponse(body io.Reader) error {
+	parser := protocol.NewParser(body)
+	sawUnpackOk := false
+	var sideBandBuf bytes.Buffer
+
+	for {
+		line, err := parser.Next()
+		if err == nil {
+			if len(line) > 0 && line[0] == 0x01 {
+				// Accumulate channel-1 bytes; they form a nested
+				// pkt-line stream that we parse once the outer
+				// stream has ended.
+				sideBandBuf.Write(line[1:])
+				continue
+			}
+			if isUnpackOkLine(line) {
+				sawUnpackOk = true
+			}
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
+		return fmt.Errorf("git protocol error: %w", err)
+	}
+
+	// Re-parse any side-band-wrapped report-status content so we can
+	// detect push failures (ng) or success sentinels that the server
+	// delivered on channel 1.
+	if sideBandBuf.Len() > 0 {
+		innerParser := protocol.NewParser(&sideBandBuf)
+		for {
+			line, err := innerParser.Next()
+			if err == nil {
+				if isUnpackOkLine(line) {
+					sawUnpackOk = true
+				}
+				continue
+			}
+			if err == io.EOF {
+				break
+			}
 			return fmt.Errorf("git protocol error: %w", err)
 		}
 	}
+
+	if !sawUnpackOk {
+		// No report-status was observed. Per gitprotocol-pack, a
+		// successful receive-pack response MUST include "unpack ok".
+		// Treat the absence as a protocol error rather than silently
+		// returning success — otherwise servers that emit a
+		// degenerate/empty response, or wrap their report-status in a
+		// side-band channel the parser does not recognize, would
+		// leave the ref unadvanced with no error reported to the
+		// caller.
+		return fmt.Errorf("git protocol error: %w", ErrMissingReportStatus)
+	}
+	return nil
+}
+
+// isUnpackOkLine reports whether a parsed packet line is the
+// "unpack ok" report-status sentinel, tolerating a leading side-band
+// channel-1 byte (0x01) and any trailing whitespace per
+// gitprotocol-common.
+func isUnpackOkLine(line []byte) bool {
+	if len(line) > 0 && line[0] == 0x01 {
+		line = line[1:]
+	}
+	return bytes.Equal(bytes.TrimRight(line, " \t\r\n"), unpackOkLine)
 }

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -12,12 +12,15 @@ import (
 	"github.com/grafana/nanogit/protocol"
 )
 
-// ErrMissingReportStatus is returned when a receive-pack response completes
-// without an "unpack ok" report-status line. Historically, nanogit accepted
-// such responses as successful pushes, which hid server-side rejections when
-// the server silently closed the stream or wrapped the report-status in a
-// side-band channel the parser did not recognize. Requiring an explicit
-// "unpack ok" ensures push failures surface as errors.
+// ErrMissingReportStatus is returned when a receive-pack response contains
+// non-trivial content but no "unpack ok" report-status sentinel. Empty or
+// flush-only responses are accepted silently — they correspond to clients
+// that legitimately omitted report-status / report-status-v2 from their
+// advertised capabilities (via WithReceivePackCapabilities), in which case
+// the server is not required to send a report-status reply. The
+// requirement only kicks in when the server sent something the parser
+// could not interpret as a successful sentinel, which is precisely the
+// silent-failure mode the side-band channel-1 wrapping bug exhibited.
 var ErrMissingReportStatus = errors.New("receive-pack response did not contain 'unpack ok' report-status line")
 
 // unpackOkLine is the Git report-status success sentinel (gitprotocol-pack).
@@ -79,10 +82,13 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 }
 
 // parseReceivePackResponse consumes the pkt-line stream from a
-// git-receive-pack response and enforces that a successful response
-// contains an explicit "unpack ok" report-status line. Any protocol
-// error detected by the parser (ERR, ng, unpack failure, error:/fatal:
-// messages including side-band-wrapped ones) is surfaced as a wrapped
+// git-receive-pack response. When the response contains a recognizable
+// report-status (either bare or side-band-wrapped) it must include an
+// explicit "unpack ok" sentinel; otherwise ErrMissingReportStatus is
+// returned. Empty or flush-only bodies are accepted silently because
+// callers may legitimately omit report-status from their negotiated
+// capabilities. Any protocol error detected by the parser
+// (ERR / ng / unpack failure / error: / fatal:) is surfaced as a wrapped
 // git protocol error.
 //
 // Side-band handling:
@@ -98,21 +104,31 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 //     own channel-1 outer packet as literal text (no inner length
 //     prefix).
 //
-// We accumulate all channel-1 payload, then dispatch on whether the
-// accumulated bytes start with a valid pkt-line length (4 hex digits).
-// Crucially, channel-1 unwrap is scoped to this function and does not
-// leak into the generic detectError path, where channel 1 also carries
-// binary packfile data during fetch/clone.
+// Channel-1 packet boundaries are preserved: each outer packet's
+// payload is stored separately so that two raw packets without
+// trailing LF do not concatenate into a single misclassified line.
+// Format detection runs on the first non-empty payload; if it begins
+// with a pkt-line length header we treat the whole channel-1 stream as
+// nested pkt-lines, otherwise we process each packet's payload as
+// LF-separated raw lines. Channel-1 unwrap is scoped to this function
+// and does not leak into the generic detectError path, where channel 1
+// also carries binary packfile data during fetch/clone.
 func parseReceivePackResponse(body io.Reader) error {
 	parser := protocol.NewParser(body)
 	sawUnpackOk := false
-	var sideBandBuf bytes.Buffer
+	sawAnyContent := false
+	var sideBandPackets [][]byte
 
 	for {
 		line, err := parser.Next()
 		if err == nil {
+			sawAnyContent = true
 			if len(line) > 0 && line[0] == 0x01 {
-				sideBandBuf.Write(line[1:])
+				// Copy the payload so we own a stable slice; the
+				// parser's internal pool may reuse the underlying
+				// buffer between Next() calls.
+				payload := append([]byte(nil), line[1:]...)
+				sideBandPackets = append(sideBandPackets, payload)
 				continue
 			}
 			if isUnpackOkLine(line) {
@@ -126,8 +142,8 @@ func parseReceivePackResponse(body io.Reader) error {
 		return fmt.Errorf("git protocol error: %w", err)
 	}
 
-	if sideBandBuf.Len() > 0 {
-		ok, err := scanSideBandReportStatus(sideBandBuf.Bytes())
+	if len(sideBandPackets) > 0 {
+		ok, err := scanSideBandReportStatus(sideBandPackets)
 		if err != nil {
 			return err
 		}
@@ -136,31 +152,41 @@ func parseReceivePackResponse(body io.Reader) error {
 		}
 	}
 
-	if !sawUnpackOk {
-		// No report-status was observed. Per gitprotocol-pack, a
-		// successful receive-pack response MUST include "unpack ok".
-		// Treat the absence as a protocol error rather than silently
-		// returning success — otherwise servers that emit a
-		// degenerate/empty response, or wrap their report-status in a
-		// side-band channel the parser does not recognize, would
-		// leave the ref unadvanced with no error reported to the
-		// caller.
+	if !sawUnpackOk && sawAnyContent {
+		// The server sent something but no "unpack ok" was observed.
+		// This is the silent-failure shape: a rejection wrapped in a
+		// channel the parser could not interpret would otherwise
+		// leave the ref unadvanced with no error to the caller.
 		return fmt.Errorf("git protocol error: %w", ErrMissingReportStatus)
 	}
 	return nil
 }
 
-// scanSideBandReportStatus inspects accumulated side-band channel-1
-// bytes and reports whether an "unpack ok" success sentinel was seen.
-// It auto-detects between two on-wire encodings of the channel-1
-// payload (nested pkt-line stream vs raw text lines) and returns any
-// protocol-level error (ng/unpack failure/ERR) detected by the
-// underlying parser.
-func scanSideBandReportStatus(payload []byte) (sawUnpackOk bool, err error) {
-	if looksLikePktLine(payload) {
-		return scanNestedPktLineStream(payload)
+// scanSideBandReportStatus inspects channel-1 packets (in arrival
+// order, with original packet boundaries preserved) and reports whether
+// an "unpack ok" success sentinel was seen. The encoding is auto-
+// detected from the first non-empty packet payload: a leading pkt-line
+// length header selects the nested-pkt-line path, otherwise we fall
+// back to raw text parsing.
+func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
+	var first []byte
+	for _, p := range packets {
+		if len(p) > 0 {
+			first = p
+			break
+		}
 	}
-	return scanRawReportStatusLines(payload)
+	if first == nil {
+		return false, nil
+	}
+	if looksLikePktLine(first) {
+		var buf bytes.Buffer
+		for _, p := range packets {
+			buf.Write(p)
+		}
+		return scanNestedPktLineStream(buf.Bytes())
+	}
+	return scanRawReportStatusPackets(packets)
 }
 
 // scanNestedPktLineStream parses payload as an inner pkt-line stream
@@ -183,10 +209,27 @@ func scanNestedPktLineStream(payload []byte) (sawUnpackOk bool, err error) {
 	}
 }
 
-// scanRawReportStatusLines treats payload as one or more LF-separated
-// raw report-status lines (the form some servers use when sending each
-// line in its own channel-1 packet). Each non-empty line is wrapped in
-// a synthetic pkt-line and fed to the parser so the same ng / unpack /
+// scanRawReportStatusPackets walks each channel-1 packet payload
+// independently. Within a single packet, lines are LF-separated; across
+// packets, the boundaries provided by the outer pkt-line length act as
+// implicit line terminators so two raw packets without trailing LF
+// (e.g. "unpack ok" + "ok refs/...") are not merged into a single
+// misclassified line.
+func scanRawReportStatusPackets(packets [][]byte) (sawUnpackOk bool, err error) {
+	for _, payload := range packets {
+		ok, e := scanRawReportStatusLines(payload)
+		if e != nil {
+			return sawUnpackOk, e
+		}
+		if ok {
+			sawUnpackOk = true
+		}
+	}
+	return sawUnpackOk, nil
+}
+
+// scanRawReportStatusLines splits a single packet payload on LF and
+// feeds each non-empty line through Parser so the same ng / unpack /
 // ERR / error: / fatal: detection that runs on the bare channel-0
 // stream applies here.
 func scanRawReportStatusLines(payload []byte) (sawUnpackOk bool, err error) {

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -96,33 +96,22 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 // Side-band handling:
 //
 // When the client negotiates side-band-64k, the server delivers the
-// report-status multiplexed on channel 1 (each outer packet starts with
-// 0x01). Different servers wrap the channel-1 payload differently:
-//
-//   - Gitea / GitLab (chunked): the channel-1 payload is itself a
-//     pkt-line stream of report-status lines, possibly chunked across
-//     multiple outer packets.
-//   - GitHub / others (raw):    each report-status line is sent in its
-//     own channel-1 outer packet as literal text (no inner length
-//     prefix).
-//
-// Channel-1 packet boundaries are preserved: each outer packet's
-// payload is stored separately so that two raw packets without
-// trailing LF do not concatenate into a single misclassified line.
-// Format detection runs on the first non-empty payload; if it begins
-// with a pkt-line length header we treat the whole channel-1 stream as
-// nested pkt-lines, otherwise we process each packet's payload as
-// LF-separated raw lines. Channel-1 unwrap is scoped to this function
-// and does not leak into the generic detectError path, where channel 1
-// also carries binary packfile data during fetch/clone.
+// report-status multiplexed on channel 1 (each outer packet starts
+// with 0x01). Side-band framing is a byte stream, so outer packet
+// boundaries do NOT carry semantic meaning — inner pkt-lines or raw
+// text lines may be split arbitrarily across outer packets. Channel-1
+// payloads are accumulated and reassembled before line-level analysis;
+// see scanSideBandReportStatus for the reassembly + format-detection
+// strategy. Channel-1 unwrap is scoped to this function and does not
+// leak into the generic detectError path, where channel 1 also carries
+// binary packfile data during fetch/clone.
 func parseReceivePackResponse(body io.Reader) error {
 	parser := protocol.NewParser(body)
 	sawUnpackOk := false
 	// sawReportStatusContent tracks whether the server sent anything
 	// that could legitimately carry a report-status sentinel — i.e. a
 	// bare channel-0 line or a non-empty channel-1 packet. Channel-2
-	// (progress) and channel-3 (fatal — already converted to an error
-	// by detectError) do NOT arm the unpack-ok requirement, so callers
+	// (progress) does NOT arm the unpack-ok requirement, so callers
 	// that omit report-status from their advertised capabilities are
 	// not misreported as failed pushes when the server still streams
 	// progress.
@@ -131,36 +120,22 @@ func parseReceivePackResponse(body io.Reader) error {
 
 	for {
 		line, err := parser.Next()
-		if err == nil {
-			if len(line) == 0 {
-				continue
-			}
-			switch line[0] {
-			case 0x02, 0x03:
-				// Progress / fatal channels carry no report-status.
-				continue
-			case 0x01:
-				// Parser.Next() already returns a freshly allocated
-				// slice (see protocol.readPacketData), so a sub-slice
-				// of it is safe to retain across iterations.
-				payload := line[1:]
-				sideBandPackets = append(sideBandPackets, payload)
-				if len(payload) > 0 {
-					sawReportStatusContent = true
-				}
-			default:
-				// Bare channel-0 report-status line.
-				sawReportStatusContent = true
-				if isUnpackOkLine(line) {
-					sawUnpackOk = true
-				}
-			}
-			continue
-		}
 		if err == io.EOF {
 			break
 		}
-		return fmt.Errorf("git protocol error: %w", err)
+		if err != nil {
+			return fmt.Errorf("git protocol error: %w", err)
+		}
+		ok, content, classifyErr := classifyReceivePackLine(line, &sideBandPackets)
+		if classifyErr != nil {
+			return classifyErr
+		}
+		if ok {
+			sawUnpackOk = true
+		}
+		if content {
+			sawReportStatusContent = true
+		}
 	}
 
 	if len(sideBandPackets) > 0 {
@@ -184,6 +159,47 @@ func parseReceivePackResponse(body io.Reader) error {
 	return nil
 }
 
+// classifyReceivePackLine inspects a single parsed pkt-line from the
+// receive-pack response and either appends a channel-1 payload to the
+// running side-band buffer, returns a fatal channel-3 error, or signals
+// whether the line counts as report-status content / contains an
+// "unpack ok" sentinel for the bare channel-0 case.
+func classifyReceivePackLine(line []byte, sideBandPackets *[][]byte) (sawUnpackOk, sawReportStatusContent bool, err error) {
+	if len(line) == 0 {
+		return false, false, nil
+	}
+	switch line[0] {
+	case 0x02:
+		// Channel 2 is progress; it never carries report-status and
+		// does not arm any requirement.
+		return false, false, nil
+	case 0x03:
+		// Channel 3 is fatal. detectError already converts the
+		// well-formed "fatal:"/"error:" prefixed shape into a
+		// GitServerError; an arbitrary non-empty channel-3 payload
+		// that fell through must still be surfaced rather than
+		// silently dropped, otherwise a server that closes the stream
+		// with a fatal note in a shape the parser does not recognize
+		// would look like a successful push.
+		payload := line[1:]
+		if len(payload) == 0 {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("git protocol error: %w",
+			protocol.NewGitServerError(line, "fatal", string(payload)))
+	case 0x01:
+		// Parser.Next() already returns a freshly allocated slice (see
+		// protocol.readPacketData), so a sub-slice of it is safe to
+		// retain across iterations.
+		payload := line[1:]
+		*sideBandPackets = append(*sideBandPackets, payload)
+		return false, len(payload) > 0, nil
+	default:
+		// Bare channel-0 report-status line.
+		return isUnpackOkLine(line), true, nil
+	}
+}
+
 // scanSideBandReportStatus inspects channel-1 packets in arrival order
 // and reports whether an "unpack ok" success sentinel was seen. The
 // encoding is auto-detected by peeking the first 4 bytes of the
@@ -197,10 +213,19 @@ func parseReceivePackResponse(body io.Reader) error {
 // byte stream, so packet boundaries do NOT carry semantic meaning —
 // inner pkt-lines or raw text lines may be split arbitrarily across
 // outer packets, including in the middle of "unpack ok" or "ng <ref>".
-// Per gitprotocol-common, non-binary report-status lines SHOULD be
-// terminated by an LF; a non-conformant server that omits LF
-// separators will produce a single merged line, which surfaces as
-// ErrMissingReportStatus rather than a silent misclassification.
+//
+// Trade-off: in the raw path, distinct report-status lines without an
+// LF separator between them merge into a single line. The exact error
+// surfaced depends on what that merged line looks like to detectError
+// (typically GitUnpackError when it begins with "unpack ", or
+// ErrMissingReportStatus when it does not match any sentinel). The
+// alternative — preserving outer packet boundaries as line boundaries
+// — would handle no-LF-separated cases but would also misclassify
+// legitimate mid-token splits (e.g. "unpack o" + "k\n") as failures,
+// which is the path real chunked servers use. We optimise for the
+// byte-stream interpretation that side-band actually specifies and
+// rely on the gitprotocol-common SHOULD that report-status lines are
+// LF-terminated.
 func scanSideBandReportStatus(packets [][]byte) (sawUnpackOk bool, err error) {
 	// Format detection: peek the first 4 bytes of the channel-1 byte
 	// stream, accumulating across packets so a fragmented inner

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -408,14 +408,42 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Server sent a non-trivial body (a channel-2 progress
-			// message) but never sent "unpack ok". This is the
-			// silent-failure shape ErrMissingReportStatus exists
-			// to surface.
-			name: "non-trivial body without unpack ok is rejected",
-			body: flushed(pkt(string(append([]byte{0x02}, []byte("Counting objects: 1, done.\n")...)))),
+			// Channel-2 progress packets do not carry report-status
+			// content, so a body that contains only progress (and
+			// no unpack ok) is accepted. Callers that omit
+			// report-status from negotiated capabilities legitimately
+			// hit this shape and must not be misreported as failed.
+			name:    "channel-2 progress only is accepted (no report-status negotiated)",
+			body:    flushed(pkt(string(append([]byte{0x02}, []byte("Counting objects: 1, done.\n")...)))),
+			wantErr: false,
+		},
+		{
+			// Same shape, but the body also includes a non-empty
+			// channel-1 packet that is NOT report-status (just
+			// gibberish). The channel-1 packet arms the report-status
+			// requirement, so the missing unpack ok must surface as
+			// ErrMissingReportStatus.
+			name: "channel-1 content without unpack ok is rejected",
+			body: flushed(append(
+				pkt(string(append([]byte{0x02}, []byte("progress\n")...))),
+				rawSideband1("ng refs/heads/main hook declined")...,
+			)),
 			wantErr:     true,
-			errContains: "did not contain 'unpack ok'",
+			errContains: "reference update failed for refs/heads/main",
+		},
+		{
+			// Server fragments the inner pkt-line 4-byte length
+			// header across two channel-1 outer packets: first
+			// packet carries "00", second packet starts with "0e"
+			// followed by "unpack ok\n0000". Format detection must
+			// accumulate across packets to recognize the nested
+			// stream rather than misclassifying it as raw.
+			name: "nested side-band length header fragmented across packets is recognized",
+			body: flushed(append(
+				rawSideband1("00"),
+				rawSideband1("0eunpack ok\n0000")...,
+			)),
+			wantErr: false,
 		},
 	}
 

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -370,32 +370,50 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 			errContains: "reference update failed for refs/heads/main",
 		},
 		{
-			// Two raw channel-1 packets with NO trailing LF on the
-			// first one. The previous shape concatenated their
-			// payloads and split on LF, producing a single bogus
-			// line "unpack okok refs/heads/main"; with packet
-			// boundaries preserved each packet stays a separate
-			// line and "unpack ok" is recognized.
-			name: "raw side-band channel 1 packets without trailing LF preserve boundaries",
+			// Side-band framing is a byte stream, so packet boundaries
+			// do NOT carry semantic meaning — a status line may be
+			// split mid-token across outer packets (here "unpack o" +
+			// "k\n"). Reassembling across boundaries before line
+			// classification is essential: a per-packet scan would
+			// match "unpack " on the first fragment and emit a
+			// spurious GitUnpackError with Message="o" on a successful
+			// push. This is the Codex P1 case.
+			name: "raw side-band channel 1 line split mid-token across packets is recognized",
 			body: flushed(append(
-				rawSideband1("unpack ok"),
-				rawSideband1("ok refs/heads/main")...,
+				rawSideband1("unpack o"),
+				rawSideband1("k\n")...,
 			)),
 			wantErr: false,
 		},
 		{
-			// Side-band framing is a chunked byte stream, so a
-			// single status line CAN legitimately be split across
-			// outer packets. The concatenated-stream fallback in
-			// scanSideBandReportStatus must still recognize
-			// "unpack ok\n" when one packet ends with "unpack " and
-			// the next begins with "ok\n".
-			name: "raw side-band channel 1 unpack ok split across packets is recognized",
+			// Companion to the mid-token case: a status line split
+			// AFTER a token boundary ("unpack " + "ok\n") must also
+			// reassemble.
+			name: "raw side-band channel 1 unpack ok split at token boundary is recognized",
 			body: flushed(append(
 				rawSideband1("unpack "),
 				rawSideband1("ok\n")...,
 			)),
 			wantErr: false,
+		},
+		{
+			// Two raw channel-1 packets carrying distinct lines
+			// without a trailing LF on the first one is genuinely
+			// ambiguous in the byte-stream model — the bytes merge
+			// into "unpack okok refs/heads/main" with no separator.
+			// We surface this as a failure (the merged line matches
+			// the "unpack " prefix and yields GitUnpackError) rather
+			// than silently misclassifying the response. Servers
+			// SHOULD LF-terminate per gitprotocol-common; one that
+			// doesn't is non-conformant and a hard failure here is
+			// safer than a silent success.
+			name: "raw side-band channel 1 distinct lines without LF separator surfaces as failure",
+			body: flushed(append(
+				rawSideband1("unpack ok"),
+				rawSideband1("ok refs/heads/main")...,
+			)),
+			wantErr:     true,
+			errContains: "pack unpack failed",
 		},
 		{
 			name:    "empty body is accepted (no report-status negotiated)",

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -291,10 +291,15 @@ func TestReceivePack_Retry(t *testing.T) {
 }
 
 // TestReceivePack_PositiveValidation ensures a receive-pack response is
-// only considered successful if it contains an explicit "unpack ok"
-// report-status line. Previously, an empty 2xx response body was
-// silently accepted as success, which hid server-side rejections that
-// wrapped their report-status in an unrecognized side-band channel.
+// considered successful only when one of the following holds:
+//   - the body is empty / flush-only (caller may have legitimately
+//     omitted report-status from negotiated capabilities), OR
+//   - the body contains an explicit "unpack ok" sentinel (bare or
+//     side-band-wrapped).
+//
+// Non-trivial bodies that lack "unpack ok" are rejected so server-side
+// rejections wrapped in channels the parser cannot interpret no longer
+// silently appear as successful pushes.
 func TestReceivePack_PositiveValidation(t *testing.T) {
 	t.Parallel()
 
@@ -311,6 +316,15 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 	// report-status when side-band-64k is negotiated.
 	sideband1 := func(inner []byte) []byte {
 		payload := append([]byte{0x01}, inner...)
+		b, err := protocol.PackLine(payload).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+	// rawSideband1 wraps a literal text payload (no inner pkt-line
+	// length prefix) inside a single channel-1 outer packet. Used to
+	// exercise the raw-line branch of the side-band parser.
+	rawSideband1 := func(text string) []byte {
+		payload := append([]byte{0x01}, []byte(text)...)
 		b, err := protocol.PackLine(payload).Marshal()
 		require.NoError(t, err)
 		return b
@@ -342,7 +356,7 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 		},
 		{
 			name: "side-band channel 1 raw ng payload triggers reference update error",
-			body: flushed(pkt(string(append([]byte{0x01}, []byte("ng refs/heads/main pre-receive hook declined\n")...)))),
+			body: flushed(rawSideband1("ng refs/heads/main pre-receive hook declined\n")),
 			wantErr:     true,
 			errContains: "reference update failed for refs/heads/main",
 		},
@@ -356,14 +370,36 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 			errContains: "reference update failed for refs/heads/main",
 		},
 		{
-			name:        "empty body is rejected",
-			body:        []byte{},
-			wantErr:     true,
-			errContains: "did not contain 'unpack ok'",
+			// Two raw channel-1 packets with NO trailing LF on the
+			// first one. The previous shape concatenated their
+			// payloads and split on LF, producing a single bogus
+			// line "unpack okok refs/heads/main"; with packet
+			// boundaries preserved each packet stays a separate
+			// line and "unpack ok" is recognized.
+			name: "raw side-band channel 1 packets without trailing LF preserve boundaries",
+			body: flushed(append(
+				rawSideband1("unpack ok"),
+				rawSideband1("ok refs/heads/main")...,
+			)),
+			wantErr: false,
 		},
 		{
-			name:        "flush-only body is rejected",
-			body:        []byte("0000"),
+			name:    "empty body is accepted (no report-status negotiated)",
+			body:    []byte{},
+			wantErr: false,
+		},
+		{
+			name:    "flush-only body is accepted (no report-status negotiated)",
+			body:    []byte("0000"),
+			wantErr: false,
+		},
+		{
+			// Server sent a non-trivial body (a channel-2 progress
+			// message) but never sent "unpack ok". This is the
+			// silent-failure shape ErrMissingReportStatus exists
+			// to surface.
+			name: "non-trivial body without unpack ok is rejected",
+			body: flushed(pkt(string(append([]byte{0x02}, []byte("Counting objects: 1, done.\n")...)))),
 			wantErr:     true,
 			errContains: "did not contain 'unpack ok'",
 		},

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -463,6 +463,19 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 			)),
 			wantErr: false,
 		},
+		{
+			// Channel 3 is the fatal channel. detectError converts
+			// well-formed "fatal:"/"error:" shapes already; a
+			// non-empty channel-3 payload that does NOT match those
+			// prefixes (a server-specific abrupt close) must still
+			// surface as a GitServerError rather than be silently
+			// dropped — otherwise the push would look successful
+			// despite the server signalling termination.
+			name: "channel-3 payload without fatal prefix surfaces as server error",
+			body: flushed(pkt(string(append([]byte{0x03}, []byte("connection terminated by host")...)))),
+			wantErr:     true,
+			errContains: "git server fatal:",
+		},
 	}
 
 	for _, tt := range tests {

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -384,6 +384,20 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Side-band framing is a chunked byte stream, so a
+			// single status line CAN legitimately be split across
+			// outer packets. The concatenated-stream fallback in
+			// scanSideBandReportStatus must still recognize
+			// "unpack ok\n" when one packet ends with "unpack " and
+			// the next begins with "ok\n".
+			name: "raw side-band channel 1 unpack ok split across packets is recognized",
+			body: flushed(append(
+				rawSideband1("unpack "),
+				rawSideband1("ok\n")...,
+			)),
+			wantErr: false,
+		},
+		{
 			name:    "empty body is accepted (no report-status negotiated)",
 			body:    []byte{},
 			wantErr: false,

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -289,3 +289,106 @@ func TestReceivePack_Retry(t *testing.T) {
 	})
 
 }
+
+// TestReceivePack_PositiveValidation ensures a receive-pack response is
+// only considered successful if it contains an explicit "unpack ok"
+// report-status line. Previously, an empty 2xx response body was
+// silently accepted as success, which hid server-side rejections that
+// wrapped their report-status in an unrecognized side-band channel.
+func TestReceivePack_PositiveValidation(t *testing.T) {
+	t.Parallel()
+
+	pkt := func(s string) []byte {
+		b, err := protocol.PackLine(s).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+	flushed := func(data []byte) []byte {
+		return append(append([]byte{}, data...), []byte("0000")...)
+	}
+	// sideband1 wraps `inner` (which is itself a pkt-line stream) inside a
+	// single outer channel-1 pkt-line, mimicking how Gitea/GitLab deliver
+	// report-status when side-band-64k is negotiated.
+	sideband1 := func(inner []byte) []byte {
+		payload := append([]byte{0x01}, inner...)
+		b, err := protocol.PackLine(payload).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+
+	tests := []struct {
+		name        string
+		body        []byte
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "unpack ok is accepted",
+			body:    flushed(pkt("unpack ok")),
+			wantErr: false,
+		},
+		{
+			name:    "unpack ok with trailing LF is accepted",
+			body:    flushed(pkt("unpack ok\n")),
+			wantErr: false,
+		},
+		{
+			name: "side-band channel 1 nested report-status is accepted",
+			body: flushed(sideband1(flushed(append(
+				pkt("unpack ok\n"),
+				pkt("ok refs/heads/main\n")...,
+			)))),
+			wantErr: false,
+		},
+		{
+			name: "side-band channel 1 raw ng payload triggers reference update error",
+			body: flushed(pkt(string(append([]byte{0x01}, []byte("ng refs/heads/main pre-receive hook declined\n")...)))),
+			wantErr:     true,
+			errContains: "reference update failed for refs/heads/main",
+		},
+		{
+			name: "side-band channel 1 nested ng triggers reference update error",
+			body: flushed(sideband1(flushed(append(
+				pkt("unpack ok\n"),
+				pkt("ng refs/heads/main pre-receive hook declined\n")...,
+			)))),
+			wantErr:     true,
+			errContains: "reference update failed for refs/heads/main",
+		},
+		{
+			name:        "empty body is rejected",
+			body:        []byte{},
+			wantErr:     true,
+			errContains: "did not contain 'unpack ok'",
+		},
+		{
+			name:        "flush-only body is rejected",
+			body:        []byte("0000"),
+			wantErr:     true,
+			errContains: "did not contain 'unpack ok'",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(tt.body)
+			}))
+			defer server.Close()
+
+			c, err := NewRawClient(server.URL + "/repo")
+			require.NoError(t, err)
+
+			err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/protocol/pack.go
+++ b/protocol/pack.go
@@ -529,14 +529,12 @@ func readPacketData(reader io.Reader, lengthBytes []byte, length uint64) ([]byte
 // It examines the packet data for error indicators like "ERR", "error:", "fatal:", "ng", and "unpack" messages.
 // Returns an error if any error condition is detected, otherwise returns nil to continue processing.
 //
-// Side-band handling for report-status: some Git servers (notably some GitLab
-// configurations) wrap report-status packets in side-band channel 1 (0x01).
-// Per https://git-scm.com/docs/protocol-capabilities#_report_status and
-// https://git-scm.com/docs/gitprotocol-pack, when side-band-64k is active the
-// report-status payload ("unpack ...", "ok <ref>", "ng <ref> <reason>") may be
-// preceded by a single 0x01 byte that identifies the pack-data channel. We
-// unwrap that byte before pattern-matching so push failures wrapped in band 1
-// are not silently treated as regular data.
+// Side-band handling is intentionally context-specific. Some Git servers
+// may wrap receive-pack report-status payloads in side-band channel 1
+// (0x01), but detectError does not unwrap channel 1 itself. That
+// unwrapping/parsing is performed by receive-pack response parsing code,
+// such as protocol/client.parseReceivePackResponse, where channel-1
+// report-status data can be distinguished from ordinary packfile data.
 func detectError(lengthBytes, packetData []byte) error {
 	// Avoid allocation by building fullPacket only when needed.
 	//

--- a/protocol/pack.go
+++ b/protocol/pack.go
@@ -538,15 +538,15 @@ func readPacketData(reader io.Reader, lengthBytes []byte, length uint64) ([]byte
 // unwrap that byte before pattern-matching so push failures wrapped in band 1
 // are not silently treated as regular data.
 func detectError(lengthBytes, packetData []byte) error {
-	// Avoid allocation by building fullPacket only when needed
-
-	// Unwrap side-band channel 1 (packfile data channel) for report-status
-	// content. Channels 2 (progress) and 3 (fatal) are handled by
-	// isErrorOrFatalMessageOptimized / handleErrorFatalMessage below.
-	reportData := packetData
-	if len(reportData) > 0 && reportData[0] == 0x01 {
-		reportData = reportData[1:]
-	}
+	// Avoid allocation by building fullPacket only when needed.
+	//
+	// NOTE: side-band channel 1 (0x01) is intentionally NOT unwrapped here.
+	// During fetch/clone, channel 1 carries arbitrary binary packfile data
+	// via MultiplexedReader, and a chunk that happens to start with bytes
+	// matching "ng "/"unpack "/etc. would be misclassified as a report-
+	// status error. Channel-1 unwrapping for receive-pack response parsing
+	// is performed in protocol/client.parseReceivePackResponse where it is
+	// scoped to the right context.
 
 	switch {
 	case bytes.HasPrefix(packetData, errPattern):
@@ -557,18 +557,18 @@ func detectError(lengthBytes, packetData []byte) error {
 		fullPacket := append(lengthBytes, packetData...)
 		return handleErrorFatalMessage(fullPacket, packetData)
 
-	case bytes.HasPrefix(reportData, ngPattern):
+	case bytes.HasPrefix(packetData, ngPattern):
 		fullPacket := append(lengthBytes, packetData...)
-		return handleReferenceUpdateFailure(fullPacket, reportData)
+		return handleReferenceUpdateFailure(fullPacket, packetData)
 
-	case bytes.HasPrefix(reportData, unpackPattern):
+	case bytes.HasPrefix(packetData, unpackPattern):
 		// Extract the status string after "unpack " and trim any trailing
 		// whitespace (LF/CR/spaces). Per gitprotocol-common, non-binary
 		// pkt-lines may or may not include a trailing LF and receivers MUST
 		// tolerate either form. Gitea/GitHub send "unpack ok\n" when
 		// side-band is disabled; a byte-exact comparison to "ok" would
 		// otherwise misclassify that as a failure.
-		unpackData := reportData[len(unpackPattern):]
+		unpackData := packetData[len(unpackPattern):]
 		trimmed := bytes.TrimRight(unpackData, " \t\r\n")
 		if bytes.Equal(trimmed, unpackOkPattern) {
 			return nil // "unpack ok" success

--- a/protocol/pack.go
+++ b/protocol/pack.go
@@ -96,7 +96,6 @@ var (
 	ngPattern       = []byte("ng ")
 	unpackPattern   = []byte("unpack ")
 	unpackOkPattern = []byte("ok")
-	unpackOkFull    = []byte("unpack ok") // Most common success case
 )
 
 // Pack is the interface that wraps the Marshal method.
@@ -529,8 +528,25 @@ func readPacketData(reader io.Reader, lengthBytes []byte, length uint64) ([]byte
 // detectError processes packet content to detect and handle various Git protocol error conditions.
 // It examines the packet data for error indicators like "ERR", "error:", "fatal:", "ng", and "unpack" messages.
 // Returns an error if any error condition is detected, otherwise returns nil to continue processing.
+//
+// Side-band handling for report-status: some Git servers (notably some GitLab
+// configurations) wrap report-status packets in side-band channel 1 (0x01).
+// Per https://git-scm.com/docs/protocol-capabilities#_report_status and
+// https://git-scm.com/docs/gitprotocol-pack, when side-band-64k is active the
+// report-status payload ("unpack ...", "ok <ref>", "ng <ref> <reason>") may be
+// preceded by a single 0x01 byte that identifies the pack-data channel. We
+// unwrap that byte before pattern-matching so push failures wrapped in band 1
+// are not silently treated as regular data.
 func detectError(lengthBytes, packetData []byte) error {
 	// Avoid allocation by building fullPacket only when needed
+
+	// Unwrap side-band channel 1 (packfile data channel) for report-status
+	// content. Channels 2 (progress) and 3 (fatal) are handled by
+	// isErrorOrFatalMessageOptimized / handleErrorFatalMessage below.
+	reportData := packetData
+	if len(reportData) > 0 && reportData[0] == 0x01 {
+		reportData = reportData[1:]
+	}
 
 	switch {
 	case bytes.HasPrefix(packetData, errPattern):
@@ -541,24 +557,25 @@ func detectError(lengthBytes, packetData []byte) error {
 		fullPacket := append(lengthBytes, packetData...)
 		return handleErrorFatalMessage(fullPacket, packetData)
 
-	case bytes.HasPrefix(packetData, ngPattern):
+	case bytes.HasPrefix(reportData, ngPattern):
 		fullPacket := append(lengthBytes, packetData...)
-		return handleReferenceUpdateFailure(fullPacket, packetData)
+		return handleReferenceUpdateFailure(fullPacket, reportData)
 
-	case bytes.HasPrefix(packetData, unpackPattern):
-		// Fast path for most common case: "unpack ok"
-		if bytes.Equal(packetData, unpackOkFull) {
-			return nil // Success case, no error
+	case bytes.HasPrefix(reportData, unpackPattern):
+		// Extract the status string after "unpack " and trim any trailing
+		// whitespace (LF/CR/spaces). Per gitprotocol-common, non-binary
+		// pkt-lines may or may not include a trailing LF and receivers MUST
+		// tolerate either form. Gitea/GitHub send "unpack ok\n" when
+		// side-band is disabled; a byte-exact comparison to "ok" would
+		// otherwise misclassify that as a failure.
+		unpackData := reportData[len(unpackPattern):]
+		trimmed := bytes.TrimRight(unpackData, " \t\r\n")
+		if bytes.Equal(trimmed, unpackOkPattern) {
+			return nil // "unpack ok" success
 		}
+		fullPacket := append(lengthBytes, packetData...)
+		return NewGitUnpackError(fullPacket, string(unpackData))
 
-		// Optimize unpack handling with byte comparison instead of string conversion
-		unpackData := packetData[len(unpackPattern):]
-		if !bytes.Equal(unpackData, unpackOkPattern) {
-			fullPacket := append(lengthBytes, packetData...)
-			return NewGitUnpackError(fullPacket, string(unpackData))
-		}
-		// If unpack ok, continue processing
-		return nil
 	default:
 		// Regular data packet
 		return nil
@@ -622,10 +639,15 @@ func handleErrorFatalMessage(fullPacket, packetData []byte) error {
 	return NewGitServerError(fullPacket, errorType, message)
 }
 
-// handleReferenceUpdateFailure processes "ng" (no good) reference update failure packets
+// handleReferenceUpdateFailure processes "ng" (no good) reference update failure packets.
+// The packetData argument is expected to have any side-band channel byte already
+// stripped by the caller, so it begins with the literal "ng " prefix.
 func handleReferenceUpdateFailure(fullPacket, packetData []byte) error {
 	// Format: "ng <refname> <error-msg>"
-	parts := bytes.SplitN(packetData[3:], []byte(" "), 2) // Skip "ng "
+	// Trim any trailing whitespace (e.g. LF) before splitting, per
+	// gitprotocol-common non-binary pkt-line handling.
+	trimmed := bytes.TrimRight(packetData[3:], " \t\r\n") // Skip "ng "
+	parts := bytes.SplitN(trimmed, []byte(" "), 2)
 
 	var refName, reason string
 	if len(parts) >= 1 {

--- a/protocol/pack_test.go
+++ b/protocol/pack_test.go
@@ -777,13 +777,16 @@ func TestParsePack_UnpackTrailingWhitespace(t *testing.T) {
 	}
 }
 
-// TestParsePack_SideBandChannel1 covers bug-fix: some Git servers
-// (notably some GitLab configurations) wrap the report-status
-// payload in side-band channel 1 (leading 0x01 byte). The parser
-// MUST unwrap that channel byte before matching "ng", "unpack",
-// etc., otherwise push failures are silently treated as
-// "regular data" and the push appears to succeed.
-func TestParsePack_SideBandChannel1(t *testing.T) {
+// TestParsePack_Channel1NotMisclassified guards the rule that the
+// generic Parser does NOT unwrap side-band channel 1 (0x01) before
+// matching report-status prefixes. Channel 1 also carries arbitrary
+// binary packfile data during fetch/clone (via MultiplexedReader); a
+// pack chunk that happens to start with bytes spelling "ng " or
+// "unpack " must not be misclassified as a reference-update or unpack
+// failure. Channel-1 unwrapping for receive-pack is performed in
+// protocol/client.parseReceivePackResponse, where it is correctly
+// scoped to the response-parsing context.
+func TestParsePack_Channel1NotMisclassified(t *testing.T) {
 	t.Parallel()
 
 	parseAll := func(data []byte) ([][]byte, error) {
@@ -801,44 +804,42 @@ func TestParsePack_SideBandChannel1(t *testing.T) {
 		}
 	}
 
-	wrap := func(payload string) []byte {
-		// 0x01 + payload as a single pkt-line
-		body := append([]byte{0x01}, []byte(payload)...)
+	wrapChannel1 := func(payload []byte) []byte {
+		body := append([]byte{0x01}, payload...)
 		b, err := protocol.PackLine(body).Marshal()
 		require.NoError(t, err)
 		return b
 	}
 
-	t.Run("side-band ng triggers reference update error", func(t *testing.T) {
-		t.Parallel()
-		_, err := parseAll(wrap("ng refs/heads/main pre-receive hook declined\n"))
-		require.Error(t, err)
-		require.True(t, protocol.IsGitReferenceUpdateError(err),
-			"expected GitReferenceUpdateError, got %T: %v", err, err)
-		var refErr *protocol.GitReferenceUpdateError
-		require.ErrorAs(t, err, &refErr)
-		require.Equal(t, "refs/heads/main", refErr.RefName)
-		require.Equal(t, "pre-receive hook declined", refErr.Reason)
-	})
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			name:    "channel 1 chunk starting with 'ng ' is opaque data",
+			payload: []byte("ng refs/heads/main pre-receive hook declined\n"),
+		},
+		{
+			name:    "channel 1 chunk starting with 'unpack ' is opaque data",
+			payload: []byte("unpack index-pack failed\n"),
+		},
+		{
+			name:    "channel 1 chunk starting with 'ERR ' is opaque data",
+			payload: []byte("ERR push declined"),
+		},
+	}
 
-	t.Run("side-band unpack ok is accepted as success", func(t *testing.T) {
-		t.Parallel()
-		_, err := parseAll(wrap("unpack ok\n"))
-		require.NoError(t, err, "side-band-wrapped 'unpack ok' must not produce an error")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			lines, err := parseAll(wrapChannel1(tt.payload))
+			require.NoError(t, err, "channel 1 binary payload must not produce a report-status error")
+			require.Len(t, lines, 1)
+			require.Equal(t, byte(0x01), lines[0][0], "channel byte must be preserved on the returned line")
+		})
+	}
 
-	t.Run("side-band unpack failure triggers unpack error", func(t *testing.T) {
-		t.Parallel()
-		_, err := parseAll(wrap("unpack index-pack failed\n"))
-		require.Error(t, err)
-		require.True(t, protocol.IsGitUnpackError(err),
-			"expected GitUnpackError, got %T: %v", err, err)
-		var unpackErr *protocol.GitUnpackError
-		require.ErrorAs(t, err, &unpackErr)
-		require.Equal(t, "index-pack failed\n", unpackErr.Message)
-	})
-
-	t.Run("side-band channel 2 progress still treated as regular", func(t *testing.T) {
+	t.Run("channel 2 progress still treated as regular", func(t *testing.T) {
 		t.Parallel()
 		// Progress messages (channel 2) that are NOT error:/fatal: are
 		// returned as regular data lines, not errors. This guards the

--- a/protocol/pack_test.go
+++ b/protocol/pack_test.go
@@ -692,3 +692,161 @@ func TestParsePackNewErrorTypes(t *testing.T) {
 		require.Equal(t, " unpack failed", unpackErr.Message)
 	})
 }
+
+// TestParsePack_UnpackTrailingWhitespace covers bug-fix: "unpack ok\n"
+// and "unpack ok\r\n" (with trailing whitespace permitted by
+// gitprotocol-common) must be accepted as success, not rejected as
+// GitUnpackError{Message: "ok\n"}. Real-world servers (Gitea, GitHub)
+// include a trailing LF on the report-status sentinel, especially when
+// side-band is disabled.
+func TestParsePack_UnpackTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	// parseAll drains parser.Next() until EOF or a non-EOF error.
+	parseAll := func(data []byte) ([][]byte, error) {
+		parser := protocol.NewParser(bytes.NewReader(data))
+		var lines [][]byte
+		for {
+			line, err := parser.Next()
+			if err != nil {
+				if err == io.EOF {
+					return lines, nil
+				}
+				return lines, err
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	pkt := func(s string) []byte {
+		b, err := protocol.PackLine(s).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+
+	tests := []struct {
+		name        string
+		input       []byte
+		wantErr     bool
+		wantMessage string // for GitUnpackError cases
+	}{
+		{
+			name:    "unpack ok no trailing newline",
+			input:   pkt("unpack ok"),
+			wantErr: false,
+		},
+		{
+			name:    "unpack ok with LF",
+			input:   pkt("unpack ok\n"),
+			wantErr: false,
+		},
+		{
+			name:    "unpack ok with CRLF",
+			input:   pkt("unpack ok\r\n"),
+			wantErr: false,
+		},
+		{
+			name:    "unpack ok with trailing spaces",
+			input:   pkt("unpack ok  \n"),
+			wantErr: false,
+		},
+		{
+			name:        "unpack failure with trailing LF",
+			input:       pkt("unpack index-pack failed\n"),
+			wantErr:     true,
+			wantMessage: "index-pack failed\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseAll(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.True(t, protocol.IsGitUnpackError(err),
+					"expected GitUnpackError, got %T: %v", err, err)
+				var unpackErr *protocol.GitUnpackError
+				require.ErrorAs(t, err, &unpackErr)
+				require.Equal(t, tt.wantMessage, unpackErr.Message)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestParsePack_SideBandChannel1 covers bug-fix: some Git servers
+// (notably some GitLab configurations) wrap the report-status
+// payload in side-band channel 1 (leading 0x01 byte). The parser
+// MUST unwrap that channel byte before matching "ng", "unpack",
+// etc., otherwise push failures are silently treated as
+// "regular data" and the push appears to succeed.
+func TestParsePack_SideBandChannel1(t *testing.T) {
+	t.Parallel()
+
+	parseAll := func(data []byte) ([][]byte, error) {
+		parser := protocol.NewParser(bytes.NewReader(data))
+		var lines [][]byte
+		for {
+			line, err := parser.Next()
+			if err != nil {
+				if err == io.EOF {
+					return lines, nil
+				}
+				return lines, err
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	wrap := func(payload string) []byte {
+		// 0x01 + payload as a single pkt-line
+		body := append([]byte{0x01}, []byte(payload)...)
+		b, err := protocol.PackLine(body).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("side-band ng triggers reference update error", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseAll(wrap("ng refs/heads/main pre-receive hook declined\n"))
+		require.Error(t, err)
+		require.True(t, protocol.IsGitReferenceUpdateError(err),
+			"expected GitReferenceUpdateError, got %T: %v", err, err)
+		var refErr *protocol.GitReferenceUpdateError
+		require.ErrorAs(t, err, &refErr)
+		require.Equal(t, "refs/heads/main", refErr.RefName)
+		require.Equal(t, "pre-receive hook declined", refErr.Reason)
+	})
+
+	t.Run("side-band unpack ok is accepted as success", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseAll(wrap("unpack ok\n"))
+		require.NoError(t, err, "side-band-wrapped 'unpack ok' must not produce an error")
+	})
+
+	t.Run("side-band unpack failure triggers unpack error", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseAll(wrap("unpack index-pack failed\n"))
+		require.Error(t, err)
+		require.True(t, protocol.IsGitUnpackError(err),
+			"expected GitUnpackError, got %T: %v", err, err)
+		var unpackErr *protocol.GitUnpackError
+		require.ErrorAs(t, err, &unpackErr)
+		require.Equal(t, "index-pack failed\n", unpackErr.Message)
+	})
+
+	t.Run("side-band channel 2 progress still treated as regular", func(t *testing.T) {
+		t.Parallel()
+		// Progress messages (channel 2) that are NOT error:/fatal: are
+		// returned as regular data lines, not errors. This guards the
+		// existing behavior for side-band channel 2 progress output.
+		body := append([]byte{0x02}, []byte("Counting objects: 100% (5/5), done.\n")...)
+		b, err := protocol.PackLine(body).Marshal()
+		require.NoError(t, err)
+		_, err = parseAll(b)
+		require.NoError(t, err)
+	})
+}

--- a/refs_test.go
+++ b/refs_test.go
@@ -415,7 +415,9 @@ func TestCreateRef(t *testing.T) {
 						// Emit a minimal successful report-status so the
 						// client-side positive-validation check in
 						// ReceivePack is satisfied.
-						_, _ = w.Write(reportStatusUnpackOk())
+						if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
+							t.Errorf("failed to write response: %v", err)
+						}
 						return
 					}
 					t.Errorf("unexpected request path: %s", r.URL.Path)
@@ -469,7 +471,9 @@ func TestCreateRef_WithReceivePackCapabilities(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			// Emit a minimal successful report-status so the client-side
 			// positive-validation check in ReceivePack is satisfied.
-			_, _ = w.Write(reportStatusUnpackOk())
+			if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
+				t.Errorf("failed to write response: %v", err)
+			}
 		default:
 			t.Errorf("unexpected request path: %s", r.URL.Path)
 		}
@@ -642,15 +646,19 @@ func handleReceivePackRequest(t *testing.T, w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusOK)
 	// Emit a minimal successful report-status ("unpack ok" + flush) so
 	// ReceivePack's positive-validation check is satisfied.
-	if _, err := w.Write(reportStatusUnpackOk()); err != nil {
+	if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
 		t.Errorf("failed to write response: %v", err)
 	}
 }
 
 // reportStatusUnpackOk builds a minimal valid receive-pack report-status
 // response consisting of a single "unpack ok" pkt-line followed by a flush.
-func reportStatusUnpackOk() []byte {
-	pkt, _ := protocol.FormatPacks(protocol.PackLine("unpack ok\n"))
+// Surfaces any FormatPacks failure via t.Helper / require.NoError instead
+// of silently discarding it.
+func reportStatusUnpackOk(t *testing.T) []byte {
+	t.Helper()
+	pkt, err := protocol.FormatPacks(protocol.PackLine("unpack ok\n"))
+	require.NoError(t, err)
 	return pkt
 }
 
@@ -849,7 +857,7 @@ func handleDeleteRefReceivePack(t *testing.T, w http.ResponseWriter, r *http.Req
 	w.WriteHeader(http.StatusOK)
 	// Emit a minimal successful report-status so the client-side
 	// positive-validation check in ReceivePack is satisfied.
-	if _, err := w.Write(reportStatusUnpackOk()); err != nil {
+	if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
 		t.Errorf("failed to write response: %v", err)
 	}
 }

--- a/refs_test.go
+++ b/refs_test.go
@@ -412,12 +412,7 @@ func TestCreateRef(t *testing.T) {
 							}
 						}
 						w.WriteHeader(http.StatusOK)
-						// Emit a minimal successful report-status so the
-						// client-side positive-validation check in
-						// ReceivePack is satisfied.
-						if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
-							t.Errorf("failed to write response: %v", err)
-						}
+						writeReportStatusUnpackOk(t, w)
 						return
 					}
 					t.Errorf("unexpected request path: %s", r.URL.Path)
@@ -469,11 +464,7 @@ func TestCreateRef_WithReceivePackCapabilities(t *testing.T) {
 			require.NoError(t, err)
 			gotBody = body
 			w.WriteHeader(http.StatusOK)
-			// Emit a minimal successful report-status so the client-side
-			// positive-validation check in ReceivePack is satisfied.
-			if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
-				t.Errorf("failed to write response: %v", err)
-			}
+			writeReportStatusUnpackOk(t, w)
 		default:
 			t.Errorf("unexpected request path: %s", r.URL.Path)
 		}
@@ -644,22 +635,21 @@ func handleReceivePackRequest(t *testing.T, w http.ResponseWriter, r *http.Reque
 		validateReceivePackBody(t, r, tt)
 	}
 	w.WriteHeader(http.StatusOK)
-	// Emit a minimal successful report-status ("unpack ok" + flush) so
-	// ReceivePack's positive-validation check is satisfied.
-	if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
-		t.Errorf("failed to write response: %v", err)
-	}
+	writeReportStatusUnpackOk(t, w)
 }
 
-// reportStatusUnpackOk builds a minimal valid receive-pack report-status
-// response consisting of a single "unpack ok" pkt-line followed by a flush.
-// Surfaces any FormatPacks failure via t.Helper / require.NoError instead
-// of silently discarding it.
-func reportStatusUnpackOk(t *testing.T) []byte {
+// writeReportStatusUnpackOk emits a minimal valid receive-pack report-
+// status response (a single "unpack ok" pkt-line followed by a flush)
+// onto w and surfaces both pkt-line marshal failures and write failures
+// to the test, so handlers can satisfy ReceivePack's positive-validation
+// check in one line without inflating their cyclomatic complexity.
+func writeReportStatusUnpackOk(t *testing.T, w http.ResponseWriter) {
 	t.Helper()
 	pkt, err := protocol.FormatPacks(protocol.PackLine("unpack ok\n"))
 	require.NoError(t, err)
-	return pkt
+	if _, err := w.Write(pkt); err != nil {
+		t.Errorf("failed to write response: %v", err)
+	}
 }
 
 // validateReceivePackBody validates the request body for receive-pack requests
@@ -855,11 +845,7 @@ func handleDeleteRefReceivePack(t *testing.T, w http.ResponseWriter, r *http.Req
 		validateDeleteRefBody(t, r, tt)
 	}
 	w.WriteHeader(http.StatusOK)
-	// Emit a minimal successful report-status so the client-side
-	// positive-validation check in ReceivePack is satisfied.
-	if _, err := w.Write(reportStatusUnpackOk(t)); err != nil {
-		t.Errorf("failed to write response: %v", err)
-	}
+	writeReportStatusUnpackOk(t, w)
 }
 
 // validateDeleteRefBody validates the request body for delete ref requests

--- a/refs_test.go
+++ b/refs_test.go
@@ -412,6 +412,10 @@ func TestCreateRef(t *testing.T) {
 							}
 						}
 						w.WriteHeader(http.StatusOK)
+						// Emit a minimal successful report-status so the
+						// client-side positive-validation check in
+						// ReceivePack is satisfied.
+						_, _ = w.Write(reportStatusUnpackOk())
 						return
 					}
 					t.Errorf("unexpected request path: %s", r.URL.Path)
@@ -463,6 +467,9 @@ func TestCreateRef_WithReceivePackCapabilities(t *testing.T) {
 			require.NoError(t, err)
 			gotBody = body
 			w.WriteHeader(http.StatusOK)
+			// Emit a minimal successful report-status so the client-side
+			// positive-validation check in ReceivePack is satisfied.
+			_, _ = w.Write(reportStatusUnpackOk())
 		default:
 			t.Errorf("unexpected request path: %s", r.URL.Path)
 		}
@@ -633,6 +640,18 @@ func handleReceivePackRequest(t *testing.T, w http.ResponseWriter, r *http.Reque
 		validateReceivePackBody(t, r, tt)
 	}
 	w.WriteHeader(http.StatusOK)
+	// Emit a minimal successful report-status ("unpack ok" + flush) so
+	// ReceivePack's positive-validation check is satisfied.
+	if _, err := w.Write(reportStatusUnpackOk()); err != nil {
+		t.Errorf("failed to write response: %v", err)
+	}
+}
+
+// reportStatusUnpackOk builds a minimal valid receive-pack report-status
+// response consisting of a single "unpack ok" pkt-line followed by a flush.
+func reportStatusUnpackOk() []byte {
+	pkt, _ := protocol.FormatPacks(protocol.PackLine("unpack ok\n"))
+	return pkt
 }
 
 // validateReceivePackBody validates the request body for receive-pack requests
@@ -828,6 +847,11 @@ func handleDeleteRefReceivePack(t *testing.T, w http.ResponseWriter, r *http.Req
 		validateDeleteRefBody(t, r, tt)
 	}
 	w.WriteHeader(http.StatusOK)
+	// Emit a minimal successful report-status so the client-side
+	// positive-validation check in ReceivePack is satisfied.
+	if _, err := w.Write(reportStatusUnpackOk()); err != nil {
+		t.Errorf("failed to write response: %v", err)
+	}
 }
 
 // validateDeleteRefBody validates the request body for delete ref requests

--- a/tests/providers_integration_test.go
+++ b/tests/providers_integration_test.go
@@ -830,3 +830,105 @@ func TestProvidersCompatibility(t *testing.T) {
 
 	t.Logf("Provider confirmed to support Git protocol v2")
 }
+
+// TestProvidersWithoutSideBand exercises the full create-branch +
+// staged-writer push flow against a real Git provider with side-band-64k
+// dropped from the advertised receive-pack capabilities. This is the
+// configuration that #269's WithoutPushSideBand option produces and is
+// the path that historically tickled the GitLab "empty branch" silent-
+// failure on servers that wrap report-status in side-band channel 1.
+//
+// Local httptest-based unit tests cover the parser logic in isolation;
+// this test only runs in the provider CI matrix (GitHub / GitLab /
+// Bitbucket) because real provider behaviour for non-default capability
+// sets cannot be reproduced offline. A regression here will surface as
+// a failed CI job, not a flake in local runs.
+func TestProvidersWithoutSideBand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping testproviders suite in short mode")
+		return
+	}
+
+	if os.Getenv("TEST_REPO") == "" || os.Getenv("TEST_TOKEN") == "" || os.Getenv("TEST_USER") == "" {
+		t.Skip("Skipping testproviders suite: TEST_REPO or TEST_TOKEN or TEST_USER not set")
+		return
+	}
+
+	// Default receive-pack set minus side-band-64k. Callers must spell
+	// out every capability they want on the wire — there is no
+	// "subtract" sugar. Mirrors the noSideBandCaps used in the local
+	// httptest integration suite.
+	noSideBandCaps := []protocol.Capability{
+		protocol.CapReportStatusV2,
+		protocol.CapQuiet,
+		protocol.CapObjectFormatSHA1,
+		protocol.CapAgent("nanogit"),
+	}
+
+	ctx := log.ToContext(context.Background(), gittest.NewStructuredLogger(gittest.NewTestLogger(t)))
+	client, err := nanogit.NewHTTPClient(
+		os.Getenv("TEST_REPO"),
+		options.WithBasicAuth(os.Getenv("TEST_USER"), os.Getenv("TEST_TOKEN")),
+		options.WithReceivePackCapabilities(noSideBandCaps...),
+	)
+	require.NoError(t, err)
+
+	mainRef, err := client.GetRef(ctx, "refs/heads/main")
+	require.NoError(t, err)
+
+	branchName := fmt.Sprintf("test-no-sideband-%d", time.Now().Unix())
+	fullBranch := "refs/heads/" + branchName
+
+	t.Logf("Creating branch %s pointing at main HEAD %s", fullBranch, mainRef.Hash)
+	require.NoError(t, client.CreateRef(ctx, nanogit.Ref{
+		Name: fullBranch,
+		Hash: mainRef.Hash,
+	}))
+	t.Cleanup(func() {
+		if err := client.DeleteRef(ctx, fullBranch); err != nil {
+			t.Logf("cleanup: failed to delete %s: %v", fullBranch, err)
+		}
+	})
+
+	branchRef, err := client.GetRef(ctx, fullBranch)
+	require.NoError(t, err)
+
+	writer, err := client.NewStagedWriter(ctx, branchRef)
+	require.NoError(t, err)
+
+	author := nanogit.Author{Name: "John Doe", Email: "john.doe@example.com", Time: time.Now()}
+	committer := nanogit.Committer{Name: "John Doe", Email: "john.doe@example.com", Time: time.Now()}
+
+	blobPath := "no-sideband-test.txt"
+	blobContent := []byte("content pushed without side-band-64k")
+	_, err = writer.CreateBlob(ctx, blobPath, blobContent)
+	require.NoError(t, err)
+
+	commit, err := writer.Commit(ctx, "no-sideband: add test file", author, committer)
+	require.NoError(t, err)
+	require.NotNil(t, commit)
+
+	t.Logf("Pushing commit %s to %s without side-band-64k", commit.Hash, fullBranch)
+	require.NoError(t, writer.Push(ctx),
+		"push without side-band-64k must succeed against the provider; "+
+			"a failure here means the server rejected the capability set or returned a "+
+			"report-status the client could not parse")
+
+	// Critical assertion: the branch must actually advance past main.
+	// If the push was silently swallowed (the historical empty-branch
+	// shape), the ref would still point at main HEAD with no error.
+	pushedRef, err := client.GetRef(ctx, fullBranch)
+	require.NoError(t, err)
+	require.Equal(t, commit.Hash, pushedRef.Hash,
+		"branch must advance to the new commit; if it equals main the push was silently swallowed")
+	require.NotEqual(t, mainRef.Hash, pushedRef.Hash,
+		"branch must advance past main; an unchanged hash here is the empty-branch silent-failure shape")
+
+	// Also verify the blob is reachable from the new commit, so we
+	// know the packfile was actually accepted (not just the ref move).
+	pushedCommit, err := client.GetCommit(ctx, pushedRef.Hash)
+	require.NoError(t, err)
+	pushedBlob, err := client.GetBlobByPath(ctx, pushedCommit.Tree, blobPath)
+	require.NoError(t, err, "pushed blob must be reachable from the new commit's tree")
+	require.Equal(t, string(blobContent), string(pushedBlob.Content))
+}

--- a/tests/push_sideband_integration_test.go
+++ b/tests/push_sideband_integration_test.go
@@ -1,0 +1,214 @@
+package integration_test
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/grafana/nanogit/options"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// noSideBandCaps is the default receive-pack capability set minus
+// side-band-64k. Without side-band, the server sends report-status packets
+// directly (no channel prefix) which historically made failure detection
+// reliable on servers that wrap them in side-band channel 1 (notably some
+// GitLab configurations). The parser fix in this PR handles the wrapped
+// case, but the no-side-band path is still exercised end-to-end here.
+var noSideBandCaps = []protocol.Capability{
+	protocol.CapReportStatusV2,
+	protocol.CapQuiet,
+	protocol.CapObjectFormatSHA1,
+	protocol.CapAgent("nanogit"),
+}
+
+// These tests exercise push flows with the side-band-64k capability
+// disabled against a real Git server. They verify that dropping "side-band-64k"
+// from the advertised receive-pack capabilities does not regress functional
+// behavior for CreateRef, UpdateRef, DeleteRef, or StagedWriter.Push.
+var _ = Describe("Push without side-band capability", func() {
+	author := nanogit.Author{Name: "Test Author", Email: "test@example.com", Time: time.Now()}
+	committer := nanogit.Committer{Name: "Test Committer", Email: "test@example.com", Time: time.Now()}
+
+	Context("CreateRef / UpdateRef / DeleteRef", func() {
+		var (
+			client      nanogit.Client
+			local       *gittest.LocalRepo
+			firstCommit hash.Hash
+		)
+
+		BeforeEach(func() {
+			By("Setting up repo with side-band-64k disabled")
+			client, _, local, _ = QuickSetup(options.WithReceivePackCapabilities(noSideBandCaps...))
+
+			By("Publishing initial main branch")
+			_, err := local.Git("branch", "-M", "main")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = local.Git("push", "-u", "origin", "main", "--force")
+			Expect(err).NotTo(HaveOccurred())
+
+			firstCommitStr, err := local.Git("rev-parse", "HEAD")
+			Expect(err).NotTo(HaveOccurred())
+			firstCommit, err = hash.FromHex(firstCommitStr)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates, updates, and deletes a ref end-to-end", func() {
+			refName := "refs/heads/no-sideband-ref-lifecycle"
+
+			By("Creating the branch ref")
+			Expect(client.CreateRef(ctx, nanogit.Ref{Name: refName, Hash: firstCommit})).To(Succeed())
+
+			created, err := client.GetRef(ctx, refName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(created.Hash).To(Equal(firstCommit))
+
+			By("Making a new commit on main and pushing it")
+			_, err = local.Git("commit", "--allow-empty", "-m", "no-sideband: second commit")
+			Expect(err).NotTo(HaveOccurred())
+			newHashStr, err := local.Git("rev-parse", "HEAD")
+			Expect(err).NotTo(HaveOccurred())
+			newHash, err := hash.FromHex(newHashStr)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = local.Git("push", "origin", "main", "--force")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Updating the ref to the new commit")
+			Expect(client.UpdateRef(ctx, nanogit.Ref{Name: refName, Hash: newHash})).To(Succeed())
+
+			updated, err := client.GetRef(ctx, refName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Hash).To(Equal(newHash))
+
+			By("Deleting the ref")
+			Expect(client.DeleteRef(ctx, refName)).To(Succeed())
+
+			_, err = client.GetRef(ctx, refName)
+			var notFoundErr *nanogit.RefNotFoundError
+			Expect(err).To(HaveOccurred())
+			Expect(errors.As(err, &notFoundErr)).To(BeTrue())
+		})
+	})
+
+	Context("StagedWriter push", func() {
+		It("pushes a new commit to an existing branch", func() {
+			client, _, local, _ := QuickSetup(options.WithReceivePackCapabilities(noSideBandCaps...))
+
+			_, err := local.Git("branch", "-M", "main")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = local.Git("push", "-u", "origin", "main", "--force")
+			Expect(err).NotTo(HaveOccurred())
+
+			mainRef, err := client.GetRef(ctx, "refs/heads/main")
+			Expect(err).NotTo(HaveOccurred())
+
+			writer, err := client.NewStagedWriter(ctx, mainRef)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.CreateBlob(ctx, "no-sideband.txt", []byte("hello from nanogit"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.Commit(ctx, "no-sideband: add file", author, committer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(writer.Push(ctx)).To(Succeed())
+
+			By("Confirming the commit reached the remote and contains the file")
+			_, err = local.Git("fetch", "origin", "main")
+			Expect(err).NotTo(HaveOccurred())
+			remoteTree, err := local.Git("ls-tree", "-r", "--name-only", "origin/main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Split(strings.TrimSpace(remoteTree), "\n")).To(ContainElement("no-sideband.txt"))
+		})
+
+		// This is the exact flow that produced empty branches for GitLab users
+		// in grafana/grafana: ensureBranchExists creates a new branch via
+		// CreateRef pointing at the source branch HEAD, and then the staged
+		// writer pushes a new commit onto that branch. When the Push was
+		// silently swallowed (side-band-wrapped "ng" packet), the branch was
+		// left pointing at the source HEAD with no new commit — exactly the
+		// "empty branch" symptom.
+		It("creates a new branch then pushes a commit onto it", func() {
+			client, _, local, _ := QuickSetup(options.WithReceivePackCapabilities(noSideBandCaps...))
+
+			_, err := local.Git("branch", "-M", "main")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = local.Git("push", "-u", "origin", "main", "--force")
+			Expect(err).NotTo(HaveOccurred())
+
+			mainRef, err := client.GetRef(ctx, "refs/heads/main")
+			Expect(err).NotTo(HaveOccurred())
+
+			branchName := "refs/heads/no-sideband-new-branch"
+			By("Creating a new branch ref pointing at main's HEAD")
+			Expect(client.CreateRef(ctx, nanogit.Ref{Name: branchName, Hash: mainRef.Hash})).To(Succeed())
+
+			By("Staging a blob, committing, and pushing to the new branch")
+			writer, err := client.NewStagedWriter(ctx, nanogit.Ref{Name: branchName, Hash: mainRef.Hash})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.CreateBlob(ctx, "from-new-branch.txt", []byte("committed on a fresh branch"))
+			Expect(err).NotTo(HaveOccurred())
+
+			commit, err := writer.Commit(ctx, "no-sideband: add file on new branch", author, committer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commit).NotTo(BeNil())
+
+			Expect(writer.Push(ctx)).To(Succeed())
+
+			By("Verifying the new branch advanced past main (no empty branch)")
+			remoteRef, err := client.GetRef(ctx, branchName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(remoteRef.Hash).NotTo(Equal(mainRef.Hash),
+				"branch must advance past the source ref; if it equals main, the push was silently swallowed")
+			Expect(remoteRef.Hash).To(Equal(commit.Hash))
+
+			By("Confirming the staged file is present on the new branch in the remote")
+			_, err = local.Git("fetch", "origin", strings.TrimPrefix(branchName, "refs/heads/"))
+			Expect(err).NotTo(HaveOccurred())
+			remoteTree, err := local.Git("ls-tree", "-r", "--name-only",
+				"origin/"+strings.TrimPrefix(branchName, "refs/heads/"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Split(strings.TrimSpace(remoteTree), "\n")).To(ContainElement("from-new-branch.txt"))
+		})
+	})
+
+	Context("Default behavior (side-band enabled) is unchanged", func() {
+		// Sanity check that the baseline flow still works without the option
+		// and that the same new-branch flow also succeeds. This is a
+		// regression guard for clients that do not opt into the workaround.
+		It("creates a branch and pushes onto it with side-band enabled", func() {
+			client, _, local, _ := QuickSetup() // defaults include side-band-64k
+
+			_, err := local.Git("branch", "-M", "main")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = local.Git("push", "-u", "origin", "main", "--force")
+			Expect(err).NotTo(HaveOccurred())
+
+			mainRef, err := client.GetRef(ctx, "refs/heads/main")
+			Expect(err).NotTo(HaveOccurred())
+
+			branchName := "refs/heads/default-sideband-new-branch"
+			Expect(client.CreateRef(ctx, nanogit.Ref{Name: branchName, Hash: mainRef.Hash})).To(Succeed())
+
+			writer, err := client.NewStagedWriter(ctx, nanogit.Ref{Name: branchName, Hash: mainRef.Hash})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = writer.CreateBlob(ctx, "default.txt", []byte("default side-band flow"))
+			Expect(err).NotTo(HaveOccurred())
+			commit, err := writer.Commit(ctx, "default: add file on new branch", author, committer)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(writer.Push(ctx)).To(Succeed())
+
+			remoteRef, err := client.GetRef(ctx, branchName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(remoteRef.Hash).To(Equal(commit.Hash))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Stacked on #269. Fixes the actual root cause of the GitLab "empty branch" bug that #269 worked around, and fixes a trailing-newline bug that made #269's integration tests red.

## Bugs fixed

### 1. `unpack ok\n` misread as failure (blocker for #269)

`detectError` in `protocol/pack.go` compared byte-exact against `"unpack ok"` / `"ok"`, so Gitea's `unpack ok\n` (trailing newline) became `GitUnpackError{Message: "ok\n"}` — turning every `WithoutPushSideBand()` push into a failure.

**Fix:** trim trailing whitespace on the unpack status before equality checks.

### 2. Side-band channel 1 not unwrapped — the real empty-branch root cause

Servers that wrap `report-status` in side-band channel 1 (`\x01...`) — notably some GitLab configurations — produced silent-success on push failures: `detectError` matched `ng`/`unpack` prefixes on the raw packet, saw the `\x01` byte instead, and fell through as "regular data." Push rejections from pre-receive hooks or push rules were swallowed and the branch was left at the source HEAD with no new commit (the exact "empty branch" symptom reported by grafana/grafana GitLab users).

**Fixes:**
- `protocol/client.parseReceivePackResponse` does the channel-1 unwrap (scoped to receive-pack response parsing — the generic `detectError` deliberately leaves channel 1 alone because it also carries binary packfile data on fetch/clone via `MultiplexedReader`).
- **Channel-1 reassembly is byte-stream**, not packet-bounded. Side-band framing per the spec is a chunked byte stream over the outer pkt-line layer, so the inner content (whether nested pkt-lines or raw text) can be split arbitrarily across outer packets — including in the middle of `unpack ok` or `ng <ref>`. We accumulate channel-1 payloads, run format detection on the first 4 bytes (peeking across packets so a fragmented inner pkt-line length header still classifies as nested), then process the concatenated stream.
- Format auto-detection picks between two on-wire encodings:
  - **Nested** (real-world Git servers — git-core, JGit, libgit2): channel-1 payload is itself a chunked pkt-line stream — concatenated and re-parsed via `protocol.NewParser`.
  - **Raw** (hypothetical / non-conformant): channel-1 payload is literal text — split on LF.
- **Trade-off in raw mode**: distinct report-status lines without an LF separator merge into a single line. Per `gitprotocol-common`, non-binary report-status lines SHOULD be LF-terminated; a non-conformant server that omits separators surfaces as a typed parser error (typically `GitUnpackError` if the merged line begins with `unpack `, otherwise `ErrMissingReportStatus`) rather than silently misclassifying. The alternative — preserving outer packet boundaries — would handle no-LF cases but would misclassify legitimate mid-token splits (e.g. `unpack o` + `k\n`) as failures, which is the path real chunked servers actually use.
- `ReceivePack` requires an explicit `unpack ok` **only when the body is non-trivial**. Empty / flush-only bodies and channel-2-progress-only bodies are accepted silently so callers that legitimately drop `report-status` / `report-status-v2` from their negotiated capabilities (via `WithReceivePackCapabilities`) don't hit a false failure. Non-trivial channel-0 / channel-1 content that lacks `unpack ok` returns `ErrMissingReportStatus`, which is exactly the silent-failure shape the customer's GitLab repo exhibited.
- Channel-3 fatal payloads that don't match `fatal:` / `error:` (an abrupt termination from the host) are now surfaced as `GitServerError` rather than silently dropped.

## Changes

- `protocol/pack.go` — trailing-whitespace tolerance on `unpack ok`. Channel-1 unwrap is intentionally NOT done here (see above).
- `protocol/client/receivepack.go` — channel-1 byte-stream reassembly, format auto-detection (with cross-packet header peeking), conditional `unpack ok` enforcement, channel-3 surfacing.
- `protocol/pack_test.go`, `protocol/client/receivepack_test.go` — unit tests covering: trailing whitespace, channel-1 not misclassified as report-status in fetch/clone, both side-band encodings, mid-token line splits, fragmented inner length headers, channel-3 fatal surfacing, no-report-status acceptance, and the silent-failure regression.
- `refs_test.go` — existing fakes updated to emit minimal valid report-status via a shared `writeReportStatusUnpackOk` helper.
- `tests/providers_integration_test.go` — `TestProvidersWithoutSideBand` exercises the create-branch + push flow against real providers (GitHub / GitLab / Bitbucket) with `side-band-64k` dropped from advertised capabilities.

## Testing

- `make test-unit` — passes
- `make lint` — 0 issues
- `make test-integration` — passes including the "Push without side-band capability" specs from #269 and the side-band-enabled regression guard
- `make test-providers` — runs the new no-side-band specs in CI (skipped locally without provider credentials)

## Follow-up consideration

Once this lands, the `WithoutPushSideBand()` option from #269 is no longer required to work around the GitLab empty-branch issue — but it remains useful as an escape hatch and its integration tests stay valid. No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)