### PR TITLE
feat: opt-in receive-pack capability negotiation

### DIFF
--- a/cli/cmd/nanogit/client_setup.go
+++ b/cli/cmd/nanogit/client_setup.go
@@ -2,13 +2,68 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/grafana/nanogit"
 	"github.com/grafana/nanogit/log"
 	"github.com/grafana/nanogit/options"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/spf13/cobra"
 )
+
+// globalReceivePackCaps and globalNegotiateCaps back the shared write-side
+// flags wired through buildClientOptions. They are populated by
+// addWriteFlags so any new write subcommand picks them up uniformly without
+// re-declaring per-command duplicates.
+var (
+	globalReceivePackCaps []string
+	globalNegotiateCaps   bool
+)
+
+// addWriteFlags registers the receive-pack-capability and
+// negotiate-capabilities flags on cmd. Write subcommands (put-file today;
+// future ones tomorrow) call this in init() so the flags stay in lockstep
+// across commands and so buildClientOptions can read them from one place.
+func addWriteFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&globalReceivePackCaps, "receive-pack-capability", nil,
+		"Advertised receive-pack capability (repeatable). When set, replaces the default set entirely. "+
+			"Common values include report-status-v2, side-band-64k, quiet, object-format=sha1, and agent=<name>. "+
+			"Arbitrary capability tokens are also accepted as an escape hatch for advanced use. "+
+			"Example: --receive-pack-capability=report-status-v2 --receive-pack-capability=quiet "+
+			"--receive-pack-capability=object-format=sha1 --receive-pack-capability=agent=nanogit "+
+			"(drops side-band-64k to work around servers that wrap report-status in side-band channel 1).")
+	cmd.Flags().BoolVar(&globalNegotiateCaps, "negotiate-capabilities", false,
+		"Fetch the server's advertised receive-pack capabilities once and advertise the intersection "+
+			"with the desired set on subsequent ref updates. Composes with --receive-pack-capability: "+
+			"the listed (or default) set is filtered against what the server actually offers. Off by default.")
+}
+
+// buildClientOptions converts the shared write-side flags into nanogit
+// options. When no capabilities are supplied and negotiation is off the
+// returned slice is empty and the caller keeps the library defaults. Each
+// raw capability is trimmed; empty entries are rejected so "a,,b" does not
+// silently inject a blank capability.
+func buildClientOptions() ([]options.Option, error) {
+	var opts []options.Option
+	if len(globalReceivePackCaps) > 0 {
+		caps := make([]protocol.Capability, 0, len(globalReceivePackCaps))
+		for _, raw := range globalReceivePackCaps {
+			v := strings.TrimSpace(raw)
+			if v == "" {
+				return nil, errors.New("--receive-pack-capability value cannot be empty")
+			}
+			caps = append(caps, protocol.Capability(v))
+		}
+		opts = append(opts, options.WithReceivePackCapabilities(caps...))
+	}
+	if globalNegotiateCaps {
+		opts = append(opts, options.WithCapabilityNegotiation())
+	}
+	return opts, nil
+}
 
 // setupClient resolves authentication from flags/env, constructs a nanogit
 // Client, and returns a context that carries the CLI logger so library

--- a/cli/cmd/nanogit/put_file.go
+++ b/cli/cmd/nanogit/put_file.go
@@ -12,17 +12,14 @@ import (
 	"time"
 
 	"github.com/grafana/nanogit"
-	"github.com/grafana/nanogit/options"
-	"github.com/grafana/nanogit/protocol"
 	"github.com/spf13/cobra"
 )
 
 var (
-	putFileMessage         string
-	putFileFromFile        string
-	putFileAuthor          string
-	putFileCommitter       string
-	putFileReceivePackCaps []string
+	putFileMessage   string
+	putFileFromFile  string
+	putFileAuthor    string
+	putFileCommitter string
 )
 
 func init() {
@@ -32,13 +29,7 @@ func init() {
 	putFileCmd.Flags().StringVar(&putFileFromFile, "from-file", "", "Read content from a local file instead of stdin")
 	putFileCmd.Flags().StringVar(&putFileAuthor, "author", "", "Author of the commit in \"Name <email>\" form (falls back to NANOGIT_AUTHOR_NAME/EMAIL)")
 	putFileCmd.Flags().StringVar(&putFileCommitter, "committer", "", "Committer of the commit in \"Name <email>\" form (falls back to NANOGIT_COMMITTER_NAME/EMAIL, then author)")
-	putFileCmd.Flags().StringSliceVar(&putFileReceivePackCaps, "receive-pack-capability", nil,
-		"Advertised receive-pack capability (repeatable). When set, replaces the default set entirely. "+
-			"Common values include report-status-v2, side-band-64k, quiet, object-format=sha1, and agent=<name>. "+
-			"Arbitrary capability tokens are also accepted as an escape hatch for advanced use. "+
-			"Example: --receive-pack-capability=report-status-v2 --receive-pack-capability=quiet "+
-			"--receive-pack-capability=object-format=sha1 --receive-pack-capability=agent=nanogit "+
-			"(drops side-band-64k to work around servers that wrap report-status in side-band channel 1).")
+	addWriteFlags(putFileCmd)
 }
 
 var putFileCmd = &cobra.Command{
@@ -142,7 +133,7 @@ func runPutFile(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	extraOpts, err := buildPutFileClientOptions(putFileReceivePackCaps)
+	extraOpts, err := buildClientOptions()
 	if err != nil {
 		return err
 	}
@@ -295,26 +286,6 @@ func stageAndCommit(ctx context.Context, writer nanogit.StagedWriter, path strin
 type putFileJSON struct {
 	Commit string `json:"commit"`
 	Path   string `json:"path"`
-}
-
-// buildPutFileClientOptions converts the --receive-pack-capability flag into
-// a nanogit options slice. When no capabilities are supplied the slice is
-// empty and the caller keeps the library defaults. Whitespace around each
-// value is trimmed and empty entries are rejected so "a,,b" does not silently
-// add a blank capability.
-func buildPutFileClientOptions(rawCaps []string) ([]options.Option, error) {
-	if len(rawCaps) == 0 {
-		return nil, nil
-	}
-	caps := make([]protocol.Capability, 0, len(rawCaps))
-	for _, raw := range rawCaps {
-		v := strings.TrimSpace(raw)
-		if v == "" {
-			return nil, errors.New("--receive-pack-capability value cannot be empty")
-		}
-		caps = append(caps, protocol.Capability(v))
-	}
-	return []options.Option{options.WithReceivePackCapabilities(caps...)}, nil
 }
 
 func outputPutFileResult(commit *nanogit.Commit, path string) error {

--- a/client.go
+++ b/client.go
@@ -107,20 +107,24 @@ type httpClient struct {
 	// receivePackCapabilities is advertised on receive-pack ref update commands.
 	// When nil or empty, protocol.DefaultReceivePackCapabilities() is used.
 	receivePackCapabilities []protocol.Capability
-	// negotiateCaps gates capability negotiation on first push. See
+	// negotiateCaps gates capability negotiation. See
 	// options.WithCapabilityNegotiation.
 	negotiateCaps bool
-	// negotiateOnce protects the lazy fetch+intersect so that ref ops, writer
-	// resets after Push, and writer resets after Cleanup all reuse the same
-	// negotiated set without extra round-trips.
-	negotiateOnce sync.Once
+	// negotiateMu serializes the lazy fetch+intersect so concurrent first
+	// callers don't race the network call. Once a successful negotiation
+	// has populated negotiatedCaps, the fast path under negotiateMu's read
+	// lock returns the cached value without extra round-trips. Failures
+	// are NOT cached: a transient first-call error must not poison the
+	// client for its lifetime.
+	negotiateMu sync.RWMutex
+	// negotiated is true only after a successful negotiation has populated
+	// negotiatedCaps. It guards the fast path and ensures retry semantics
+	// after a failed first call.
+	negotiated bool
 	// negotiatedCaps is the result of intersecting the desired client set
-	// with the server's advertised set. Populated by negotiateOnce.Do; only
-	// safe to read after negotiateOnce has run.
+	// with the server's advertised set. Only safe to read while holding
+	// negotiateMu (read or write) and only meaningful when negotiated.
 	negotiatedCaps []protocol.Capability
-	// negotiateErr captures any error from the negotiation fetch. Like
-	// negotiatedCaps, only safe to read after negotiateOnce has run.
-	negotiateErr error
 }
 
 // NewHTTPClient creates a new Git client for the specified repository URL.
@@ -173,47 +177,67 @@ func NewHTTPClient(repo string, opts ...options.Option) (Client, error) {
 // effectiveReceivePackCapabilities returns the capabilities to advertise on
 // receive-pack ref update commands. When negotiation is disabled this is just
 // c.receivePackCapabilities, so the existing nil-slice → DefaultReceivePackCapabilities
-// fallback in the protocol layer keeps working unchanged. When negotiation is
-// enabled, the first call performs a single GET info/refs fetch and intersects
-// the desired client set with the server's advertised set; subsequent calls
-// reuse the cached result via sync.Once.
+// fallback in the protocol layer keeps working unchanged. When negotiation
+// is enabled, the first successful call performs a single GET info/refs
+// fetch and intersects the desired client set with the server's advertised
+// set; the result is cached under c.negotiateMu so subsequent ref ops and
+// writer resets reuse it without extra round-trips.
 //
-// Returns the negotiation error verbatim (wrapped) so the caller can surface
-// it instead of silently falling back to the static set — silent fallback
-// would hide server misconfiguration and contradict the explicit opt-in.
+// Failures are not cached: a transient first-call error (network blip,
+// context deadline) must not poison the client for its entire lifetime, so
+// the next call retries the fetch from scratch. Once negotiation has
+// succeeded the cached value is returned forever.
+//
+// Returns the negotiation error verbatim (wrapped) so the caller can
+// surface it instead of silently falling back to the static set — silent
+// fallback would hide server misconfiguration and contradict the explicit
+// opt-in.
 func (c *httpClient) effectiveReceivePackCapabilities(ctx context.Context) ([]protocol.Capability, error) {
 	if !c.negotiateCaps {
 		return c.receivePackCapabilities, nil
 	}
 
-	c.negotiateOnce.Do(func() {
-		logger := log.FromContext(ctx)
-		logger.Debug("Negotiating receive-pack capabilities")
-
-		serverCaps, err := c.FetchReceivePackCapabilities(ctx)
-		if err != nil {
-			c.negotiateErr = fmt.Errorf("negotiate receive-pack capabilities: %w", err)
-			return
-		}
-
-		// The desired client set is whatever the user configured (via
-		// WithReceivePackCapabilities) or the library defaults if they did
-		// not. We resolve it once here so the intersection has a concrete
-		// list to filter rather than carrying the nil-fallback through.
-		desired := c.receivePackCapabilities
-		if len(desired) == 0 {
-			desired = protocol.DefaultReceivePackCapabilities()
-		}
-
-		c.negotiatedCaps = protocol.IntersectCapabilities(desired, serverCaps)
-		logger.Debug("Receive-pack capabilities negotiated",
-			"server_count", len(serverCaps),
-			"client_count", len(desired),
-			"intersected_count", len(c.negotiatedCaps))
-	})
-
-	if c.negotiateErr != nil {
-		return nil, c.negotiateErr
+	// Fast path: a previous call already negotiated successfully.
+	c.negotiateMu.RLock()
+	if c.negotiated {
+		caps := c.negotiatedCaps
+		c.negotiateMu.RUnlock()
+		return caps, nil
 	}
+	c.negotiateMu.RUnlock()
+
+	// Slow path: take the write lock and re-check, in case a concurrent
+	// caller negotiated while we were waiting.
+	c.negotiateMu.Lock()
+	defer c.negotiateMu.Unlock()
+	if c.negotiated {
+		return c.negotiatedCaps, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Debug("Negotiating receive-pack capabilities")
+
+	serverCaps, err := c.FetchReceivePackCapabilities(ctx)
+	if err != nil {
+		// Do not cache failure: leave c.negotiated false so the next
+		// caller retries the fetch instead of inheriting our error.
+		return nil, fmt.Errorf("negotiate receive-pack capabilities: %w", err)
+	}
+
+	// The desired client set is whatever the user configured (via
+	// WithReceivePackCapabilities) or the library defaults if they did
+	// not. Resolve it once here so the intersection has a concrete list
+	// to filter rather than carrying the nil-fallback through.
+	desired := c.receivePackCapabilities
+	if len(desired) == 0 {
+		desired = protocol.DefaultReceivePackCapabilities()
+	}
+
+	c.negotiatedCaps = protocol.IntersectCapabilities(desired, serverCaps)
+	c.negotiated = true
+	logger.Debug("Receive-pack capabilities negotiated",
+		"server_count", len(serverCaps),
+		"client_count", len(desired),
+		"intersected_count", len(c.negotiatedCaps))
 	return c.negotiatedCaps, nil
 }

--- a/client.go
+++ b/client.go
@@ -2,7 +2,10 @@ package nanogit
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
+	"github.com/grafana/nanogit/log"
 	"github.com/grafana/nanogit/options"
 	"github.com/grafana/nanogit/protocol"
 	"github.com/grafana/nanogit/protocol/client"
@@ -104,6 +107,20 @@ type httpClient struct {
 	// receivePackCapabilities is advertised on receive-pack ref update commands.
 	// When nil or empty, protocol.DefaultReceivePackCapabilities() is used.
 	receivePackCapabilities []protocol.Capability
+	// negotiateCaps gates capability negotiation on first push. See
+	// options.WithCapabilityNegotiation.
+	negotiateCaps bool
+	// negotiateOnce protects the lazy fetch+intersect so that ref ops, writer
+	// resets after Push, and writer resets after Cleanup all reuse the same
+	// negotiated set without extra round-trips.
+	negotiateOnce sync.Once
+	// negotiatedCaps is the result of intersecting the desired client set
+	// with the server's advertised set. Populated by negotiateOnce.Do; only
+	// safe to read after negotiateOnce has run.
+	negotiatedCaps []protocol.Capability
+	// negotiateErr captures any error from the negotiation fetch. Like
+	// negotiatedCaps, only safe to read after negotiateOnce has run.
+	negotiateErr error
 }
 
 // NewHTTPClient creates a new Git client for the specified repository URL.
@@ -149,5 +166,54 @@ func NewHTTPClient(repo string, opts ...options.Option) (Client, error) {
 	return &httpClient{
 		RawClient:               rawClient,
 		receivePackCapabilities: resolved.ReceivePackCapabilities,
+		negotiateCaps:           resolved.NegotiateCapabilities,
 	}, nil
+}
+
+// effectiveReceivePackCapabilities returns the capabilities to advertise on
+// receive-pack ref update commands. When negotiation is disabled this is just
+// c.receivePackCapabilities, so the existing nil-slice → DefaultReceivePackCapabilities
+// fallback in the protocol layer keeps working unchanged. When negotiation is
+// enabled, the first call performs a single GET info/refs fetch and intersects
+// the desired client set with the server's advertised set; subsequent calls
+// reuse the cached result via sync.Once.
+//
+// Returns the negotiation error verbatim (wrapped) so the caller can surface
+// it instead of silently falling back to the static set — silent fallback
+// would hide server misconfiguration and contradict the explicit opt-in.
+func (c *httpClient) effectiveReceivePackCapabilities(ctx context.Context) ([]protocol.Capability, error) {
+	if !c.negotiateCaps {
+		return c.receivePackCapabilities, nil
+	}
+
+	c.negotiateOnce.Do(func() {
+		logger := log.FromContext(ctx)
+		logger.Debug("Negotiating receive-pack capabilities")
+
+		serverCaps, err := c.FetchReceivePackCapabilities(ctx)
+		if err != nil {
+			c.negotiateErr = fmt.Errorf("negotiate receive-pack capabilities: %w", err)
+			return
+		}
+
+		// The desired client set is whatever the user configured (via
+		// WithReceivePackCapabilities) or the library defaults if they did
+		// not. We resolve it once here so the intersection has a concrete
+		// list to filter rather than carrying the nil-fallback through.
+		desired := c.receivePackCapabilities
+		if len(desired) == 0 {
+			desired = protocol.DefaultReceivePackCapabilities()
+		}
+
+		c.negotiatedCaps = protocol.IntersectCapabilities(desired, serverCaps)
+		logger.Debug("Receive-pack capabilities negotiated",
+			"server_count", len(serverCaps),
+			"client_count", len(desired),
+			"intersected_count", len(c.negotiatedCaps))
+	})
+
+	if c.negotiateErr != nil {
+		return nil, c.negotiateErr
+	}
+	return c.negotiatedCaps, nil
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -183,6 +183,8 @@ client, err := nanogit.NewHTTPClient(repo,
 
 The caller passes the full desired list — there is no merge with the defaults. Arbitrary tokens can be spelled as `protocol.Capability("foo")` when the typed helpers don't cover what the server expects. See [Receive-pack capabilities](server-compatibility.md#receive-pack-capabilities) for the default set and guidance on when to override.
 
+If you would rather not enumerate the safe subset by hand, `options.WithCapabilityNegotiation()` makes the client fetch the server's advertisement once and advertise the intersection on subsequent pushes. See [Programmatic negotiation](server-compatibility.md#programmatic-negotiation) for the trade-offs.
+
 ## Performance Optimization
 
 ### Clone Performance

--- a/docs/getting-started/server-compatibility.md
+++ b/docs/getting-started/server-compatibility.md
@@ -131,6 +131,32 @@ client, err := nanogit.NewHTTPClient(repoURL,
 
 Typed helpers (`CapReportStatusV2`, `CapSideBand64k`, `CapQuiet`, `CapObjectFormatSHA1`, `CapAgent(name)`) are exposed under `protocol`. Any other string literal can be passed through as `protocol.Capability("foo")` when you need to negotiate something the helpers don't cover.
 
+### Programmatic negotiation
+
+Knowing the right subset to advertise requires knowing what the server supports. `options.WithCapabilityNegotiation()` flips that around: nanogit fetches `GET info/refs?service=git-receive-pack` once per client lifetime, parses the v1-style capability advertisement, and intersects it with the desired set on every subsequent ref update. The fetch result is cached behind `sync.Once`, so writer resets after `Push` and `Cleanup` reuse the same negotiated set without extra round-trips.
+
+```go
+client, err := nanogit.NewHTTPClient(repoURL,
+    options.WithBasicAuth("git", token),
+    options.WithCapabilityNegotiation(),
+)
+```
+
+The option composes with `WithReceivePackCapabilities`: the explicit set becomes the desired list, and negotiation filters it down to what the server actually advertises. This is the right pattern when you want the safety of a hand-curated list *and* the defensiveness of dropping anything the server omits.
+
+`report-status-v2` and `agent=` are always retained on the client side regardless of the server's advertisement. Dropping `report-status-v2` would re-introduce silent push success on rejection (nanogit's response parser depends on it), and `agent=` is a pure client self-identifier with no server-side feature semantics.
+
+The CLI exposes the same option via `--negotiate-capabilities`:
+
+```bash
+NANOGIT_TRACE=1 ./nanogit -v put-file main note.md -m "add note" \
+  --negotiate-capabilities < note.md
+```
+
+The trace output will show one extra `GET info/refs?service=git-receive-pack` before the push and a receive-pack POST that advertises only the intersected set.
+
+Negotiation is opt-in. When it fails (network error, 4xx/5xx, malformed advertisement) the push aborts; silent fallback to the static set would hide server misconfiguration and contradict the explicit opt-in. This option is "defensive correctness for strict servers and cleaner traces," not a fix for protocol bugs — for example, it does not bypass servers that wrap `report-status` in side-band channel 1, because they *do* advertise `side-band-64k`. For that case, drop `side-band-64k` explicitly with `WithReceivePackCapabilities`.
+
 ### When to override
 
 - Pushes appear to succeed but the branch is unchanged or empty — retry with `side-band-64k` removed.

--- a/mocks/raw_client.go
+++ b/mocks/raw_client.go
@@ -53,6 +53,19 @@ type FakeRawClient struct {
 		result1 map[string]*protocol.PackfileObject
 		result2 error
 	}
+	FetchReceivePackCapabilitiesStub        func(context.Context) ([]protocol.Capability, error)
+	fetchReceivePackCapabilitiesMutex       sync.RWMutex
+	fetchReceivePackCapabilitiesArgsForCall []struct {
+		arg1 context.Context
+	}
+	fetchReceivePackCapabilitiesReturns struct {
+		result1 []protocol.Capability
+		result2 error
+	}
+	fetchReceivePackCapabilitiesReturnsOnCall map[int]struct {
+		result1 []protocol.Capability
+		result2 error
+	}
 	IsAuthorizedStub        func(context.Context) (bool, error)
 	isAuthorizedMutex       sync.RWMutex
 	isAuthorizedArgsForCall []struct {
@@ -324,6 +337,70 @@ func (fake *FakeRawClient) FetchReturnsOnCall(i int, result1 map[string]*protoco
 	}
 	fake.fetchReturnsOnCall[i] = struct {
 		result1 map[string]*protocol.PackfileObject
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRawClient) FetchReceivePackCapabilities(arg1 context.Context) ([]protocol.Capability, error) {
+	fake.fetchReceivePackCapabilitiesMutex.Lock()
+	ret, specificReturn := fake.fetchReceivePackCapabilitiesReturnsOnCall[len(fake.fetchReceivePackCapabilitiesArgsForCall)]
+	fake.fetchReceivePackCapabilitiesArgsForCall = append(fake.fetchReceivePackCapabilitiesArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.FetchReceivePackCapabilitiesStub
+	fakeReturns := fake.fetchReceivePackCapabilitiesReturns
+	fake.recordInvocation("FetchReceivePackCapabilities", []interface{}{arg1})
+	fake.fetchReceivePackCapabilitiesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeRawClient) FetchReceivePackCapabilitiesCallCount() int {
+	fake.fetchReceivePackCapabilitiesMutex.RLock()
+	defer fake.fetchReceivePackCapabilitiesMutex.RUnlock()
+	return len(fake.fetchReceivePackCapabilitiesArgsForCall)
+}
+
+func (fake *FakeRawClient) FetchReceivePackCapabilitiesCalls(stub func(context.Context) ([]protocol.Capability, error)) {
+	fake.fetchReceivePackCapabilitiesMutex.Lock()
+	defer fake.fetchReceivePackCapabilitiesMutex.Unlock()
+	fake.FetchReceivePackCapabilitiesStub = stub
+}
+
+func (fake *FakeRawClient) FetchReceivePackCapabilitiesArgsForCall(i int) context.Context {
+	fake.fetchReceivePackCapabilitiesMutex.RLock()
+	defer fake.fetchReceivePackCapabilitiesMutex.RUnlock()
+	argsForCall := fake.fetchReceivePackCapabilitiesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRawClient) FetchReceivePackCapabilitiesReturns(result1 []protocol.Capability, result2 error) {
+	fake.fetchReceivePackCapabilitiesMutex.Lock()
+	defer fake.fetchReceivePackCapabilitiesMutex.Unlock()
+	fake.FetchReceivePackCapabilitiesStub = nil
+	fake.fetchReceivePackCapabilitiesReturns = struct {
+		result1 []protocol.Capability
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeRawClient) FetchReceivePackCapabilitiesReturnsOnCall(i int, result1 []protocol.Capability, result2 error) {
+	fake.fetchReceivePackCapabilitiesMutex.Lock()
+	defer fake.fetchReceivePackCapabilitiesMutex.Unlock()
+	fake.FetchReceivePackCapabilitiesStub = nil
+	if fake.fetchReceivePackCapabilitiesReturnsOnCall == nil {
+		fake.fetchReceivePackCapabilitiesReturnsOnCall = make(map[int]struct {
+			result1 []protocol.Capability
+			result2 error
+		})
+	}
+	fake.fetchReceivePackCapabilitiesReturnsOnCall[i] = struct {
+		result1 []protocol.Capability
 		result2 error
 	}{result1, result2}
 }

--- a/options/http.go
+++ b/options/http.go
@@ -70,3 +70,30 @@ func WithReceivePackCapabilities(caps ...protocol.Capability) Option {
 		return nil
 	}
 }
+
+// WithCapabilityNegotiation enables opt-in receive-pack capability
+// negotiation. When set, on first push the client fetches the server's
+// advertised capabilities via GET info/refs?service=git-receive-pack and
+// advertises the intersection with its desired set on subsequent ref
+// updates. The result is cached for the lifetime of the client (a single
+// extra round-trip per client, not per push), so writer resets across
+// Push/Cleanup do not re-negotiate.
+//
+// Use this when you want defensive correctness against strict servers that
+// reject unknown capabilities, without having to enumerate the safe subset
+// by hand the way WithReceivePackCapabilities requires. The two options
+// compose: WithReceivePackCapabilities provides the desired set, and
+// WithCapabilityNegotiation filters that set against what the server
+// advertises. report-status-v2 and agent= are always retained on the client
+// side because dropping them would either break the response parser or
+// strip the client identifier.
+//
+// On error during negotiation (network failure, 4xx/5xx, parse error) the
+// push aborts. Silent fallback to the static set would hide server
+// misconfiguration and contradicts the explicit opt-in.
+func WithCapabilityNegotiation() Option {
+	return func(o *Options) error {
+		o.NegotiateCapabilities = true
+		return nil
+	}
+}

--- a/options/http.go
+++ b/options/http.go
@@ -72,12 +72,15 @@ func WithReceivePackCapabilities(caps ...protocol.Capability) Option {
 }
 
 // WithCapabilityNegotiation enables opt-in receive-pack capability
-// negotiation. When set, on first push the client fetches the server's
-// advertised capabilities via GET info/refs?service=git-receive-pack and
-// advertises the intersection with its desired set on subsequent ref
-// updates. The result is cached for the lifetime of the client (a single
-// extra round-trip per client, not per push), so writer resets across
-// Push/Cleanup do not re-negotiate.
+// negotiation. When set, the first call that needs receive-pack
+// capabilities — creating a staged writer or any ref update (CreateRef,
+// UpdateRef, DeleteRef) — fetches the server's advertised capabilities via
+// GET info/refs?service=git-receive-pack and intersects them with the
+// client's desired set. The result is cached for the lifetime of the
+// client (a single extra round-trip per client, not per operation), so
+// subsequent ref ops and writer resets across Push/Cleanup do not
+// re-negotiate. Failed first attempts (network blip, transient 5xx) are
+// not cached; the next call retries from scratch.
 //
 // Use this when you want defensive correctness against strict servers that
 // reject unknown capabilities, without having to enumerate the safe subset
@@ -85,12 +88,13 @@ func WithReceivePackCapabilities(caps ...protocol.Capability) Option {
 // compose: WithReceivePackCapabilities provides the desired set, and
 // WithCapabilityNegotiation filters that set against what the server
 // advertises. report-status-v2 and agent= are always retained on the client
-// side because dropping them would either break the response parser or
-// strip the client identifier.
+// side (and re-injected with nanogit's defaults if the user-supplied set
+// stripped them) because dropping them would either break the response
+// parser or strip the client identifier.
 //
 // On error during negotiation (network failure, 4xx/5xx, parse error) the
-// push aborts. Silent fallback to the static set would hide server
-// misconfiguration and contradicts the explicit opt-in.
+// caller's operation aborts. Silent fallback to the static set would hide
+// server misconfiguration and contradicts the explicit opt-in.
 func WithCapabilityNegotiation() Option {
 	return func(o *Options) error {
 		o.NegotiateCapabilities = true

--- a/options/http_test.go
+++ b/options/http_test.go
@@ -68,6 +68,33 @@ func TestWithReceivePackCapabilities(t *testing.T) {
 	})
 }
 
+func TestWithCapabilityNegotiation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset by default", func(t *testing.T) {
+		o := &Options{}
+		require.False(t, o.NegotiateCapabilities)
+	})
+
+	t.Run("sets the flag when applied", func(t *testing.T) {
+		o := &Options{}
+		require.NoError(t, WithCapabilityNegotiation()(o))
+		require.True(t, o.NegotiateCapabilities)
+	})
+
+	t.Run("composes with WithReceivePackCapabilities", func(t *testing.T) {
+		// WithReceivePackCapabilities provides the desired set;
+		// WithCapabilityNegotiation flags that the set should be intersected
+		// with the server's advertisement at push time. Both fields coexist.
+		o := &Options{}
+		caps := []protocol.Capability{protocol.CapReportStatusV2, protocol.CapAgent("custom")}
+		require.NoError(t, WithReceivePackCapabilities(caps...)(o))
+		require.NoError(t, WithCapabilityNegotiation()(o))
+		require.Equal(t, caps, o.ReceivePackCapabilities)
+		require.True(t, o.NegotiateCapabilities)
+	})
+}
+
 func TestWithUserAgent(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/options/options.go
+++ b/options/options.go
@@ -29,6 +29,11 @@ type Options struct {
 	// advertised on receive-pack ref update commands. When nil or empty,
 	// protocol.DefaultReceivePackCapabilities() is used.
 	ReceivePackCapabilities []protocol.Capability
+	// NegotiateCapabilities, when true, makes the client fetch the server's
+	// receive-pack capability advertisement once per client lifetime and
+	// advertise the intersection with its desired set on subsequent ref
+	// updates. Default is false (no behavior change).
+	NegotiateCapabilities bool
 }
 
 type Option func(*Options) error

--- a/protocol/capabilities.go
+++ b/protocol/capabilities.go
@@ -88,3 +88,59 @@ func FormatCapabilities(caps []Capability) (string, error) {
 	}
 	return strings.Join(parts, " "), nil
 }
+
+// alwaysRetainedCapabilityKeys lists capability keys that IntersectCapabilities
+// must keep from the client side regardless of whether the server advertised
+// them. report-status-v2 is what nanogit's receive-pack response parser relies
+// on to detect failures — dropping it because the server didn't advertise it
+// would re-introduce silent push success on rejection. agent= is a pure
+// client self-identifier with no server-side feature semantics; preserving it
+// keeps server-side request logs accurate.
+var alwaysRetainedCapabilityKeys = map[string]struct{}{
+	"report-status-v2": {},
+	"agent":            {},
+}
+
+// capabilityKey returns the comparison key for a capability token, which is
+// the substring before the first "=". For valued capabilities like
+// "agent=git/2.43" or "object-format=sha1" this is the bare name; flag
+// capabilities like "report-status-v2" are returned unchanged.
+func capabilityKey(c Capability) string {
+	key, _, _ := strings.Cut(string(c), "=")
+	return key
+}
+
+// IntersectCapabilities filters client to the capabilities also advertised by
+// server, compared by key (the substring before "="), so a client-side
+// "agent=nanogit" matches a server-side "agent=git/2.43". The client's value
+// is always kept on a match — for valued capabilities like "agent=" and
+// "object-format=" the client's value is what we will actually advertise on
+// the wire.
+//
+// Capability order from the client slice is preserved. Capabilities listed in
+// alwaysRetainedCapabilityKeys (report-status-v2, agent=) are kept regardless
+// of what the server advertised, since dropping them would either break
+// nanogit's own response parser or strip the client identifier.
+//
+// A nil or empty server slice is treated as "the server advertised nothing
+// matchable" and yields only the always-retained client entries. The returned
+// slice is freshly allocated; mutating it does not affect either input.
+func IntersectCapabilities(client, server []Capability) []Capability {
+	serverKeys := make(map[string]struct{}, len(server))
+	for _, c := range server {
+		serverKeys[capabilityKey(c)] = struct{}{}
+	}
+
+	out := make([]Capability, 0, len(client))
+	for _, c := range client {
+		key := capabilityKey(c)
+		if _, retain := alwaysRetainedCapabilityKeys[key]; retain {
+			out = append(out, c)
+			continue
+		}
+		if _, ok := serverKeys[key]; ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/protocol/capabilities.go
+++ b/protocol/capabilities.go
@@ -118,12 +118,17 @@ func capabilityKey(c Capability) string {
 // the wire.
 //
 // Capability order from the client slice is preserved. Capabilities listed in
-// alwaysRetainedCapabilityKeys (report-status-v2, agent=) are kept regardless
-// of what the server advertised, since dropping them would either break
-// nanogit's own response parser or strip the client identifier.
+// alwaysRetainedCapabilityKeys (report-status-v2, agent=) are kept in the
+// result regardless of what the server advertised, and are injected with
+// nanogit's defaults if the client did not include them — dropping them
+// would either break nanogit's own response parser (report-status-v2) or
+// strip the client identifier (agent=). The returned slice is therefore
+// guaranteed to be non-empty: returning an empty slice would trigger the
+// empty→defaults fallback in FormatCapabilities and silently re-introduce
+// capabilities the caller meant to filter out.
 //
 // A nil or empty server slice is treated as "the server advertised nothing
-// matchable" and yields only the always-retained client entries. The returned
+// matchable" and yields only the always-retained entries. The returned
 // slice is freshly allocated; mutating it does not affect either input.
 func IntersectCapabilities(client, server []Capability) []Capability {
 	serverKeys := make(map[string]struct{}, len(server))
@@ -131,16 +136,29 @@ func IntersectCapabilities(client, server []Capability) []Capability {
 		serverKeys[capabilityKey(c)] = struct{}{}
 	}
 
-	out := make([]Capability, 0, len(client))
+	out := make([]Capability, 0, len(client)+len(alwaysRetainedCapabilityKeys))
+	seenRetained := make(map[string]struct{}, len(alwaysRetainedCapabilityKeys))
 	for _, c := range client {
 		key := capabilityKey(c)
 		if _, retain := alwaysRetainedCapabilityKeys[key]; retain {
 			out = append(out, c)
+			seenRetained[key] = struct{}{}
 			continue
 		}
 		if _, ok := serverKeys[key]; ok {
 			out = append(out, c)
 		}
+	}
+
+	// Inject defaults for retained keys missing from the client list. This
+	// upholds the function's contract: the result must always carry the
+	// caps nanogit needs internally (report-status-v2 for the parser,
+	// agent= for the client identifier), even if the caller stripped them.
+	if _, ok := seenRetained["report-status-v2"]; !ok {
+		out = append(out, CapReportStatusV2)
+	}
+	if _, ok := seenRetained["agent"]; !ok {
+		out = append(out, CapAgent("nanogit"))
 	}
 	return out
 }

--- a/protocol/capabilities_test.go
+++ b/protocol/capabilities_test.go
@@ -157,8 +157,13 @@ func TestIntersectCapabilities(t *testing.T) {
 			// no quiet
 		}
 		got := protocol.IntersectCapabilities(client, server)
+		// agent= is auto-injected because the client list lacked it.
 		assert.Equal(t,
-			[]protocol.Capability{protocol.CapReportStatusV2, protocol.CapSideBand64k},
+			[]protocol.Capability{
+				protocol.CapReportStatusV2,
+				protocol.CapSideBand64k,
+				protocol.CapAgent("nanogit"),
+			},
 			got,
 		)
 	})
@@ -189,8 +194,13 @@ func TestIntersectCapabilities(t *testing.T) {
 		client := []protocol.Capability{protocol.CapAgent("nanogit")}
 		server := []protocol.Capability{protocol.CapAgent("git/2.43")}
 		got := protocol.IntersectCapabilities(client, server)
-		// We keep our own agent string regardless of what the server identified as.
-		assert.Equal(t, []protocol.Capability{protocol.CapAgent("nanogit")}, got)
+		// We keep our own agent string regardless of what the server
+		// identified as. report-status-v2 is auto-injected because the
+		// client list lacked it.
+		assert.Equal(t,
+			[]protocol.Capability{protocol.CapAgent("nanogit"), protocol.CapReportStatusV2},
+			got,
+		)
 	})
 
 	t.Run("retains report-status-v2 even when server omits it", func(t *testing.T) {
@@ -211,7 +221,12 @@ func TestIntersectCapabilities(t *testing.T) {
 		client := []protocol.Capability{protocol.CapAgent("nanogit")}
 		server := []protocol.Capability{protocol.CapQuiet}
 		got := protocol.IntersectCapabilities(client, server)
-		assert.Equal(t, []protocol.Capability{protocol.CapAgent("nanogit")}, got)
+		// agent= is preserved from the client list; report-status-v2 is
+		// auto-injected because the client list lacked it.
+		assert.Equal(t,
+			[]protocol.Capability{protocol.CapAgent("nanogit"), protocol.CapReportStatusV2},
+			got,
+		)
 	})
 
 	t.Run("drops side-band-64k when server does not advertise it", func(t *testing.T) {
@@ -240,9 +255,30 @@ func TestIntersectCapabilities(t *testing.T) {
 		)
 	})
 
-	t.Run("empty client slice yields empty result", func(t *testing.T) {
+	t.Run("empty client slice still yields the retained caps", func(t *testing.T) {
+		// The function guarantees the result carries report-status-v2 and
+		// agent= regardless of what either side supplied — otherwise an
+		// empty result would hit FormatCapabilities's empty→defaults
+		// fallback and silently advertise the full default set.
 		got := protocol.IntersectCapabilities(nil, []protocol.Capability{protocol.CapQuiet})
-		assert.Empty(t, got)
+		assert.Equal(t,
+			[]protocol.Capability{protocol.CapReportStatusV2, protocol.CapAgent("nanogit")},
+			got,
+		)
+	})
+
+	t.Run("client that strips retained caps still gets them back", func(t *testing.T) {
+		// User said "I want only quiet"; server doesn't advertise it. The
+		// raw intersection would be empty, which is unsafe — the result
+		// must still include report-status-v2 and agent=nanogit so the
+		// receive-pack response is parseable and nanogit identifies itself.
+		client := []protocol.Capability{protocol.CapQuiet}
+		server := []protocol.Capability{protocol.CapSideBand64k}
+		got := protocol.IntersectCapabilities(client, server)
+		assert.Equal(t,
+			[]protocol.Capability{protocol.CapReportStatusV2, protocol.CapAgent("nanogit")},
+			got,
+		)
 	})
 
 	t.Run("returned slice is independent of inputs", func(t *testing.T) {

--- a/protocol/capabilities_test.go
+++ b/protocol/capabilities_test.go
@@ -142,6 +142,119 @@ func TestCapability_Validate(t *testing.T) {
 	}
 }
 
+func TestIntersectCapabilities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("filters by key when both sides match", func(t *testing.T) {
+		client := []protocol.Capability{
+			protocol.CapReportStatusV2,
+			protocol.CapSideBand64k,
+			protocol.CapQuiet,
+		}
+		server := []protocol.Capability{
+			protocol.CapReportStatusV2,
+			protocol.CapSideBand64k,
+			// no quiet
+		}
+		got := protocol.IntersectCapabilities(client, server)
+		assert.Equal(t,
+			[]protocol.Capability{protocol.CapReportStatusV2, protocol.CapSideBand64k},
+			got,
+		)
+	})
+
+	t.Run("preserves client order", func(t *testing.T) {
+		client := []protocol.Capability{
+			protocol.CapAgent("nanogit"),
+			protocol.CapReportStatusV2,
+			protocol.CapQuiet,
+		}
+		server := []protocol.Capability{
+			protocol.CapQuiet,
+			protocol.CapReportStatusV2,
+			protocol.CapAgent("git/2.43"),
+		}
+		got := protocol.IntersectCapabilities(client, server)
+		assert.Equal(t,
+			[]protocol.Capability{
+				protocol.CapAgent("nanogit"),
+				protocol.CapReportStatusV2,
+				protocol.CapQuiet,
+			},
+			got,
+		)
+	})
+
+	t.Run("agent= matches by key and keeps client value", func(t *testing.T) {
+		client := []protocol.Capability{protocol.CapAgent("nanogit")}
+		server := []protocol.Capability{protocol.CapAgent("git/2.43")}
+		got := protocol.IntersectCapabilities(client, server)
+		// We keep our own agent string regardless of what the server identified as.
+		assert.Equal(t, []protocol.Capability{protocol.CapAgent("nanogit")}, got)
+	})
+
+	t.Run("retains report-status-v2 even when server omits it", func(t *testing.T) {
+		client := []protocol.Capability{
+			protocol.CapReportStatusV2,
+			protocol.CapSideBand64k,
+		}
+		server := []protocol.Capability{
+			protocol.CapSideBand64k,
+		}
+		got := protocol.IntersectCapabilities(client, server)
+		assert.Contains(t, got, protocol.CapReportStatusV2,
+			"report-status-v2 must always be retained — nanogit's parser depends on it")
+		assert.Contains(t, got, protocol.CapSideBand64k)
+	})
+
+	t.Run("retains agent= even when server omits it", func(t *testing.T) {
+		client := []protocol.Capability{protocol.CapAgent("nanogit")}
+		server := []protocol.Capability{protocol.CapQuiet}
+		got := protocol.IntersectCapabilities(client, server)
+		assert.Equal(t, []protocol.Capability{protocol.CapAgent("nanogit")}, got)
+	})
+
+	t.Run("drops side-band-64k when server does not advertise it", func(t *testing.T) {
+		// The motivating GitLab case: a strict server omits side-band-64k.
+		client := protocol.DefaultReceivePackCapabilities()
+		server := []protocol.Capability{
+			protocol.CapReportStatusV2,
+			protocol.CapQuiet,
+			protocol.CapObjectFormatSHA1,
+		}
+		got := protocol.IntersectCapabilities(client, server)
+		for _, c := range got {
+			assert.NotEqual(t, protocol.CapSideBand64k, c, "side-band-64k must be dropped when server doesn't advertise it")
+		}
+		assert.Contains(t, got, protocol.CapReportStatusV2)
+		assert.Contains(t, got, protocol.CapAgent("nanogit"), "agent must be retained regardless")
+	})
+
+	t.Run("empty server slice yields only always-retained client caps", func(t *testing.T) {
+		client := protocol.DefaultReceivePackCapabilities()
+		got := protocol.IntersectCapabilities(client, nil)
+		// Only report-status-v2 and agent= survive.
+		assert.Equal(t,
+			[]protocol.Capability{protocol.CapReportStatusV2, protocol.CapAgent("nanogit")},
+			got,
+		)
+	})
+
+	t.Run("empty client slice yields empty result", func(t *testing.T) {
+		got := protocol.IntersectCapabilities(nil, []protocol.Capability{protocol.CapQuiet})
+		assert.Empty(t, got)
+	})
+
+	t.Run("returned slice is independent of inputs", func(t *testing.T) {
+		client := []protocol.Capability{protocol.CapReportStatusV2, protocol.CapQuiet}
+		server := []protocol.Capability{protocol.CapQuiet}
+		got := protocol.IntersectCapabilities(client, server)
+		require.NotEmpty(t, got)
+		got[0] = protocol.Capability("tampered")
+		assert.Equal(t, protocol.CapReportStatusV2, client[0])
+	})
+}
+
 func TestCapabilityConstants(t *testing.T) {
 	t.Parallel()
 

--- a/protocol/client/rawclient.go
+++ b/protocol/client/rawclient.go
@@ -26,6 +26,7 @@ type RawClient interface {
 	IsServerCompatible(ctx context.Context) (bool, error)
 	UploadPack(ctx context.Context, data io.Reader) (io.ReadCloser, error)
 	ReceivePack(ctx context.Context, data io.Reader) error
+	FetchReceivePackCapabilities(ctx context.Context) ([]protocol.Capability, error)
 	Fetch(ctx context.Context, opts FetchOptions) (map[string]*protocol.PackfileObject, error)
 	LsRefs(ctx context.Context, opts LsRefsOptions) ([]protocol.RefLine, error)
 }

--- a/protocol/client/receivepackcaps.go
+++ b/protocol/client/receivepackcaps.go
@@ -35,6 +35,15 @@ func (c *rawClient) FetchReceivePackCapabilities(ctx context.Context) (caps []pr
 	}
 
 	c.addDefaultHeaders(req)
+	// addDefaultHeaders advertises Git-Protocol: version=2, which lets a
+	// server choose between v1 and v2 responses on /info/refs. v2 returns a
+	// "version 2\n" capability advertisement in place of the v1
+	// "# service=git-receive-pack\n" prelude that
+	// protocol.ParseReceivePackInfoRefs expects. We only support the v1
+	// shape (it's the one that carries the receive-pack capability set in
+	// the first ref line), so suppress the protocol-version hint and let
+	// the server fall back to v1.
+	req.Header.Del("Git-Protocol")
 
 	res, err := c.do(ctx, req)
 	if err != nil {

--- a/protocol/client/receivepackcaps.go
+++ b/protocol/client/receivepackcaps.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/grafana/nanogit/log"
+	"github.com/grafana/nanogit/protocol"
+)
+
+// FetchReceivePackCapabilities issues GET info/refs?service=git-receive-pack and
+// returns the capabilities the server advertised after the NUL byte on the
+// first ref line. Unlike SmartInfo (which only validates the HTTP transport),
+// this method consumes and parses the response body so the caller can use the
+// advertised set for capability negotiation on subsequent ReceivePack calls.
+//
+// 4xx responses are mapped through CheckHTTPClientError so callers see the
+// usual ErrRepositoryNotFound / authentication errors. 5xx and network errors
+// follow the same retry path as SmartInfo via the shared do() helper.
+func (c *rawClient) FetchReceivePackCapabilities(ctx context.Context) (caps []protocol.Capability, err error) {
+	u := c.base.JoinPath("info/refs")
+
+	query := make(url.Values)
+	query.Set("service", "git-receive-pack")
+	u.RawQuery = query.Encode()
+
+	logger := log.FromContext(ctx)
+	logger.Debug("FetchReceivePackCapabilities", "url", u.String())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.addDefaultHeaders(req)
+
+	res, err := c.do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if closeErr := res.Body.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("error closing response body: %w", closeErr)
+		}
+	}()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		// Map 401/403/404 to the structured client errors used elsewhere so
+		// users see ErrRepositoryNotFound / auth failures consistently.
+		if clientErr := CheckHTTPClientError(res); clientErr != nil {
+			return nil, clientErr
+		}
+		return nil, fmt.Errorf("got status code %d: %s", res.StatusCode, res.Status)
+	}
+
+	logger.Debug("FetchReceivePackCapabilities response",
+		"status", res.StatusCode,
+		"statusText", res.Status)
+
+	caps, err = protocol.ParseReceivePackInfoRefs(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parse receive-pack info/refs: %w", err)
+	}
+
+	logger.Debug("FetchReceivePackCapabilities parsed",
+		"capability_count", len(caps))
+	return caps, nil
+}

--- a/protocol/client/receivepackcaps_test.go
+++ b/protocol/client/receivepackcaps_test.go
@@ -63,6 +63,37 @@ func TestFetchReceivePackCapabilities(t *testing.T) {
 			"expected ErrRepositoryNotFound, got %v", err)
 	})
 
+	t.Run("does not advertise Git-Protocol version=2", func(t *testing.T) {
+		// info/refs?service=git-receive-pack is the v1 smart discovery
+		// endpoint; advertising v2 risks getting a v2 response that the
+		// parser cannot handle. The implementation explicitly suppresses
+		// the header — guard that here so a refactor doesn't silently
+		// re-introduce it.
+		var sawProtocolHeader string
+		body, err := protocol.FormatPacks(
+			protocol.PackLine("# service=git-receive-pack\n"),
+			protocol.FlushPacket,
+			protocol.PackLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00report-status-v2\n"),
+			protocol.FlushPacket,
+		)
+		require.NoError(t, err)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sawProtocolHeader = r.Header.Get("Git-Protocol")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		client, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		_, err = client.FetchReceivePackCapabilities(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, sawProtocolHeader,
+			"FetchReceivePackCapabilities must not advertise Git-Protocol version=2")
+	})
+
 	t.Run("propagates parse errors verbatim", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/protocol/client/receivepackcaps_test.go
+++ b/protocol/client/receivepackcaps_test.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/nanogit/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchReceivePackCapabilities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses caps from typical Gitea response", func(t *testing.T) {
+		body, err := protocol.FormatPacks(
+			protocol.PackLine("# service=git-receive-pack\n"),
+			protocol.FlushPacket,
+			protocol.PackLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00report-status-v2 side-band-64k quiet object-format=sha1 agent=git/2.43\n"),
+			protocol.FlushPacket,
+		)
+		require.NoError(t, err)
+
+		var gotPath, gotService, gotMethod string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotService = r.URL.Query().Get("service")
+			gotMethod = r.Method
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		client, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		caps, err := client.FetchReceivePackCapabilities(context.Background())
+		require.NoError(t, err)
+
+		assert.Equal(t, "/repo.git/info/refs", gotPath)
+		assert.Equal(t, "git-receive-pack", gotService)
+		assert.Equal(t, http.MethodGet, gotMethod)
+		assert.Contains(t, caps, protocol.CapSideBand64k)
+		assert.Contains(t, caps, protocol.CapReportStatusV2)
+		assert.Contains(t, caps, protocol.CapAgent("git/2.43"))
+	})
+
+	t.Run("maps 404 to ErrRepositoryNotFound", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		client, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		_, err = client.FetchReceivePackCapabilities(context.Background())
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrRepositoryNotFound),
+			"expected ErrRepositoryNotFound, got %v", err)
+	})
+
+	t.Run("propagates parse errors verbatim", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not a pkt-line stream"))
+		}))
+		defer server.Close()
+
+		client, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		_, err = client.FetchReceivePackCapabilities(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse receive-pack info/refs")
+	})
+}

--- a/protocol/receivepackcaps.go
+++ b/protocol/receivepackcaps.go
@@ -32,10 +32,11 @@ import (
 func ParseReceivePackInfoRefs(r io.Reader) ([]Capability, error) {
 	parser := NewParser(r)
 
-	// First pkt-line: "# service=git-receive-pack\n". Parser.Next surfaces
-	// flush packets as io.EOF — the intermediate flush between header and ref
-	// list will produce EOF too, so we keep reading past it until we see the
-	// first ref line or run out of input.
+	// First pkt-line: "# service=git-receive-pack\n". The receive-pack
+	// info/refs format has exactly one flush between the service header and
+	// the ref list (and one trailing flush at end of stream); readNonFlush
+	// skips that single intermediate flush before returning the next
+	// pkt-line.
 	first, err := readNonFlush(parser)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -79,9 +80,18 @@ func ParseReceivePackInfoRefs(r io.Reader) ([]Capability, error) {
 }
 
 // readNonFlush returns the next non-flush pkt-line from p. Parser.Next maps
-// every flush packet (length == 0000) to io.EOF, so we retry on EOF: if the
-// EOF was a flush separator the retry reads the following pkt-line; if the
-// stream is genuinely exhausted the retry returns io.EOF again.
+// every flush packet (length == 0000) to io.EOF, so on EOF we retry exactly
+// once: if the EOF was a single flush separator the retry consumes the
+// following pkt-line; if the stream is genuinely exhausted the retry
+// returns io.EOF again.
+//
+// The receive-pack info/refs body has at most one flush between the
+// service header and the ref list (and a trailing flush at end of stream),
+// so a single retry is sufficient. Streams with two or more consecutive
+// flushes — which the format does not produce — would surface io.EOF on
+// the second flush and the caller would treat it as end of input. We
+// deliberately do not loop indefinitely on EOF because real EOF would
+// then never terminate.
 func readNonFlush(p *Parser) ([]byte, error) {
 	line, err := p.Next()
 	if err == nil {

--- a/protocol/receivepackcaps.go
+++ b/protocol/receivepackcaps.go
@@ -1,0 +1,94 @@
+package protocol
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParseReceivePackInfoRefs reads the body of GET info/refs?service=git-receive-pack
+// and returns the capabilities the server advertised after the NUL byte on
+// the first ref line. The Git Smart HTTP v1-style discovery format is:
+//
+//	001e# service=git-receive-pack\n
+//	0000
+//	<sha> <refname>\x00<cap1> <cap2> ...\n
+//	<sha> <refname>\n
+//	...
+//	0000
+//
+// Empty repositories advertise a synthetic "capabilities^{}" ref:
+//
+//	0000000000000000000000000000000000000000 capabilities^{}\x00<caps>
+//
+// The parser is intentionally pure: it accepts an io.Reader, never touches
+// net/http, and never blocks the caller on transport state. The caller is
+// responsible for reading response bodies and for reporting transport errors.
+//
+// Returns an empty slice (not nil) when the first ref line has no NUL — i.e.,
+// the server advertised zero capabilities. Returns an error when the response
+// is malformed (not a pkt-line stream, missing service header, no ref lines).
+func ParseReceivePackInfoRefs(r io.Reader) ([]Capability, error) {
+	parser := NewParser(r)
+
+	// First pkt-line: "# service=git-receive-pack\n". Parser.Next surfaces
+	// flush packets as io.EOF — the intermediate flush between header and ref
+	// list will produce EOF too, so we keep reading past it until we see the
+	// first ref line or run out of input.
+	first, err := readNonFlush(parser)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("receive-pack info/refs: empty response")
+		}
+		return nil, fmt.Errorf("receive-pack info/refs: read service header: %w", err)
+	}
+	service := strings.TrimRight(string(first), "\n")
+	if service != "# service=git-receive-pack" {
+		return nil, fmt.Errorf("receive-pack info/refs: expected service header, got %q", service)
+	}
+
+	refLine, err := readNonFlush(parser)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("receive-pack info/refs: no ref lines after service header")
+		}
+		return nil, fmt.Errorf("receive-pack info/refs: read first ref line: %w", err)
+	}
+
+	// First ref line: "<sha> <refname>\x00<caps>\n" — split on NUL.
+	line := strings.TrimRight(string(refLine), "\n")
+	_, capPart, ok := strings.Cut(line, "\x00")
+	if !ok || capPart == "" {
+		// Either no NUL (server advertised no capabilities on the first ref —
+		// unusual but technically legal) or NUL with empty suffix. Return an
+		// empty (non-nil) slice so callers can distinguish "advertised
+		// nothing" from "parse error".
+		return []Capability{}, nil
+	}
+
+	tokens := strings.Split(capPart, " ")
+	caps := make([]Capability, 0, len(tokens))
+	for _, t := range tokens {
+		if t == "" {
+			continue
+		}
+		caps = append(caps, Capability(t))
+	}
+	return caps, nil
+}
+
+// readNonFlush returns the next non-flush pkt-line from p. Parser.Next maps
+// every flush packet (length == 0000) to io.EOF, so we retry on EOF: if the
+// EOF was a flush separator the retry reads the following pkt-line; if the
+// stream is genuinely exhausted the retry returns io.EOF again.
+func readNonFlush(p *Parser) ([]byte, error) {
+	line, err := p.Next()
+	if err == nil {
+		return line, nil
+	}
+	if !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return p.Next()
+}

--- a/protocol/receivepackcaps_test.go
+++ b/protocol/receivepackcaps_test.go
@@ -1,0 +1,161 @@
+package protocol_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/grafana/nanogit/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pktLine returns a wire-format pkt-line for raw payload data, with the
+// 4-byte hex length prefix. Used to build realistic info/refs bodies in
+// tests without depending on the higher-level FormatPacks helper (we want
+// fine control over flush placement and arbitrary trailing bytes).
+func pktLine(payload string) string {
+	length := len(payload) + 4
+	return strings.Join([]string{
+		// %04x format, lowercase, fixed width 4.
+		hex4(length),
+		payload,
+	}, "")
+}
+
+func hex4(n int) string {
+	const digits = "0123456789abcdef"
+	buf := []byte("0000")
+	for i := 3; i >= 0; i-- {
+		buf[i] = digits[n&0xF]
+		n >>= 4
+	}
+	return string(buf)
+}
+
+func TestParseReceivePackInfoRefs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("typical Gitea-style body", func(t *testing.T) {
+		// "# service=git-receive-pack\n", flush, ref-with-caps, ref, flush.
+		body := pktLine("# service=git-receive-pack\n") +
+			"0000" +
+			pktLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00report-status-v2 side-band-64k quiet object-format=sha1 agent=git/2.43\n") +
+			pktLine("00112233445566778899aabbccddeeff00112233 refs/heads/dev\n") +
+			"0000"
+
+		caps, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.NoError(t, err)
+		assert.Equal(t, []protocol.Capability{
+			protocol.CapReportStatusV2,
+			protocol.CapSideBand64k,
+			protocol.CapQuiet,
+			protocol.CapObjectFormatSHA1,
+			protocol.CapAgent("git/2.43"),
+		}, caps)
+	})
+
+	t.Run("GitHub-style body with agent prefix", func(t *testing.T) {
+		body := pktLine("# service=git-receive-pack\n") +
+			"0000" +
+			pktLine("0123456789abcdef0123456789abcdef01234567 refs/heads/main\x00report-status delete-refs side-band-64k quiet atomic ofs-delta agent=github/g16\n") +
+			"0000"
+
+		caps, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.NoError(t, err)
+		// Spot-check the high-value entries; we don't enumerate every server token.
+		assert.Contains(t, caps, protocol.CapSideBand64k)
+		assert.Contains(t, caps, protocol.CapAgent("github/g16"))
+		assert.Contains(t, caps, protocol.Capability("delete-refs"))
+	})
+
+	t.Run("empty repository advertises capabilities^{}", func(t *testing.T) {
+		// Empty repos have no real refs; Git's discovery uses a synthetic
+		// "0000...0000 capabilities^{}\x00<caps>" line so capability negotiation
+		// still works.
+		body := pktLine("# service=git-receive-pack\n") +
+			"0000" +
+			pktLine("0000000000000000000000000000000000000000 capabilities^{}\x00report-status-v2 side-band-64k object-format=sha1 agent=nano-server\n") +
+			"0000"
+
+		caps, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.NoError(t, err)
+		assert.Equal(t, []protocol.Capability{
+			protocol.CapReportStatusV2,
+			protocol.CapSideBand64k,
+			protocol.CapObjectFormatSHA1,
+			protocol.CapAgent("nano-server"),
+		}, caps)
+	})
+
+	t.Run("first ref has no NUL returns empty slice", func(t *testing.T) {
+		body := pktLine("# service=git-receive-pack\n") +
+			"0000" +
+			pktLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\n") +
+			"0000"
+
+		caps, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.NoError(t, err)
+		assert.NotNil(t, caps, "should return empty (non-nil) slice to distinguish from parse error")
+		assert.Empty(t, caps)
+	})
+
+	t.Run("first ref has NUL with empty cap list", func(t *testing.T) {
+		body := pktLine("# service=git-receive-pack\n") +
+			"0000" +
+			pktLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00\n") +
+			"0000"
+
+		caps, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.NoError(t, err)
+		assert.NotNil(t, caps)
+		assert.Empty(t, caps)
+	})
+
+	t.Run("malformed pkt-line length", func(t *testing.T) {
+		// Length field "zzzz" is not valid hex.
+		body := "zzzz# service=git-receive-pack\n"
+		_, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.Error(t, err)
+	})
+
+	t.Run("missing service header", func(t *testing.T) {
+		// First pkt-line is a regular ref instead of "# service=...".
+		body := pktLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00report-status-v2\n") +
+			"0000"
+		_, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected service header")
+	})
+
+	t.Run("empty body", func(t *testing.T) {
+		_, err := protocol.ParseReceivePackInfoRefs(bytes.NewReader(nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty response")
+	})
+
+	t.Run("no ref lines after service header", func(t *testing.T) {
+		body := pktLine("# service=git-receive-pack\n") + "0000"
+		_, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ref lines")
+	})
+
+	t.Run("trailing space in capability list", func(t *testing.T) {
+		// Some servers append trailing whitespace; we should not produce empty
+		// capability tokens that would later fail Validate().
+		body := pktLine("# service=git-receive-pack\n") +
+			"0000" +
+			pktLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00report-status-v2  quiet \n") +
+			"0000"
+
+		caps, err := protocol.ParseReceivePackInfoRefs(strings.NewReader(body))
+		require.NoError(t, err)
+		for _, c := range caps {
+			assert.NoError(t, c.Validate(),
+				"parser must not emit tokens that fail Validate; got %q", c)
+		}
+		assert.Contains(t, caps, protocol.CapReportStatusV2)
+		assert.Contains(t, caps, protocol.CapQuiet)
+	})
+}

--- a/push_negotiation_wire_test.go
+++ b/push_negotiation_wire_test.go
@@ -1,0 +1,215 @@
+package nanogit
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/nanogit/options"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// formatInfoRefsBody renders a v1-style info/refs?service=git-receive-pack
+// body advertising the given capabilities on the first ref line.
+func formatInfoRefsBody(t *testing.T, caps string) []byte {
+	t.Helper()
+	body, err := protocol.FormatPacks(
+		protocol.PackLine("# service=git-receive-pack\n"),
+		protocol.FlushPacket,
+		protocol.PackLine("aabbccddeeff00112233445566778899aabbccdd refs/heads/main\x00"+caps+"\n"),
+		protocol.FlushPacket,
+	)
+	require.NoError(t, err)
+	return body
+}
+
+// TestNegotiation_DropsServerOmittedCapabilities is the core wire-level
+// guarantee: when the server advertises a strict subset, the receive-pack
+// POST that follows must advertise only the intersection (plus the
+// always-retained client caps). This is the property capability negotiation
+// buys us — and it's the property Gitea integration tests cannot prove from
+// outside the container.
+func TestNegotiation_DropsServerOmittedCapabilities(t *testing.T) {
+	refHash, err := hash.FromHex("1234567890123456789012345678901234567890")
+	require.NoError(t, err)
+
+	var (
+		infoRefsHits       atomic.Int32
+		gotReceivePackBody []byte
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/info/refs") && r.URL.Query().Get("service") == "git-receive-pack":
+			infoRefsHits.Add(1)
+			// Strict server: omits side-band-64k. This is the GitLab-shaped
+			// case the option is designed to handle defensively.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(formatInfoRefsBody(t, "report-status-v2 quiet object-format=sha1 agent=git/2.43"))
+		case strings.HasSuffix(r.URL.Path, "/git-upload-pack"):
+			// CreateRef calls GetRef first; "0000" signals no refs match.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("0000"))
+		case strings.HasSuffix(r.URL.Path, "/git-receive-pack"):
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			gotReceivePackBody = body
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(server.URL, options.WithCapabilityNegotiation())
+	require.NoError(t, err)
+
+	require.NoError(t, client.CreateRef(context.Background(), Ref{
+		Name: "refs/heads/feature",
+		Hash: refHash,
+	}))
+
+	// Exactly one info/refs fetch for capability negotiation.
+	assert.Equal(t, int32(1), infoRefsHits.Load(),
+		"capability negotiation should fetch info/refs exactly once")
+
+	// The receive-pack POST must NOT advertise side-band-64k because the
+	// server didn't advertise it. This is the visible behavior change.
+	require.NotEmpty(t, gotReceivePackBody)
+	assert.NotContains(t, string(gotReceivePackBody), string(protocol.CapSideBand64k),
+		"side-band-64k should be filtered out when the server doesn't advertise it")
+
+	// The always-retained capabilities (report-status-v2 and our agent=)
+	// must still be present, regardless.
+	assert.Contains(t, string(gotReceivePackBody), string(protocol.CapReportStatusV2))
+	assert.Contains(t, string(gotReceivePackBody), string(protocol.CapAgent("nanogit")),
+		"agent= should always carry the client's identifier, not the server's")
+}
+
+// TestNegotiation_CachedAcrossRefOps verifies sync.Once caching: a sequence
+// of CreateRef ops on the same client must perform exactly one info/refs
+// fetch, not one per call.
+func TestNegotiation_CachedAcrossRefOps(t *testing.T) {
+	refHash, err := hash.FromHex("1234567890123456789012345678901234567890")
+	require.NoError(t, err)
+
+	var infoRefsHits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/info/refs") && r.URL.Query().Get("service") == "git-receive-pack":
+			infoRefsHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(formatInfoRefsBody(t, "report-status-v2 side-band-64k quiet object-format=sha1 agent=git/2.43"))
+		case strings.HasSuffix(r.URL.Path, "/git-upload-pack"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("0000"))
+		case strings.HasSuffix(r.URL.Path, "/git-receive-pack"):
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(server.URL, options.WithCapabilityNegotiation())
+	require.NoError(t, err)
+
+	// Three create-ref ops, one client. The negotiation fetch must run exactly once.
+	for _, name := range []string{"refs/heads/a", "refs/heads/b", "refs/heads/c"} {
+		require.NoError(t, client.CreateRef(context.Background(), Ref{Name: name, Hash: refHash}))
+	}
+
+	assert.Equal(t, int32(1), infoRefsHits.Load(),
+		"capability negotiation should be cached across ref ops via sync.Once")
+}
+
+// TestNegotiation_FailurePropagates verifies that a negotiation fetch error
+// aborts the push instead of silently falling back to the static set.
+// Silent fallback would hide server misconfiguration and contradict the
+// explicit opt-in.
+func TestNegotiation_FailurePropagates(t *testing.T) {
+	refHash, err := hash.FromHex("1234567890123456789012345678901234567890")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/info/refs") && r.URL.Query().Get("service") == "git-receive-pack":
+			// 404 here exercises the CheckHTTPClientError path.
+			w.WriteHeader(http.StatusNotFound)
+		case strings.HasSuffix(r.URL.Path, "/git-upload-pack"):
+			// CreateRef calls GetRef before the negotiation lookup; let it
+			// succeed with "no refs match" so the negotiation step is what
+			// actually trips the test.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("0000"))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(server.URL, options.WithCapabilityNegotiation())
+	require.NoError(t, err)
+
+	err = client.CreateRef(context.Background(), Ref{
+		Name: "refs/heads/feature",
+		Hash: refHash,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negotiate receive-pack capabilities",
+		"error chain should mention the negotiation step rather than masking it")
+}
+
+// TestNoNegotiation_DefaultBehaviorUnchanged guards the opt-in contract:
+// without WithCapabilityNegotiation the client must not fetch info/refs at
+// all and must advertise the full static default set.
+func TestNoNegotiation_DefaultBehaviorUnchanged(t *testing.T) {
+	refHash, err := hash.FromHex("1234567890123456789012345678901234567890")
+	require.NoError(t, err)
+
+	var (
+		infoRefsHits       atomic.Int32
+		gotReceivePackBody []byte
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/info/refs"):
+			infoRefsHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/git-upload-pack"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("0000"))
+		case strings.HasSuffix(r.URL.Path, "/git-receive-pack"):
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			gotReceivePackBody = body
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	// No negotiation option — should behave exactly like before.
+	client, err := NewHTTPClient(server.URL)
+	require.NoError(t, err)
+
+	require.NoError(t, client.CreateRef(context.Background(), Ref{
+		Name: "refs/heads/feature",
+		Hash: refHash,
+	}))
+
+	assert.Equal(t, int32(0), infoRefsHits.Load(),
+		"info/refs should not be fetched when negotiation is off")
+	assert.Contains(t, string(gotReceivePackBody), string(protocol.CapSideBand64k),
+		"the static default set must still be advertised when negotiation is off")
+}

--- a/push_negotiation_wire_test.go
+++ b/push_negotiation_wire_test.go
@@ -168,6 +168,59 @@ func TestNegotiation_FailurePropagates(t *testing.T) {
 		"error chain should mention the negotiation step rather than masking it")
 }
 
+// TestNegotiation_TransientFailureDoesNotPoisonClient guards the retry
+// contract: if the first negotiation fetch fails (transient network error,
+// 5xx, etc.), a subsequent call must retry rather than return the cached
+// error forever. sync.Once would have poisoned the client; the mutex-based
+// implementation only caches successes.
+func TestNegotiation_TransientFailureDoesNotPoisonClient(t *testing.T) {
+	refHash, err := hash.FromHex("1234567890123456789012345678901234567890")
+	require.NoError(t, err)
+
+	var infoRefsHits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/info/refs") && r.URL.Query().Get("service") == "git-receive-pack":
+			n := infoRefsHits.Add(1)
+			if n == 1 {
+				// First call fails — a transient network blip in disguise.
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			// Second call succeeds.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(formatInfoRefsBody(t, "report-status-v2 side-band-64k quiet object-format=sha1 agent=git/2.43"))
+		case strings.HasSuffix(r.URL.Path, "/git-upload-pack"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("0000"))
+		case strings.HasSuffix(r.URL.Path, "/git-receive-pack"):
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(server.URL, options.WithCapabilityNegotiation())
+	require.NoError(t, err)
+
+	// First call: server returns 500 → CreateRef must error out without
+	// caching the failure.
+	err = client.CreateRef(context.Background(), Ref{Name: "refs/heads/a", Hash: refHash})
+	require.Error(t, err, "first call should fail because the server is 500-ing")
+
+	// Second call: server now responds successfully → CreateRef must retry
+	// the negotiation fetch (not return the stale error) and succeed.
+	require.NoError(t, client.CreateRef(context.Background(), Ref{Name: "refs/heads/b", Hash: refHash}),
+		"a transient first failure must not poison the client")
+
+	// Two info/refs hits: one for the failed first attempt, one for the
+	// successful retry. Subsequent ops would reuse the cached success.
+	assert.Equal(t, int32(2), infoRefsHits.Load(),
+		"failed negotiation must not be cached; the next call should retry")
+}
+
 // TestNoNegotiation_DefaultBehaviorUnchanged guards the opt-in contract:
 // without WithCapabilityNegotiation the client must not fetch info/refs at
 // all and must advertise the full static default set.

--- a/refs.go
+++ b/refs.go
@@ -167,7 +167,11 @@ func (c *httpClient) CreateRef(ctx context.Context, ref Ref) error {
 		return fmt.Errorf("check existing ref %q: %w", ref.Name, err)
 	}
 
-	req := protocol.NewCreateRefRequest(ref.Name, ref.Hash, c.receivePackCapabilities...)
+	caps, err := c.effectiveReceivePackCapabilities(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve receive-pack capabilities: %w", err)
+	}
+	req := protocol.NewCreateRefRequest(ref.Name, ref.Hash, caps...)
 	pkt, err := req.Format()
 	if err != nil {
 		return fmt.Errorf("format ref create request for %q: %w", ref.Name, err)
@@ -224,7 +228,11 @@ func (c *httpClient) UpdateRef(ctx context.Context, ref Ref) error {
 		return fmt.Errorf("get existing ref %q: %w", ref.Name, err)
 	}
 
-	req := protocol.NewUpdateRefRequest(oldRef.Hash, ref.Hash, ref.Name, c.receivePackCapabilities...)
+	caps, err := c.effectiveReceivePackCapabilities(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve receive-pack capabilities: %w", err)
+	}
+	req := protocol.NewUpdateRefRequest(oldRef.Hash, ref.Hash, ref.Name, caps...)
 	pkt, err := req.Format()
 	if err != nil {
 		return fmt.Errorf("format ref update request for %q: %w", ref.Name, err)
@@ -278,7 +286,11 @@ func (c *httpClient) DeleteRef(ctx context.Context, refName string) error {
 		return fmt.Errorf("get existing ref %q: %w", refName, err)
 	}
 
-	req := protocol.NewDeleteRefRequest(oldRef.Hash, refName, c.receivePackCapabilities...)
+	caps, err := c.effectiveReceivePackCapabilities(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve receive-pack capabilities: %w", err)
+	}
+	req := protocol.NewDeleteRefRequest(oldRef.Hash, refName, caps...)
 	pkt, err := req.Format()
 	if err != nil {
 		return fmt.Errorf("format ref delete request for %q: %w", refName, err)

--- a/tests/providers_negotiation_integration_test.go
+++ b/tests/providers_negotiation_integration_test.go
@@ -1,0 +1,128 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/grafana/nanogit/log"
+	"github.com/grafana/nanogit/options"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProvidersCapabilityNegotiation exercises the full
+// WithCapabilityNegotiation() path end-to-end against a real provider
+// (GitHub / GitLab / Bitbucket via the make test-providers matrix). Unlike
+// the Gitea Ginkgo spec, which only proves the wiring works against a
+// container we control, this test exercises the parser against each
+// provider's actual receive-pack info/refs response shape and verifies the
+// negotiated capability set is sufficient for a real push.
+//
+// Skipped (like the other TestProviders* tests) when the TEST_REPO /
+// TEST_TOKEN / TEST_USER env vars are unset.
+func TestProvidersCapabilityNegotiation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping testproviders suite in short mode")
+		return
+	}
+
+	if os.Getenv("TEST_REPO") == "" || os.Getenv("TEST_TOKEN") == "" || os.Getenv("TEST_USER") == "" {
+		t.Skip("Skipping testproviders suite: TEST_REPO or TEST_TOKEN or TEST_USER not set")
+		return
+	}
+
+	ctx := log.ToContext(context.Background(), gittest.NewStructuredLogger(gittest.NewTestLogger(t)))
+	client, err := nanogit.NewHTTPClient(
+		os.Getenv("TEST_REPO"),
+		options.WithBasicAuth(os.Getenv("TEST_USER"), os.Getenv("TEST_TOKEN")),
+		options.WithCapabilityNegotiation(),
+	)
+	require.NoError(t, err)
+
+	// Sanity: the same client we'll push with must report read access.
+	// This is the first call that consumes the negotiated set indirectly
+	// (LsRefs goes over upload-pack; receive-pack negotiation fires later
+	// when we touch ref-update endpoints).
+	auth, err := client.IsAuthorized(ctx)
+	require.NoError(t, err)
+	require.True(t, auth)
+
+	branchName := fmt.Sprintf("test-negotiation-%d", time.Now().Unix())
+	mainRef, err := client.GetRef(ctx, "refs/heads/main")
+	require.NoError(t, err)
+
+	// CreateRef triggers the lazy negotiation fetch (GET info/refs?service=git-receive-pack)
+	// against the real provider. A parse failure here would mean the provider's
+	// receive-pack discovery shape is something the parser can't handle.
+	err = client.CreateRef(ctx, nanogit.Ref{
+		Name: "refs/heads/" + branchName,
+		Hash: mainRef.Hash,
+	})
+	require.NoError(t, err, "CreateRef must succeed when capability negotiation is enabled")
+
+	t.Cleanup(func() {
+		// Cleanup uses the cached negotiated set — no extra round-trip.
+		err := client.DeleteRef(ctx, "refs/heads/"+branchName)
+		require.NoError(t, err)
+	})
+
+	// Full push flow. NewStagedWriter goes through the same
+	// effectiveReceivePackCapabilities path (already cached at this point)
+	// and threads the negotiated set into the packfile writer.
+	branchRef, err := client.GetRef(ctx, "refs/heads/"+branchName)
+	require.NoError(t, err)
+
+	writer, err := client.NewStagedWriter(ctx, branchRef)
+	require.NoError(t, err)
+
+	author := nanogit.Author{
+		Name:  "Negotiation Test",
+		Email: "negotiation-test@example.com",
+		Time:  time.Now(),
+	}
+	committer := nanogit.Committer{
+		Name:  "Negotiation Test",
+		Email: "negotiation-test@example.com",
+		Time:  time.Now(),
+	}
+
+	_, err = writer.CreateBlob(ctx, "negotiation.txt", []byte("pushed via capability negotiation"))
+	require.NoError(t, err)
+
+	commit, err := writer.Commit(ctx, "Add file via negotiated capabilities", author, committer)
+	require.NoError(t, err)
+
+	// The push itself: a real receive-pack POST advertising only the
+	// intersected capabilities. If the provider rejects the negotiated
+	// set or our parser dropped a capability the provider requires, this
+	// is where it surfaces.
+	err = writer.Push(ctx)
+	require.NoError(t, err, "Push must succeed using the negotiated capability set")
+
+	// Read-after-write: confirm the ref actually moved to our commit.
+	branchRef, err = client.GetRef(ctx, "refs/heads/"+branchName)
+	require.NoError(t, err)
+	require.Equal(t, commit.Hash, branchRef.Hash, "branch should point at the negotiated push's commit")
+
+	// Second push on the same client. This exercises the cache: the
+	// post-push writer reset (writer.go) and any subsequent ref op should
+	// reuse the negotiated set without re-fetching info/refs. We can't
+	// observe the round-trip count from outside, but if caching were
+	// broken in a way that produced a wire-incompatible cap set, this
+	// second push would fail.
+	_, err = writer.UpdateBlob(ctx, "negotiation.txt", []byte("updated via cached negotiated caps"))
+	require.NoError(t, err)
+	updateCommit, err := writer.Commit(ctx, "Update file (cached negotiated caps)", author, committer)
+	require.NoError(t, err)
+	require.NoError(t, writer.Push(ctx), "second push must reuse cached negotiated caps")
+
+	branchRef, err = client.GetRef(ctx, "refs/heads/"+branchName)
+	require.NoError(t, err)
+	require.Equal(t, updateCommit.Hash, branchRef.Hash, "branch should point at the second commit")
+
+	t.Logf("Capability negotiation succeeded end-to-end against the configured provider")
+}

--- a/tests/push_negotiation_integration_test.go
+++ b/tests/push_negotiation_integration_test.go
@@ -1,0 +1,67 @@
+package integration_test
+
+import (
+	"time"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/options"
+	"github.com/grafana/nanogit/protocol/hash"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Capability negotiation happy path against the Gitea container. Gitea
+// advertises the full default set, so the negotiated intersection is
+// observably equivalent to the static defaults — what we exercise here is
+// that the lazy fetch + sync.Once cache + intersection wiring all run
+// cleanly through a real receive-pack discovery and a real push.
+var _ = Describe("Push with capability negotiation", func() {
+	author := nanogit.Author{
+		Name:  "Test Author",
+		Email: "test@example.com",
+		Time:  time.Now(),
+	}
+	committer := nanogit.Committer{
+		Name:  "Test Committer",
+		Email: "test@example.com",
+		Time:  time.Now(),
+	}
+
+	It("creates and pushes a commit when negotiation is enabled", func() {
+		client, _, local, _ := QuickSetup(options.WithCapabilityNegotiation())
+
+		headOutput, err := local.Git("rev-parse", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		head, err := hash.FromHex(headOutput)
+		Expect(err).NotTo(HaveOccurred())
+
+		writer, err := client.NewStagedWriter(ctx, nanogit.Ref{
+			Name: "refs/heads/main",
+			Hash: head,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = writer.CreateBlob(ctx, "negotiation.txt", []byte("negotiated"))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = writer.Commit(ctx, "add file via negotiation", author, committer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(writer.Push(ctx)).To(Succeed())
+	})
+
+	It("reuses the negotiated set across multiple ref operations", func() {
+		// sync.Once on httpClient guarantees we don't fetch info/refs more
+		// than once even when the caller drives many ref ops in a row. We
+		// can't observe the round-trip count from outside Gitea, but the
+		// operations must still all succeed end-to-end.
+		client, _, _, _ := QuickSetup(options.WithCapabilityNegotiation())
+
+		for range 3 {
+			refs, err := client.ListRefs(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(refs).NotTo(BeEmpty())
+		}
+	})
+})

--- a/writer.go
+++ b/writer.go
@@ -103,7 +103,11 @@ func (c *httpClient) NewStagedWriter(ctx context.Context, ref Ref, options ...Wr
 		protocolStorageMode = protocol.PackfileStorageAuto
 	}
 
-	writer := protocol.NewPackfileWriter(crypto.SHA1, protocolStorageMode, c.receivePackCapabilities...)
+	caps, err := c.effectiveReceivePackCapabilities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve receive-pack capabilities: %w", err)
+	}
+	writer := protocol.NewPackfileWriter(crypto.SHA1, protocolStorageMode, caps...)
 	return &stagedWriter{
 		client:      c,
 		ref:         ref,
@@ -941,7 +945,16 @@ func (w *stagedWriter) Push(ctx context.Context) error {
 	// Always reset the writer and update the ref even if cleanup fails, to maintain consistency
 	// with the successful push that already happened on the server.
 	cleanupErr := w.writer.Cleanup()
-	w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode, w.client.receivePackCapabilities...)
+	// Capability negotiation is cached behind sync.Once on the client; by the
+	// time we reach this post-push reset the same client has already
+	// negotiated successfully (NewStagedWriter is the first call that fires
+	// it), so this lookup hits the cached value with no extra round-trip.
+	caps, capsErr := w.client.effectiveReceivePackCapabilities(ctx)
+	if capsErr != nil {
+		w.ref.Hash = w.lastCommit.Hash
+		return fmt.Errorf("resolve receive-pack capabilities after push: %w", capsErr)
+	}
+	w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode, caps...)
 	w.ref.Hash = w.lastCommit.Hash
 
 	logger.Debug("Push completed",
@@ -1268,8 +1281,14 @@ func (w *stagedWriter) Cleanup(ctx context.Context) error {
 	w.treeEntries = make(map[string]*FlatTreeEntry)
 	w.dirtyPaths = make(map[string]bool)
 
-	// Reset writer state
-	w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode, w.client.receivePackCapabilities...)
+	// Reset writer state. Capability negotiation, if enabled, is cached
+	// behind sync.Once so this lookup reuses the result negotiated when the
+	// writer was constructed.
+	caps, err := w.client.effectiveReceivePackCapabilities(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve receive-pack capabilities during cleanup: %w", err)
+	}
+	w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode, caps...)
 
 	// Mark as cleaned up to prevent further use
 	w.isCleanedUp = true

--- a/writer_test.go
+++ b/writer_test.go
@@ -64,6 +64,10 @@ func (m *mockRawClient) UploadPack(ctx context.Context, data io.Reader) (io.Read
 	return nil, errors.New("not implemented")
 }
 
+func (m *mockRawClient) FetchReceivePackCapabilities(ctx context.Context) ([]protocol.Capability, error) {
+	return nil, errors.New("not implemented")
+}
+
 // TestStagedWriter_Cleanup_NormalBehavior tests that Cleanup()
 // properly cleans up resources and marks the writer as cleaned up.
 func TestStagedWriter_Cleanup_NormalBehavior(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `options.WithCapabilityNegotiation()` (and a CLI `--negotiate-capabilities` flag). When enabled, the client fetches the server's advertised receive-pack capabilities once per client lifetime and advertises the **intersection** with its desired set on subsequent ref updates. Default behavior is unchanged — this is fully opt-in.

Motivated by the [seps GitLab support escalation](https://github.com/grafana/support-escalations/issues/21934), where the customer had to be told to manually omit `side-band-64k` via the existing `WithReceivePackCapabilities` escape hatch. Negotiation flips that around: nanogit asks the server what it supports.

**Honest scope note**: this would NOT have prevented the PR #270 GitLab side-band-wrapping bug — that GitLab does advertise `side-band-64k`, and the bug was in nanogit's parser. This is "defensive correctness for strict servers and cleaner traces," not a bug fix.

## Design rules

- **Layer separation**: negotiation lives in `httpClient` (Go layer). `protocol/` stays pure — it gets a parser (`ParseReceivePackInfoRefs`) and an intersection helper (`IntersectCapabilities`) but no transport state.
- **Key-based intersection**: client `agent=nanogit` matches server `agent=git/2.43`; the client value is kept.
- **Always-retained capabilities**: `report-status-v2` (parser depends on it — dropping it would re-introduce silent push success on rejection) and `agent=` (pure client self-identifier) are kept regardless of what the server advertised.
- **sync.Once caching**: a single `GET info/refs?service=git-receive-pack` per client lifetime. Writer resets after `Push` and `Cleanup` reuse the cached set with no extra round-trips.
- **Fail loud**: negotiation fetch errors propagate up and abort the push. 4xx responses go through the existing `CheckHTTPClientError` mapping so users see the usual `ErrRepositoryNotFound` / auth errors.

## Changes

- **`protocol/`** — new pure helpers:
  - `IntersectCapabilities(client, server []Capability) []Capability` (`protocol/capabilities.go`)
  - `ParseReceivePackInfoRefs(io.Reader) ([]Capability, error)` (`protocol/receivepackcaps.go`)
- **`protocol/client/`** — interface gets `FetchReceivePackCapabilities(ctx)`; implementation mirrors `smartinfo.go` for headers/retry/error mapping. `mocks/raw_client.go` regenerated.
- **`options/`** — `Options.NegotiateCapabilities bool` + `WithCapabilityNegotiation() Option`.
- **`client.go`** — `httpClient` gains `negotiateCaps`, `negotiateOnce sync.Once`, `negotiatedCaps`, `negotiateErr` and an `effectiveReceivePackCapabilities(ctx)` helper.
- **`refs.go` (3 sites) + `writer.go` (3 sites)** — direct field access replaced by helper calls; errors propagate.
- **`cli/cmd/nanogit/client_setup.go`** — new `addWriteFlags(cmd)` + `buildClientOptions()` shared across write subcommands. `--negotiate-capabilities` and the existing `--receive-pack-capability` flow through one place. `put-file` updated to use them.
- **`docs/`** — new "Programmatic negotiation" subsection in `server-compatibility.md`; cross-link from `quick-start.md`.

## Testing

- `make test-unit` — passes (10 packages clean).
- `make lint` — 0 issues.
- `make lint-staticcheck` — clean.

New test coverage:
- **`protocol/receivepackcaps_test.go`** — 9 cases: Gitea/GitHub/empty-repo bodies, no-NUL, empty cap list, malformed pkt, missing service header, empty body, trailing whitespace.
- **`protocol/capabilities_test.go`** — 9 `IntersectCapabilities` cases (key matching, order preservation, agent=, retained caps, side-band drop, empty inputs, slice independence).
- **`protocol/client/receivepackcaps_test.go`** — happy path, 404→`ErrRepositoryNotFound`, parse-error propagation.
- **`push_negotiation_wire_test.go`** — 4 `httptest`-driven assertions:
  - drops `side-band-64k` when the server omits it; retains `report-status-v2` + `agent=nanogit`
  - sync.Once caches across 3 `CreateRef` ops (single info/refs hit)
  - 404 during negotiation surfaces with `"negotiate receive-pack capabilities"` (not silently masked)
  - default behavior unchanged when the option is not set
- **`tests/push_negotiation_integration_test.go`** — Gitea Ginkgo specs: full create-blob/commit/push under negotiation; 3-call `ListRefs` reuse.

Manual smoke (CLI):
```bash
NANOGIT_TRACE=1 nanogit -v put-file --negotiate-capabilities <repo> <branch> <path> -m test --author "X <x@y>" < f
```
Expect a single extra `GET info/refs?service=git-receive-pack` in the trace before the push, then the receive-pack POST advertising only the intersected set.

## Checklist

- [x] Tests added (parser, intersection, transport, wire-level, integration)
- [x] Documentation updated (server-compatibility.md + quick-start.md cross-link)
- [x] No breaking changes (fully opt-in; default path untouched)
- [ ] `make test-integration` (requires Docker — please run before merge)

## Follow-up

Once shipped, update [grafana/support-escalations#21934](https://github.com/grafana/support-escalations/issues/21934) to point at `WithCapabilityNegotiation()` as a more ergonomic alternative to listing capabilities by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)