### PR TITLE
feat(cli): add NANOGIT_REPO env var for default repository URL

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -80,6 +80,20 @@ NANOGIT_TRACE=1 nanogit clone https://github.com/grafana/nanogit.git ./tmp
 nanogit -v --json ls-tree https://github.com/grafana/nanogit.git main
 ```
 
+### Default repository
+
+Set `NANOGIT_REPO` once to avoid repeating the repository URL on every command. When it is set, the `<repository>` positional argument becomes optional; pass an explicit URL to override.
+
+```bash
+export NANOGIT_REPO=https://github.com/user/repo.git
+nanogit check
+nanogit ls-tree main
+echo "hi" | nanogit put-file main note.md -m "add note"
+nanogit cat-file main note.md
+```
+
+For `clone`, a single positional argument is treated as the destination path unless it looks like a URL (contains `://`).
+
 ### Authentication
 
 For private repositories, use the `--token` flag or set the `NANOGIT_TOKEN` environment variable:

--- a/cli/cmd/nanogit/cat_file.go
+++ b/cli/cmd/nanogit/cat_file.go
@@ -15,16 +15,21 @@ func init() {
 }
 
 var catFileCmd = &cobra.Command{
-	Use:   "cat-file <repository> <ref> <path>",
+	Use:   "cat-file [<repository>] <ref> <path>",
 	Short: "Display the contents of a file",
 	Long: `Display the contents of a file from a Git repository at a specific reference.
 
 The ref can be a branch name, tag name, or commit hash.
 The path is the file path within the repository.
+The repository argument is optional when NANOGIT_REPO is set.
 
 Examples:
   # Display file contents
   nanogit cat-file https://github.com/grafana/nanogit.git main README.md
+
+  # Use NANOGIT_REPO env var instead of repeating the URL
+  export NANOGIT_REPO=https://github.com/grafana/nanogit.git
+  nanogit cat-file main README.md
 
   # Display file from a specific tag
   nanogit cat-file https://github.com/grafana/nanogit.git v1.0.0 docs/api.md
@@ -38,14 +43,14 @@ Examples:
   # With authentication
   nanogit cat-file https://github.com/user/private-repo.git main file.txt --token <token>
   NANOGIT_TOKEN=<token> nanogit cat-file https://github.com/user/private-repo.git main file.txt`,
-	Args: cobra.ExactArgs(3),
+	Args: repoArgs(3),
 	RunE: runCatFile,
 }
 
 func runCatFile(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
-	ref := args[1]
-	filePath := args[2]
+	repoURL, rest := resolveRepoURL(args, 3)
+	ref := rest[0]
+	filePath := rest[1]
 
 	ctx, client, err := setupClient(context.Background(), repoURL)
 	if err != nil {

--- a/cli/cmd/nanogit/cat_file_test.go
+++ b/cli/cmd/nanogit/cat_file_test.go
@@ -79,6 +79,7 @@ func TestCatFileCommand(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envRepo     string
 		expectError bool
 	}{
 		{
@@ -92,7 +93,7 @@ func TestCatFileCommand(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "two arguments returns error",
+			name:        "two arguments returns error without env",
 			args:        []string{"url", "ref"},
 			expectError: true,
 		},
@@ -106,6 +107,12 @@ func TestCatFileCommand(t *testing.T) {
 			args:        []string{"https://github.com/grafana/nanogit.git", "main", "README.md"},
 			expectError: false,
 		},
+		{
+			name:        "two arguments accepted when NANOGIT_REPO is set",
+			args:        []string{"main", "README.md"},
+			envRepo:     "https://github.com/grafana/nanogit.git",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -114,6 +121,8 @@ func TestCatFileCommand(t *testing.T) {
 			globalJSON = false
 			globalUsername = ""
 			globalToken = ""
+
+			t.Setenv("NANOGIT_REPO", tt.envRepo)
 
 			// Test argument validation
 			catFileCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/check.go
+++ b/cli/cmd/nanogit/check.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 var checkCmd = &cobra.Command{
-	Use:   "check <repository>",
+	Use:   "check [<repository>]",
 	Short: "Check if a Git server is compatible with nanogit",
 	Long: `Check if a Git server supports Git protocol v2, which is required by nanogit.
 
@@ -24,21 +24,27 @@ before attempting other operations. nanogit requires Git Smart HTTP Protocol v2.
 Many modern Git hosting providers support protocol v2, but some older servers or
 certain cloud providers may only support protocol v1.
 
+The repository argument is optional when NANOGIT_REPO is set.
+
 Examples:
   # Check repository compatibility
   nanogit check https://example.com/repo.git
+
+  # Use NANOGIT_REPO env var instead of repeating the URL
+  export NANOGIT_REPO=https://example.com/repo.git
+  nanogit check
 
   # Check with authentication
   nanogit check https://example.com/private-repo.git --token <token>
 
   # Output as JSON
   nanogit --json check https://example.com/repo.git`,
-	Args: cobra.ExactArgs(1),
+	Args: repoArgs(1),
 	RunE: runCheck,
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
+	repoURL, _ := resolveRepoURL(args, 1)
 
 	ctx, client, err := setupClient(context.Background(), repoURL)
 	if err != nil {

--- a/cli/cmd/nanogit/check_test.go
+++ b/cli/cmd/nanogit/check_test.go
@@ -15,10 +15,11 @@ func TestCheckCommand(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envRepo     string
 		expectError bool
 	}{
 		{
-			name:        "no arguments returns error",
+			name:        "no arguments returns error without env",
 			args:        []string{},
 			expectError: true,
 		},
@@ -32,6 +33,12 @@ func TestCheckCommand(t *testing.T) {
 			args:        []string{"https://github.com/grafana/nanogit.git"},
 			expectError: false,
 		},
+		{
+			name:        "no arguments accepted when NANOGIT_REPO is set",
+			args:        []string{},
+			envRepo:     "https://github.com/grafana/nanogit.git",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +47,8 @@ func TestCheckCommand(t *testing.T) {
 			globalJSON = false
 			globalUsername = ""
 			globalToken = ""
+
+			t.Setenv("NANOGIT_REPO", tt.envRepo)
 
 			// Test argument validation
 			checkCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/clone.go
+++ b/cli/cmd/nanogit/clone.go
@@ -10,6 +10,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// cloneArgs validates the positional arguments for `clone`. It accepts 1 or 2
+// args when NANOGIT_REPO is unset (the original behaviour) and additionally
+// allows 0 args when NANOGIT_REPO supplies the URL.
+func cloneArgs(_ *cobra.Command, args []string) error {
+	envSet := os.Getenv(repoEnv) != ""
+	switch len(args) {
+	case 0:
+		if !envSet {
+			return fmt.Errorf("accepts 1-2 arg(s), received 0 (or set %s)", repoEnv)
+		}
+		return nil
+	case 1, 2:
+		return nil
+	default:
+		return fmt.Errorf("accepts at most 2 arg(s), received %d", len(args))
+	}
+}
+
+// resolveCloneArgs picks the repo URL and destination from positional args,
+// falling back to NANOGIT_REPO. With a single positional arg and env set, the
+// URL-vs-path disambiguation uses looksLikeRepoURL.
+func resolveCloneArgs(args []string) (repoURL, dest string) {
+	env := os.Getenv(repoEnv)
+	switch len(args) {
+	case 0:
+		return env, "."
+	case 1:
+		if env != "" && !looksLikeRepoURL(args[0]) {
+			return env, args[0]
+		}
+		return args[0], "."
+	default:
+		return args[0], args[1]
+	}
+}
+
 var (
 	cloneRef         string
 	cloneInclude     []string
@@ -29,7 +65,7 @@ func init() {
 }
 
 var cloneCmd = &cobra.Command{
-	Use:   "clone <repository> [<destination>]",
+	Use:   "clone [<repository>] [<destination>]",
 	Short: "Clone a repository to a local directory",
 	Long: `Clone a repository to a local directory.
 
@@ -38,9 +74,17 @@ using the --ref flag.
 
 Supports path filtering with glob patterns to clone only specific files or directories.
 
+The repository argument is optional when NANOGIT_REPO is set. When it is set
+and a single positional argument is passed, it is treated as the destination
+path unless it looks like a URL (contains "://").
+
 Examples:
   # Clone to current directory (uses HEAD/default branch)
   nanogit clone https://github.com/grafana/nanogit.git
+
+  # Use NANOGIT_REPO env var instead of passing the URL
+  export NANOGIT_REPO=https://github.com/grafana/nanogit.git
+  nanogit clone ./my-repo
 
   # Clone to specific directory
   nanogit clone https://github.com/grafana/nanogit.git ./my-repo
@@ -56,21 +100,12 @@ Examples:
 
   # Clone with batching and concurrency for better performance
   nanogit clone https://github.com/grafana/nanogit.git ./my-repo --batch-size 100 --concurrency 20`,
-	Args: cobra.RangeArgs(1, 2),
+	Args: cloneArgs,
 	RunE: runClone,
 }
 
 func runClone(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
-
-	// Determine destination path
-	var destPath string
-	if len(args) == 2 {
-		destPath = args[1]
-	} else {
-		// Default to current directory
-		destPath = "."
-	}
+	repoURL, destPath := resolveCloneArgs(args)
 
 	// Determine ref (default to HEAD)
 	ref := cloneRef

--- a/cli/cmd/nanogit/clone_test.go
+++ b/cli/cmd/nanogit/clone_test.go
@@ -51,10 +51,11 @@ func TestCloneCommand(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envRepo     string
 		expectError bool
 	}{
 		{
-			name:        "no arguments returns error",
+			name:        "no arguments returns error without env",
 			args:        []string{},
 			expectError: true,
 		},
@@ -73,6 +74,18 @@ func TestCloneCommand(t *testing.T) {
 			args:        []string{"url", "dest", "extra"},
 			expectError: true,
 		},
+		{
+			name:        "no arguments accepted when NANOGIT_REPO is set",
+			args:        []string{},
+			envRepo:     "https://github.com/grafana/nanogit.git",
+			expectError: false,
+		},
+		{
+			name:        "destination-only accepted when NANOGIT_REPO is set",
+			args:        []string{"./my-repo"},
+			envRepo:     "https://github.com/grafana/nanogit.git",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -85,6 +98,8 @@ func TestCloneCommand(t *testing.T) {
 			cloneBatchSize = 50
 			cloneConcurrency = 10
 
+			t.Setenv("NANOGIT_REPO", tt.envRepo)
+
 			// Test argument validation
 			cloneCmd.SetArgs(tt.args)
 			err := cloneCmd.Args(cloneCmd, tt.args)
@@ -96,6 +111,43 @@ func TestCloneCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveCloneArgs(t *testing.T) {
+	t.Run("no env, single positional", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "")
+		repo, dest := resolveCloneArgs([]string{"https://example.com/repo.git"})
+		assert.Equal(t, "https://example.com/repo.git", repo)
+		assert.Equal(t, ".", dest)
+	})
+
+	t.Run("env, no positional", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+		repo, dest := resolveCloneArgs([]string{})
+		assert.Equal(t, "https://env.example.com/repo.git", repo)
+		assert.Equal(t, ".", dest)
+	})
+
+	t.Run("env, single path-like positional is destination", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+		repo, dest := resolveCloneArgs([]string{"./my-repo"})
+		assert.Equal(t, "https://env.example.com/repo.git", repo)
+		assert.Equal(t, "./my-repo", dest)
+	})
+
+	t.Run("env, single URL-like positional overrides env", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+		repo, dest := resolveCloneArgs([]string{"https://override.example.com/repo.git"})
+		assert.Equal(t, "https://override.example.com/repo.git", repo)
+		assert.Equal(t, ".", dest)
+	})
+
+	t.Run("env, two positionals always URL first", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+		repo, dest := resolveCloneArgs([]string{"https://arg.example.com/repo.git", "./dest"})
+		assert.Equal(t, "https://arg.example.com/repo.git", repo)
+		assert.Equal(t, "./dest", dest)
+	})
 }
 
 func TestCloneFlagsValidation(t *testing.T) {

--- a/cli/cmd/nanogit/common.go
+++ b/cli/cmd/nanogit/common.go
@@ -3,11 +3,54 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/grafana/nanogit"
 	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/spf13/cobra"
 )
+
+// repoEnv is the environment variable fallback for the repository URL so that
+// users can avoid repeating the URL on every command.
+const repoEnv = "NANOGIT_REPO"
+
+// resolveRepoURL returns the repository URL and the remaining positional args
+// after stripping the optional repo positional. `required` is the total number
+// of positional args expected when the repo URL is passed explicitly. When
+// len(args) equals required-1, the URL is read from NANOGIT_REPO instead.
+// Callers must pair this with repoArgs so argument counts are already
+// validated by the time this runs.
+func resolveRepoURL(args []string, required int) (string, []string) {
+	if len(args) == required {
+		return args[0], args[1:]
+	}
+	return os.Getenv(repoEnv), args
+}
+
+// repoArgs builds a cobra positional-arg validator that accepts either
+// `required` args (explicit repo URL as the first positional) or `required-1`
+// args (repo URL from NANOGIT_REPO). Commands with a variable-length tail
+// (clone, put-file) have bespoke validators and don't use this.
+func repoArgs(required int) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if len(args) == required {
+			return nil
+		}
+		if len(args) == required-1 && os.Getenv(repoEnv) != "" {
+			return nil
+		}
+		return fmt.Errorf("accepts %d arg(s), received %d (set %s to omit the <repository> argument)", required, len(args), repoEnv)
+	}
+}
+
+// looksLikeRepoURL is a coarse heuristic used by `clone` to disambiguate a
+// single positional between a repo URL and a destination path when
+// NANOGIT_REPO is set. A scheme separator (`://`) is enough to decide; any
+// string without one is treated as a path.
+func looksLikeRepoURL(s string) bool {
+	return strings.Contains(s, "://")
+}
 
 // resolveRef resolves a ref name to a commit hash.
 // It tries multiple strategies:

--- a/cli/cmd/nanogit/common_test.go
+++ b/cli/cmd/nanogit/common_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoArgsExplicit(t *testing.T) {
+	t.Setenv("NANOGIT_REPO", "")
+
+	validator := repoArgs(2)
+	require.NoError(t, validator(nil, []string{"https://example.com/repo.git", "main"}))
+
+	// Without env, missing the repo URL is an error and hints at the env var.
+	err := validator(nil, []string{"main"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), repoEnv)
+}
+
+func TestRepoArgsWithEnv(t *testing.T) {
+	t.Setenv("NANOGIT_REPO", "https://example.com/repo.git")
+
+	validator := repoArgs(2)
+	require.NoError(t, validator(nil, []string{"main"}))
+	require.NoError(t, validator(nil, []string{"https://example.com/other.git", "main"}))
+
+	require.Error(t, validator(nil, []string{}))
+	require.Error(t, validator(nil, []string{"a", "b", "c"}))
+}
+
+func TestResolveRepoURL(t *testing.T) {
+	t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+
+	// Explicit arg wins over env.
+	repoURL, rest := resolveRepoURL([]string{"https://flag.example.com/repo.git", "main"}, 2)
+	assert.Equal(t, "https://flag.example.com/repo.git", repoURL)
+	assert.Equal(t, []string{"main"}, rest)
+
+	// Env fallback when arg count is shorter.
+	repoURL, rest = resolveRepoURL([]string{"main"}, 2)
+	assert.Equal(t, "https://env.example.com/repo.git", repoURL)
+	assert.Equal(t, []string{"main"}, rest)
+}
+
+func TestLooksLikeRepoURL(t *testing.T) {
+	assert.True(t, looksLikeRepoURL("https://github.com/foo/bar.git"))
+	assert.True(t, looksLikeRepoURL("http://example.com/x"))
+	assert.False(t, looksLikeRepoURL("./my-repo"))
+	assert.False(t, looksLikeRepoURL("my-repo"))
+	assert.False(t, looksLikeRepoURL("/tmp/repo"))
+}

--- a/cli/cmd/nanogit/ls_remote.go
+++ b/cli/cmd/nanogit/ls_remote.go
@@ -24,13 +24,19 @@ func init() {
 }
 
 var lsRemoteCmd = &cobra.Command{
-	Use:   "ls-remote <repository>",
+	Use:   "ls-remote [<repository>]",
 	Short: "List references in a remote repository",
 	Long: `List references (branches and tags) from a remote Git repository.
+
+The repository argument is optional when NANOGIT_REPO is set.
 
 Examples:
   # List all references
   nanogit ls-remote https://github.com/grafana/nanogit.git
+
+  # Use NANOGIT_REPO env var instead of repeating the URL
+  export NANOGIT_REPO=https://github.com/grafana/nanogit.git
+  nanogit ls-remote
 
   # List only branches
   nanogit ls-remote https://github.com/grafana/nanogit.git --heads
@@ -48,12 +54,12 @@ Examples:
   # With custom username
   nanogit ls-remote https://github.com/user/private-repo.git --username myuser --token <token>
   NANOGIT_USERNAME=myuser NANOGIT_TOKEN=<token> nanogit ls-remote https://github.com/user/private-repo.git`,
-	Args: cobra.ExactArgs(1),
+	Args: repoArgs(1),
 	RunE: runLsRemote,
 }
 
 func runLsRemote(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
+	repoURL, _ := resolveRepoURL(args, 1)
 
 	ctx, client, err := setupClient(context.Background(), repoURL)
 	if err != nil {

--- a/cli/cmd/nanogit/ls_remote_test.go
+++ b/cli/cmd/nanogit/ls_remote_test.go
@@ -158,10 +158,11 @@ func TestLsRemoteCommand(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envRepo     string
 		expectError bool
 	}{
 		{
-			name:        "no arguments returns error",
+			name:        "no arguments returns error without env",
 			args:        []string{},
 			expectError: true,
 		},
@@ -175,6 +176,12 @@ func TestLsRemoteCommand(t *testing.T) {
 			args:        []string{"https://github.com/grafana/nanogit"},
 			expectError: false, // Will fail when trying to connect, but args validation passes
 		},
+		{
+			name:        "no arguments accepted when NANOGIT_REPO is set",
+			args:        []string{},
+			envRepo:     "https://github.com/grafana/nanogit",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +192,8 @@ func TestLsRemoteCommand(t *testing.T) {
 			globalJSON = false
 			globalToken = ""
 			globalUsername = ""
+
+			t.Setenv("NANOGIT_REPO", tt.envRepo)
 
 			// Test argument validation
 			lsRemoteCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/ls_tree.go
+++ b/cli/cmd/nanogit/ls_tree.go
@@ -28,16 +28,21 @@ func init() {
 }
 
 var lsTreeCmd = &cobra.Command{
-	Use:   "ls-tree <repository> <ref>",
+	Use:   "ls-tree [<repository>] <ref>",
 	Short: "List the contents of a tree object",
 	Long: `List the contents of a tree object from a Git repository at a specific reference.
 
 The ref can be a branch name, tag name, or commit hash.
 By default, shows mode, type, hash, and name for each entry (like git ls-tree).
+The repository argument is optional when NANOGIT_REPO is set.
 
 Examples:
   # List files at root (shows mode, type, hash, name)
   nanogit ls-tree https://github.com/grafana/nanogit.git main
+
+  # Use NANOGIT_REPO env var instead of repeating the URL
+  export NANOGIT_REPO=https://github.com/grafana/nanogit.git
+  nanogit ls-tree main
 
   # List files in a specific directory
   nanogit ls-tree https://github.com/grafana/nanogit.git main --path docs
@@ -50,13 +55,13 @@ Examples:
 
   # Output as JSON
   nanogit --json ls-tree https://github.com/grafana/nanogit.git main`,
-	Args: cobra.ExactArgs(2),
+	Args: repoArgs(2),
 	RunE: runLsTree,
 }
 
 func runLsTree(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
-	ref := args[1]
+	repoURL, rest := resolveRepoURL(args, 2)
+	ref := rest[0]
 
 	ctx, client, err := setupClient(context.Background(), repoURL)
 	if err != nil {

--- a/cli/cmd/nanogit/ls_tree_test.go
+++ b/cli/cmd/nanogit/ls_tree_test.go
@@ -266,6 +266,7 @@ func TestLsTreeCommand(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envRepo     string
 		expectError bool
 	}{
 		{
@@ -274,7 +275,7 @@ func TestLsTreeCommand(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "one argument returns error",
+			name:        "one argument returns error without env",
 			args:        []string{"url"},
 			expectError: true,
 		},
@@ -288,6 +289,12 @@ func TestLsTreeCommand(t *testing.T) {
 			args:        []string{"https://github.com/grafana/nanogit.git", "main"},
 			expectError: false,
 		},
+		{
+			name:        "one argument accepted when NANOGIT_REPO is set",
+			args:        []string{"main"},
+			envRepo:     "https://github.com/grafana/nanogit.git",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -299,6 +306,8 @@ func TestLsTreeCommand(t *testing.T) {
 			lsTreePath = ""
 			globalUsername = ""
 			globalToken = ""
+
+			t.Setenv("NANOGIT_REPO", tt.envRepo)
 
 			// Test argument validation
 			lsTreeCmd.SetArgs(tt.args)

--- a/cli/cmd/nanogit/put_file.go
+++ b/cli/cmd/nanogit/put_file.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -31,19 +32,24 @@ func init() {
 }
 
 var putFileCmd = &cobra.Command{
-	Use:   "put-file <repository> <ref> <path> [-]",
+	Use:   "put-file [<repository>] <ref> <path> [-]",
 	Short: "Create or update a file on a branch in a single commit",
 	Long: `Create or update a file on a branch by staging a blob, committing, and
 pushing in a single step. The ref must be a branch: the change is written on
 top of the branch's current tip.
 
 Content can be provided on stdin (default) or read from a local file with
---from-file. The special path "-" as the fourth positional argument is
-accepted but optional.
+--from-file. The trailing "-" positional argument is accepted but optional.
+
+The repository argument is optional when NANOGIT_REPO is set.
 
 Examples:
   # Pipe content on stdin
   echo "hello" | nanogit put-file https://github.com/user/repo.git main docs/note.md -m "add note" --author "Jane <jane@example.com>"
+
+  # Use NANOGIT_REPO env var instead of repeating the URL
+  export NANOGIT_REPO=https://github.com/user/repo.git
+  echo "hello" | nanogit put-file main docs/note.md -m "add note" --author "Jane <jane@example.com>"
 
   # Read content from a local file
   nanogit put-file https://github.com/user/repo.git main docs/note.md \
@@ -60,26 +66,48 @@ Examples:
 	RunE: runPutFile,
 }
 
-// putFileArgs validates positional arguments: three are required, and a
-// fourth optional argument must be the literal "-" meaning "read from stdin".
+// putFileArgs validates positional arguments. The optional trailing "-" marks
+// stdin; after peeling it off we need exactly (repo, ref, path) — or just
+// (ref, path) when NANOGIT_REPO provides the repo URL.
 func putFileArgs(_ *cobra.Command, args []string) error {
-	if len(args) < 3 {
-		return fmt.Errorf("accepts at least 3 arg(s), received %d", len(args))
+	envSet := os.Getenv(repoEnv) != ""
+
+	// A trailing "-" means "read from stdin"; strip it so we can validate the
+	// remaining positional count. "-" in any other position is rejected.
+	if len(args) > 0 && args[len(args)-1] == "-" {
+		args = args[:len(args)-1]
 	}
-	if len(args) > 4 {
-		return fmt.Errorf("accepts at most 4 arg(s), received %d", len(args))
+	if slices.Contains(args, "-") {
+		return fmt.Errorf(`"-" marker is only valid as the last positional argument`)
 	}
-	if len(args) == 4 && args[3] != "-" {
-		return fmt.Errorf("fourth positional argument must be \"-\" (stdin) or omitted, got %q", args[3])
+
+	if len(args) == 3 {
+		return nil
 	}
-	return nil
+	if envSet && len(args) == 2 {
+		return nil
+	}
+	if envSet {
+		return fmt.Errorf("accepts 2-3 positional args (plus optional trailing \"-\" for stdin), received %d", len(args))
+	}
+	return fmt.Errorf("accepts 3 positional args (plus optional trailing \"-\" for stdin), received %d (or set %s and pass 2)", len(args), repoEnv)
+}
+
+// resolvePutFileArgs extracts the repo URL, ref, path, and whether the stdin
+// marker was present. Callers rely on putFileArgs having validated counts.
+func resolvePutFileArgs(args []string) (repoURL, refName, filePath string, stdinMarker bool) {
+	if len(args) > 0 && args[len(args)-1] == "-" {
+		stdinMarker = true
+		args = args[:len(args)-1]
+	}
+	if len(args) == 3 {
+		return args[0], args[1], args[2], stdinMarker
+	}
+	return os.Getenv(repoEnv), args[0], args[1], stdinMarker
 }
 
 func runPutFile(cmd *cobra.Command, args []string) error {
-	repoURL := args[0]
-	refName := args[1]
-	filePath := args[2]
-	stdinMarker := len(args) == 4
+	repoURL, refName, filePath, stdinMarker := resolvePutFileArgs(args)
 
 	if putFileMessage == "" {
 		return errors.New("--message/-m is required")

--- a/cli/cmd/nanogit/put_file_test.go
+++ b/cli/cmd/nanogit/put_file_test.go
@@ -139,18 +139,41 @@ func TestPutFileCommandArgs(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envRepo     string
 		expectError bool
 	}{
-		{"no arguments", []string{}, true},
-		{"two arguments", []string{"repo", "ref"}, true},
-		{"three arguments", []string{"repo", "ref", "path"}, false},
-		{"four arguments with stdin marker", []string{"repo", "ref", "path", "-"}, false},
-		{"four arguments with invalid marker", []string{"repo", "ref", "path", "bad"}, true},
-		{"five arguments", []string{"repo", "ref", "path", "-", "extra"}, true},
+		{name: "no arguments", args: []string{}, expectError: true},
+		{name: "two arguments without env", args: []string{"repo", "ref"}, expectError: true},
+		{name: "three arguments", args: []string{"repo", "ref", "path"}, expectError: false},
+		{name: "four arguments with stdin marker", args: []string{"repo", "ref", "path", "-"}, expectError: false},
+		{name: "four arguments with invalid marker", args: []string{"repo", "ref", "path", "bad"}, expectError: true},
+		{name: "five arguments", args: []string{"repo", "ref", "path", "-", "extra"}, expectError: true},
+		{
+			name:    "two arguments accepted when NANOGIT_REPO is set",
+			args:    []string{"ref", "path"},
+			envRepo: "https://example.com/repo.git",
+		},
+		{
+			name:    "two arguments plus stdin marker when NANOGIT_REPO is set",
+			args:    []string{"ref", "path", "-"},
+			envRepo: "https://example.com/repo.git",
+		},
+		{
+			name:    "three arguments override env",
+			args:    []string{"repo", "ref", "path"},
+			envRepo: "https://example.com/repo.git",
+		},
+		{
+			name:        "dash in non-trailing position rejected",
+			args:        []string{"repo", "-", "path"},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NANOGIT_REPO", tt.envRepo)
+
 			err := putFileCmd.Args(putFileCmd, tt.args)
 			if tt.expectError {
 				assert.Error(t, err)
@@ -159,4 +182,42 @@ func TestPutFileCommandArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolvePutFileArgs(t *testing.T) {
+	t.Run("explicit three args", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "")
+		repo, ref, path, stdin := resolvePutFileArgs([]string{"https://example.com/repo.git", "main", "note.md"})
+		assert.Equal(t, "https://example.com/repo.git", repo)
+		assert.Equal(t, "main", ref)
+		assert.Equal(t, "note.md", path)
+		assert.False(t, stdin)
+	})
+
+	t.Run("explicit with stdin marker", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "")
+		repo, ref, path, stdin := resolvePutFileArgs([]string{"https://example.com/repo.git", "main", "note.md", "-"})
+		assert.Equal(t, "https://example.com/repo.git", repo)
+		assert.Equal(t, "main", ref)
+		assert.Equal(t, "note.md", path)
+		assert.True(t, stdin)
+	})
+
+	t.Run("env fallback", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+		repo, ref, path, stdin := resolvePutFileArgs([]string{"main", "note.md"})
+		assert.Equal(t, "https://env.example.com/repo.git", repo)
+		assert.Equal(t, "main", ref)
+		assert.Equal(t, "note.md", path)
+		assert.False(t, stdin)
+	})
+
+	t.Run("env fallback with stdin marker", func(t *testing.T) {
+		t.Setenv("NANOGIT_REPO", "https://env.example.com/repo.git")
+		repo, ref, path, stdin := resolvePutFileArgs([]string{"main", "note.md", "-"})
+		assert.Equal(t, "https://env.example.com/repo.git", repo)
+		assert.Equal(t, "main", ref)
+		assert.Equal(t, "note.md", path)
+		assert.True(t, stdin)
+	})
 }

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -103,6 +103,7 @@ The following flags are available for all commands:
 These flags can also be set via environment variables:
 - `NANOGIT_USERNAME` - Authentication username
 - `NANOGIT_TOKEN` - Authentication token
+- `NANOGIT_REPO` - Default repository URL. When set, the `<repository>` positional argument becomes optional for all commands. An explicit positional still overrides it.
 - `NANOGIT_TRACE` - When set (to any non-empty value), emits Debug-level wire/protocol logs to stderr
 
 ## Verbose mode

--- a/docs/getting-started/server-compatibility.md
+++ b/docs/getting-started/server-compatibility.md
@@ -18,21 +18,20 @@ See [CLI Installation](cli.md#installation) for platform-specific binary downloa
 
 ## Configure credentials
 
-Export credentials once so the commands below stay readable. `NANOGIT_USERNAME` defaults to `git`, which is what most providers expect when authenticating with a token.
+Export credentials once so the commands below stay readable. `NANOGIT_USERNAME` defaults to `git`, which is what most providers expect when authenticating with a token. `NANOGIT_REPO` lets every command below omit the repository URL argument.
 
 ```bash
 export NANOGIT_USERNAME=git                       # default; override for providers that require a specific user
 export NANOGIT_TOKEN=ghp_xxx                      # required for private repos or write operations
 export NANOGIT_AUTHOR_NAME="You"
 export NANOGIT_AUTHOR_EMAIL="you@example.com"
-
-REPO=https://github.com/<you>/<scratch>.git
+export NANOGIT_REPO=https://github.com/<you>/<scratch>.git
 ```
 
 ## 1. Verify protocol v2
 
 ```bash
-./nanogit check "$REPO"
+./nanogit check
 ```
 
 Expected output on a compatible server:
@@ -54,7 +53,7 @@ If you see `❌ Not Compatible`, stop here — the server only speaks protocol v
 ## 2. List files (read path)
 
 ```bash
-./nanogit ls-tree "$REPO" main
+./nanogit ls-tree main
 ```
 
 This confirms authentication, branch resolution, and tree fetching all work against the server.
@@ -62,7 +61,7 @@ This confirms authentication, branch resolution, and tree fetching all work agai
 ## 3. Write a file (write path)
 
 ```bash
-echo "hi" | ./nanogit put-file "$REPO" main note.md -m "add note"
+echo "hi" | ./nanogit put-file main note.md -m "add note"
 ```
 
 `put-file` stages the blob, creates a commit, and pushes in a single step. It prints the new commit hash to stdout. If the push fails, the server has rejected the write path — check branch protection rules, token scopes, and server-side hooks.
@@ -70,7 +69,7 @@ echo "hi" | ./nanogit put-file "$REPO" main note.md -m "add note"
 ## 4. Verify (read-after-write)
 
 ```bash
-./nanogit cat-file "$REPO" main note.md
+./nanogit cat-file main note.md
 ```
 
 You should see `hi`. This closes the loop: if all four commands succeed, nanogit can read from and write to this server.
@@ -80,9 +79,11 @@ You should see `hi`. This closes the loop: if all four commands succeed, nanogit
 Add `-v` for progress on stderr, or `NANOGIT_TRACE=1` for full Git wire-level detail. Both leave stdout clean so commit hashes and file contents stay pipeable.
 
 ```bash
-./nanogit -v check "$REPO"
-NANOGIT_TRACE=1 ./nanogit ls-tree "$REPO" main
+./nanogit -v check
+NANOGIT_TRACE=1 ./nanogit ls-tree main
 ```
+
+Each command still accepts the repository URL as its first positional argument, so you can override `NANOGIT_REPO` inline — for example `./nanogit check https://other.example.com/repo.git`.
 
 See [Verbose mode](cli.md#verbose-mode) for details on the logging levels.
 


### PR DESCRIPTION
## Summary

Adds `NANOGIT_REPO` as a fallback for the `<repository>` positional argument on every CLI command. The server-compatibility walkthrough previously recommended a `REPO=https://…` shell variable that had to be interpolated into every call (`nanogit check "$REPO"`, `nanogit ls-tree "$REPO" main`, etc.); exporting `NANOGIT_REPO` once now lets those commands drop the positional entirely.

```bash
export NANOGIT_REPO=https://github.com/<you>/<scratch>.git
nanogit check
nanogit ls-tree main
echo "hi" | nanogit put-file main note.md -m "add note"
nanogit cat-file main note.md
```

An explicit positional still overrides the env var (matches the `--token` / `NANOGIT_TOKEN` precedence already in place).

## Changes

- `cli/cmd/nanogit/common.go` — new `resolveRepoURL` / `repoArgs` helpers plus a `looksLikeRepoURL` heuristic (used by `clone`)
- `check`, `ls-remote`, `ls-tree`, `cat-file` — swap `cobra.ExactArgs(N)` for `repoArgs(N)` and use `resolveRepoURL` in the `RunE`
- `clone` — custom `cloneArgs` validator; a single positional is treated as the destination path unless it contains `://`
- `put-file` — strip the trailing `-` stdin marker before validating the count, accept 2 positionals (`<ref> <path>`) when the env var is set, and reject `-` in non-trailing positions
- Docs: `cli/README.md`, `docs/getting-started/cli.md`, and `docs/getting-started/server-compatibility.md` updated to document the new env var
- Tests: every command's args-validation test now covers both the env-unset and env-set paths, with new `common_test.go`, `TestResolveCloneArgs`, and `TestResolvePutFileArgs`

## Testing

- `cd cli && go test -count=1 ./...` — all CLI tests pass (including new NANOGIT_REPO cases)
- `make lint` — 0 issues
- Manual smoke tests for the new error messages, confirming the help text hints at `NANOGIT_REPO` when the positional is missing

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (CLI README, getting-started/cli, server-compatibility)
- [x] No breaking changes — the explicit `<repository>` positional still works exactly as before