### PR TITLE
feat: surface side-band channel-2 progress in receive-pack errors

### DIFF
--- a/gittest/server.go
+++ b/gittest/server.go
@@ -126,7 +126,13 @@ func NewServer(ctx context.Context, opts ...ServerOption) (*Server, error) {
 		"GITEA__security__SECRET_KEY":             "supersecretkey",
 		"GITEA__security__INTERNAL_TOKEN":         "internal",
 		"GITEA__security__DISABLE_GITEA_SSH":      "true",
-		"GITEA__mailer__ENABLED":                  "false",
+		// Allow site admins to set custom git hooks via the API.
+		// Gitea defaults this to true; we flip it so integration tests
+		// can install per-repo pre-receive hooks to exercise the
+		// receive-pack error path with realistic side-band channel-2
+		// progress (e.g. hook stderr surfaced as remote: messages).
+		"GITEA__security__DISABLE_GIT_HOOKS": "false",
+		"GITEA__mailer__ENABLED":             "false",
 	}
 
 	// Start Gitea container

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -28,6 +28,44 @@ var ErrMissingReportStatus = errors.New("receive-pack response did not contain '
 // unpackOkLine is the Git report-status success sentinel (gitprotocol-pack).
 var unpackOkLine = []byte("unpack ok")
 
+// maxRemoteProgressBytes caps the total bytes of side-band channel 2
+// (progress) buffered per receive-pack response. The buffer is only
+// read on the error path, but is populated speculatively from every
+// channel-2 packet — without a cap, a successful push that streams
+// verbose progress would retain it all until EOF and then drop it,
+// regressing memory usage versus the pre-channel-2-capture code path.
+//
+// 64 KiB is an order of magnitude larger than realistic hook output
+// (typical GitLab push-rule violations and pre-receive hook messages
+// are well under 1 KiB) yet small enough that worst-case retention is
+// trivial even under high concurrency. When exceeded, further
+// channel-2 packets are silently dropped — the surfaced error message
+// gets clipped, which is far better than an unbounded allocation.
+const maxRemoteProgressBytes = 64 * 1024
+
+// remoteProgressBuffer captures side-band channel 2 payloads up to a
+// fixed total byte budget. Once the budget is exhausted further
+// payloads are dropped on the floor; the truncation is silent because
+// the only consumer (decodeRemoteProgress) is purely diagnostic and
+// the alternative — a "(truncated)" sentinel line — adds noise to the
+// surfaced error string for negligible debugging value.
+type remoteProgressBuffer struct {
+	payloads [][]byte
+	used     int
+}
+
+func (b *remoteProgressBuffer) append(payload []byte) {
+	if len(payload) == 0 || b.used >= maxRemoteProgressBytes {
+		return
+	}
+	remain := maxRemoteProgressBytes - b.used
+	if len(payload) > remain {
+		payload = payload[:remain]
+	}
+	b.payloads = append(b.payloads, payload)
+	b.used += len(payload)
+}
+
 // ReceivePack sends a POST request to the git-receive-pack endpoint.
 // This endpoint is used to send objects to the remote repository.
 // The data parameter is streamed to the server, and the response is parsed internally.
@@ -117,20 +155,20 @@ func parseReceivePackResponse(body io.Reader) (err error) {
 	// progress.
 	sawReportStatusContent := false
 	var sideBandPackets [][]byte
-	// progressPackets accumulates side-band channel 2 payloads in
-	// arrival order. Channel 2 carries the human-readable output of
-	// pre-receive hooks and push rules (visible to git CLI users as
-	// `remote: …` lines), which is the actionable detail behind a
-	// bare "pre-receive hook declined" or "push rule violation"
-	// reason. We surface it on the error path only — successful
-	// pushes don't need it, and including it on success would just
-	// noisy-up benign progress.
-	var progressPackets [][]byte
+	// progress accumulates side-band channel 2 payloads up to
+	// maxRemoteProgressBytes. Channel 2 carries the human-readable
+	// output of pre-receive hooks and push rules (visible to git CLI
+	// users as `remote: …` lines), which is the actionable detail
+	// behind a bare "pre-receive hook declined" or "push rule
+	// violation" reason. We surface it on the error path only —
+	// successful pushes drop it after EOF — and the cap keeps a
+	// successful, verbose push from holding onto unbounded progress.
+	var progress remoteProgressBuffer
 	defer func() {
 		if err == nil {
 			return
 		}
-		msgs := decodeRemoteProgress(progressPackets)
+		msgs := decodeRemoteProgress(progress.payloads)
 		if len(msgs) == 0 {
 			return
 		}
@@ -145,7 +183,7 @@ func parseReceivePackResponse(body io.Reader) (err error) {
 		if parseErr != nil {
 			return fmt.Errorf("git protocol error: %w", parseErr)
 		}
-		ok, content, classifyErr := classifyReceivePackLine(line, &sideBandPackets, &progressPackets)
+		ok, content, classifyErr := classifyReceivePackLine(line, &sideBandPackets, &progress)
 		if classifyErr != nil {
 			return classifyErr
 		}
@@ -180,11 +218,11 @@ func parseReceivePackResponse(body io.Reader) (err error) {
 
 // classifyReceivePackLine inspects a single parsed pkt-line from the
 // receive-pack response and either appends a channel-1 payload to the
-// running side-band buffer, captures a channel-2 progress payload,
-// returns a fatal channel-3 error, or signals whether the line counts
-// as report-status content / contains an "unpack ok" sentinel for the
-// bare channel-0 case.
-func classifyReceivePackLine(line []byte, sideBandPackets, progressPackets *[][]byte) (sawUnpackOk, sawReportStatusContent bool, err error) {
+// running side-band buffer, captures a channel-2 progress payload (up
+// to the buffer's byte budget), returns a fatal channel-3 error, or
+// signals whether the line counts as report-status content / contains
+// an "unpack ok" sentinel for the bare channel-0 case.
+func classifyReceivePackLine(line []byte, sideBandPackets *[][]byte, progress *remoteProgressBuffer) (sawUnpackOk, sawReportStatusContent bool, err error) {
 	if len(line) == 0 {
 		return false, false, nil
 	}
@@ -196,11 +234,9 @@ func classifyReceivePackLine(line []byte, sideBandPackets, progressPackets *[][]
 		// returned from this response — pre-receive hook stdout and
 		// push-rule violation messages are emitted here on GitLab,
 		// and a bare "pre-receive hook declined" is rarely actionable
-		// without that context.
-		payload := line[1:]
-		if len(payload) > 0 {
-			*progressPackets = append(*progressPackets, payload)
-		}
+		// without that context. Capture is bounded; see
+		// remoteProgressBuffer.
+		progress.append(line[1:])
 		return false, false, nil
 	case 0x03:
 		// Channel 3 is fatal. detectError already converts the
@@ -369,10 +405,13 @@ func isUnpackOkLine(line []byte) bool {
 
 // decodeRemoteProgress concatenates side-band channel 2 payloads,
 // splits them on LF or CR (servers commonly use \r for spinner
-// updates), trims surrounding whitespace, and returns the non-empty
-// lines in arrival order. Channel 2 is a byte stream, so an
-// individual progress line may be split across outer packets;
-// reassembly before splitting is essential.
+// updates), trims trailing whitespace, and returns the non-empty
+// lines in arrival order. Leading whitespace is preserved so indented
+// hook output (bullet lists, sub-items emitted by GitLab push rules,
+// etc.) renders correctly when re-surfaced as `remote: …` lines.
+// Channel 2 is a byte stream, so an individual progress line may be
+// split across outer packets; reassembly before splitting is
+// essential.
 func decodeRemoteProgress(packets [][]byte) []string {
 	if len(packets) == 0 {
 		return nil
@@ -389,11 +428,14 @@ func decodeRemoteProgress(packets [][]byte) []string {
 	}
 	out := make([]string, 0, len(lines))
 	for _, l := range lines {
-		trimmed := bytes.TrimSpace(l)
-		if len(trimmed) == 0 {
+		// TrimRight strips trailing CR/whitespace from the kept
+		// content; TrimSpace is used only to decide emptiness so
+		// lines like "    - bullet" keep their indentation.
+		kept := bytes.TrimRight(l, " \t\r\n")
+		if len(bytes.TrimSpace(kept)) == 0 {
 			continue
 		}
-		out = append(out, string(trimmed))
+		out = append(out, string(kept))
 	}
 	if len(out) == 0 {
 		return nil

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -105,7 +105,7 @@ func (c *rawClient) ReceivePack(ctx context.Context, data io.Reader) (err error)
 // strategy. Channel-1 unwrap is scoped to this function and does not
 // leak into the generic detectError path, where channel 1 also carries
 // binary packfile data during fetch/clone.
-func parseReceivePackResponse(body io.Reader) error {
+func parseReceivePackResponse(body io.Reader) (err error) {
 	parser := protocol.NewParser(body)
 	sawUnpackOk := false
 	// sawReportStatusContent tracks whether the server sent anything
@@ -117,16 +117,35 @@ func parseReceivePackResponse(body io.Reader) error {
 	// progress.
 	sawReportStatusContent := false
 	var sideBandPackets [][]byte
+	// progressPackets accumulates side-band channel 2 payloads in
+	// arrival order. Channel 2 carries the human-readable output of
+	// pre-receive hooks and push rules (visible to git CLI users as
+	// `remote: …` lines), which is the actionable detail behind a
+	// bare "pre-receive hook declined" or "push rule violation"
+	// reason. We surface it on the error path only — successful
+	// pushes don't need it, and including it on success would just
+	// noisy-up benign progress.
+	var progressPackets [][]byte
+	defer func() {
+		if err == nil {
+			return
+		}
+		msgs := decodeRemoteProgress(progressPackets)
+		if len(msgs) == 0 {
+			return
+		}
+		err = &protocol.RemoteRejectionError{Err: err, RemoteMessages: msgs}
+	}()
 
 	for {
-		line, err := parser.Next()
-		if err == io.EOF {
+		line, parseErr := parser.Next()
+		if parseErr == io.EOF {
 			break
 		}
-		if err != nil {
-			return fmt.Errorf("git protocol error: %w", err)
+		if parseErr != nil {
+			return fmt.Errorf("git protocol error: %w", parseErr)
 		}
-		ok, content, classifyErr := classifyReceivePackLine(line, &sideBandPackets)
+		ok, content, classifyErr := classifyReceivePackLine(line, &sideBandPackets, &progressPackets)
 		if classifyErr != nil {
 			return classifyErr
 		}
@@ -161,17 +180,27 @@ func parseReceivePackResponse(body io.Reader) error {
 
 // classifyReceivePackLine inspects a single parsed pkt-line from the
 // receive-pack response and either appends a channel-1 payload to the
-// running side-band buffer, returns a fatal channel-3 error, or signals
-// whether the line counts as report-status content / contains an
-// "unpack ok" sentinel for the bare channel-0 case.
-func classifyReceivePackLine(line []byte, sideBandPackets *[][]byte) (sawUnpackOk, sawReportStatusContent bool, err error) {
+// running side-band buffer, captures a channel-2 progress payload,
+// returns a fatal channel-3 error, or signals whether the line counts
+// as report-status content / contains an "unpack ok" sentinel for the
+// bare channel-0 case.
+func classifyReceivePackLine(line []byte, sideBandPackets, progressPackets *[][]byte) (sawUnpackOk, sawReportStatusContent bool, err error) {
 	if len(line) == 0 {
 		return false, false, nil
 	}
 	switch line[0] {
 	case 0x02:
 		// Channel 2 is progress; it never carries report-status and
-		// does not arm any requirement.
+		// does not arm any requirement. Capture the payload so
+		// parseReceivePackResponse can attach it to any error
+		// returned from this response — pre-receive hook stdout and
+		// push-rule violation messages are emitted here on GitLab,
+		// and a bare "pre-receive hook declined" is rarely actionable
+		// without that context.
+		payload := line[1:]
+		if len(payload) > 0 {
+			*progressPackets = append(*progressPackets, payload)
+		}
 		return false, false, nil
 	case 0x03:
 		// Channel 3 is fatal. detectError already converts the
@@ -336,4 +365,38 @@ func looksLikePktLine(data []byte) bool {
 // whitespace per gitprotocol-common.
 func isUnpackOkLine(line []byte) bool {
 	return bytes.Equal(bytes.TrimRight(line, " \t\r\n"), unpackOkLine)
+}
+
+// decodeRemoteProgress concatenates side-band channel 2 payloads,
+// splits them on LF or CR (servers commonly use \r for spinner
+// updates), trims surrounding whitespace, and returns the non-empty
+// lines in arrival order. Channel 2 is a byte stream, so an
+// individual progress line may be split across outer packets;
+// reassembly before splitting is essential.
+func decodeRemoteProgress(packets [][]byte) []string {
+	if len(packets) == 0 {
+		return nil
+	}
+	var buf bytes.Buffer
+	for _, p := range packets {
+		buf.Write(p)
+	}
+	lines := bytes.FieldsFunc(buf.Bytes(), func(r rune) bool {
+		return r == '\n' || r == '\r'
+	})
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		trimmed := bytes.TrimSpace(l)
+		if len(trimmed) == 0 {
+			continue
+		}
+		out = append(out, string(trimmed))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/protocol/client/receivepack.go
+++ b/protocol/client/receivepack.go
@@ -60,7 +60,17 @@ func (b *remoteProgressBuffer) append(payload []byte) {
 	}
 	remain := maxRemoteProgressBytes - b.used
 	if len(payload) > remain {
-		payload = payload[:remain]
+		// Copy the kept prefix into a fresh slice. Slicing alone
+		// would retain the original pkt-line's full backing array
+		// (up to ~64 KiB) for the lifetime of the buffer, so a
+		// payload that mostly overflows the budget could pin
+		// almost a full packet of memory per response — defeating
+		// maxRemoteProgressBytes. The copy releases the rest.
+		truncated := make([]byte, remain)
+		copy(truncated, payload)
+		b.payloads = append(b.payloads, truncated)
+		b.used = maxRemoteProgressBytes
+		return
 	}
 	b.payloads = append(b.payloads, payload)
 	b.used += len(payload)

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -561,9 +561,24 @@ func TestDecodeRemoteProgress(t *testing.T) {
 			want:    []string{"frame1", "frame2", "final"},
 		},
 		{
-			name:    "leading and trailing whitespace per line is trimmed",
+			name:    "trailing whitespace is trimmed but leading whitespace is preserved",
 			packets: [][]byte{[]byte("  spaced  \n\thello\t\n")},
-			want:    []string{"spaced", "hello"},
+			want:    []string{"  spaced", "\thello"},
+		},
+		{
+			name: "indented hook output keeps its indentation (bullet lists, sub-items)",
+			packets: [][]byte{
+				[]byte("GL-HOOK-ERR: Push rule violations:\n"),
+				[]byte("  - Commit message must reference an issue\n"),
+				[]byte("  - File exceeds maximum size\n"),
+				[]byte("    See https://example.com/policy\n"),
+			},
+			want: []string{
+				"GL-HOOK-ERR: Push rule violations:",
+				"  - Commit message must reference an issue",
+				"  - File exceeds maximum size",
+				"    See https://example.com/policy",
+			},
 		},
 		{
 			name:    "consecutive empty lines are dropped",
@@ -991,6 +1006,86 @@ func TestReceivePack_RemoteProgressOnError(t *testing.T) {
 		var wrapped *protocol.RemoteRejectionError
 		require.False(t, errors.As(err, &wrapped),
 			"channel-2 error: prefix is the error itself, not progress; got %T: %v", err, err)
+	})
+
+	t.Run("channel-2 progress is bounded by maxRemoteProgressBytes", func(t *testing.T) {
+		t.Parallel()
+		// A verbose hook that streams more channel-2 bytes than the
+		// per-response cap must not retain unbounded data; once the
+		// cap is exhausted further packets are dropped silently and
+		// the surfaced error contains only the captured prefix.
+		// pkt-line lengths are 4 hex chars (uint16, max 0xffff), so
+		// a single packet payload can't exceed ~64 KiB. We send
+		// several 32 KiB chunks whose total exceeds the cap; the
+		// captured byte count must not exceed maxRemoteProgressBytes.
+		chunk := func(b byte) []byte {
+			line := bytes.Repeat([]byte{b}, 32*1024)
+			return progress(string(line) + "\n")
+		}
+		body := flushed(bytes.Join([][]byte{
+			chunk('a'), chunk('b'), chunk('c'), chunk('d'), chunk('e'), // 5 * 32 KiB = 160 KiB > 64 KiB cap
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+
+		var totalRetained int
+		for _, m := range wrapped.RemoteMessages {
+			totalRetained += len(m)
+		}
+		require.LessOrEqual(t, totalRetained, maxRemoteProgressBytes,
+			"total captured progress must not exceed the byte cap")
+		// Sanity: we should have actually filled close to the cap so
+		// this test would notice if the bound were silently set to 0.
+		require.Greater(t, totalRetained, maxRemoteProgressBytes/2,
+			"captured progress should fill at least half the cap before truncation")
+	})
+
+	t.Run("channel-2 packets past the cap are silently dropped", func(t *testing.T) {
+		t.Parallel()
+		// First packet nearly fills the cap; second packet exceeds
+		// the remaining headroom and is mostly dropped.
+		filler := bytes.Repeat([]byte("a"), maxRemoteProgressBytes-1024) // leaves 1 KiB headroom
+		dropped := bytes.Repeat([]byte("b"), 32*1024)                    // only ~1 KiB fits, rest dropped
+		body := flushed(bytes.Join([][]byte{
+			progress(string(filler) + "\n"),
+			progress(string(dropped) + "\n"),
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+		var totalRetained int
+		for _, m := range wrapped.RemoteMessages {
+			totalRetained += len(m)
+		}
+		require.LessOrEqual(t, totalRetained, maxRemoteProgressBytes,
+			"total captured progress must not exceed the byte cap regardless of packet count")
 	})
 
 	t.Run("progress emitted after the rejection in the same response is still captured", func(t *testing.T) {

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -502,6 +502,118 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 	}
 }
 
+// TestDecodeRemoteProgress exercises the channel-2 progress decoder
+// directly. Side-band channel 2 is a byte stream — a single line may
+// be split across outer packets, and servers terminate lines with
+// either LF, CRLF, or bare CR (the latter is used for spinner
+// overwrites). The decoder concatenates payloads, splits on LF/CR,
+// trims surrounding whitespace, and drops empty lines.
+func TestDecodeRemoteProgress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		packets [][]byte
+		want    []string
+	}{
+		{
+			name:    "nil input",
+			packets: nil,
+			want:    nil,
+		},
+		{
+			name:    "no packets",
+			packets: [][]byte{},
+			want:    nil,
+		},
+		{
+			name:    "all-whitespace packets are dropped",
+			packets: [][]byte{[]byte("   \t  \n\r\n  ")},
+			want:    nil,
+		},
+		{
+			// FieldsFunc treats consecutive separators as one and
+			// produces no fields at all, so this hits the
+			// len(lines)==0 short-circuit rather than the
+			// per-line trim-then-drop path above.
+			name:    "only line terminators yields no lines",
+			packets: [][]byte{[]byte("\n\n\r\n\r\n")},
+			want:    nil,
+		},
+		{
+			name:    "single LF-terminated line",
+			packets: [][]byte{[]byte("hello\n")},
+			want:    []string{"hello"},
+		},
+		{
+			name:    "single line without trailing LF",
+			packets: [][]byte{[]byte("hello")},
+			want:    []string{"hello"},
+		},
+		{
+			name:    "CRLF line terminator",
+			packets: [][]byte{[]byte("hello\r\nworld\r\n")},
+			want:    []string{"hello", "world"},
+		},
+		{
+			name:    "bare CR line terminator (spinner overwrite)",
+			packets: [][]byte{[]byte("frame1\rframe2\rfinal\n")},
+			want:    []string{"frame1", "frame2", "final"},
+		},
+		{
+			name:    "leading and trailing whitespace per line is trimmed",
+			packets: [][]byte{[]byte("  spaced  \n\thello\t\n")},
+			want:    []string{"spaced", "hello"},
+		},
+		{
+			name:    "consecutive empty lines are dropped",
+			packets: [][]byte{[]byte("\n\n\nreal line\n\n\n")},
+			want:    []string{"real line"},
+		},
+		{
+			name: "line split across packet boundaries is reassembled",
+			packets: [][]byte{
+				[]byte("part one "),
+				[]byte("part two\n"),
+			},
+			want: []string{"part one part two"},
+		},
+		{
+			name: "multiple packets with multiple lines",
+			packets: [][]byte{
+				[]byte("first\nsecond"),
+				[]byte("-continued\n"),
+				[]byte("third\n"),
+			},
+			want: []string{"first", "second-continued", "third"},
+		},
+		{
+			name: "GitLab-style decorated multi-line output",
+			packets: [][]byte{
+				[]byte("\n========================================\n"),
+				[]byte("GL-HOOK-ERR: Commit must reference issue.\n"),
+				[]byte("GL-HOOK-ERR: See https://example.com\n"),
+				[]byte("========================================\n\n"),
+			},
+			want: []string{
+				"========================================",
+				"GL-HOOK-ERR: Commit must reference issue.",
+				"GL-HOOK-ERR: See https://example.com",
+				"========================================",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := decodeRemoteProgress(tt.packets)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestReceivePack_RemoteProgressOnError ensures human-readable remote
 // progress messages emitted on side-band channel 2 are attached to any
 // error returned from the same response. Pre-receive hooks and push
@@ -659,5 +771,253 @@ func TestReceivePack_RemoteProgressOnError(t *testing.T) {
 
 		var wrapped *protocol.RemoteRejectionError
 		require.False(t, errors.As(err, &wrapped), "did not expect RemoteRejectionError when no channel-2 progress was sent, got %T: %v", err, err)
+	})
+
+	t.Run("unpack failure with channel-2 progress is wrapped and preserves GitUnpackError", func(t *testing.T) {
+		t.Parallel()
+		// Bare channel-0 "unpack <reason>" (not "ok") triggers
+		// detectError → GitUnpackError directly out of parser.Next().
+		// The same response carries channel-2 progress from the
+		// server. Note: a channel-2 packet whose payload is prefixed
+		// with "error:" or "fatal:" is intentionally converted to a
+		// GitServerError by detectError (see isErrorOrFatalMessageOptimized);
+		// only non-error-prefixed channel-2 payloads are captured as
+		// progress, so the fixture deliberately uses a plain message.
+		body := flushed(bytes.Join([][]byte{
+			progress("Receiving objects...\n"),
+			pkt("unpack index-pack failed\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var unpackErr *protocol.GitUnpackError
+		require.True(t, errors.As(err, &unpackErr),
+			"expected GitUnpackError in chain, got %T: %v", err, err)
+		require.Equal(t, "index-pack failed", strings.TrimSpace(unpackErr.Message))
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+		require.Equal(t, []string{"Receiving objects..."}, wrapped.RemoteMessages)
+	})
+
+	t.Run("channel-3 fatal with channel-2 progress is wrapped and preserves GitServerError", func(t *testing.T) {
+		t.Parallel()
+		// Channel 2 progress arrives first, then a channel-3 fatal
+		// terminates parsing. The defer in parseReceivePackResponse
+		// must still attach the captured progress.
+		body := flushed(bytes.Join([][]byte{
+			progress("Counting objects: 1, done.\n"),
+			progress("Resolving deltas: 100% (0/0).\n"),
+			pkt(string(append([]byte{0x03}, []byte("connection terminated by host")...))),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var serverErr *protocol.GitServerError
+		require.True(t, errors.As(err, &serverErr),
+			"expected GitServerError in chain, got %T: %v", err, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+		require.Equal(t, []string{
+			"Counting objects: 1, done.",
+			"Resolving deltas: 100% (0/0).",
+		}, wrapped.RemoteMessages)
+	})
+
+	t.Run("missing report-status with channel-2 progress is wrapped", func(t *testing.T) {
+		t.Parallel()
+		// A non-empty channel-1 packet with content that does not
+		// match any error sentinel arms the report-status requirement
+		// without satisfying it, producing ErrMissingReportStatus.
+		// Channel-2 progress in the same response should still be
+		// attached.
+		body := flushed(bytes.Join([][]byte{
+			progress("server-side message of the day\n"),
+			rawSideband1("garbled report status with no recognizable line\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingReportStatus)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped),
+			"expected ErrMissingReportStatus to be wrapped with progress, got %T: %v", err, err)
+		require.Equal(t, []string{"server-side message of the day"}, wrapped.RemoteMessages)
+	})
+
+	t.Run("empty channel-2 packet does not produce a wrapper", func(t *testing.T) {
+		t.Parallel()
+		// A packet that is just the side-band channel byte (0x02)
+		// with no payload should not be captured as progress —
+		// otherwise rejected pushes with no real progress would
+		// surface a wrapper with an empty RemoteMessages list.
+		body := flushed(bytes.Join([][]byte{
+			pkt(string([]byte{0x02})),
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.False(t, errors.As(err, &wrapped),
+			"empty channel-2 payload must not arm the wrapper, got %T: %v", err, err)
+
+		var refErr *protocol.GitReferenceUpdateError
+		require.True(t, errors.As(err, &refErr))
+	})
+
+	t.Run("CR-only line terminator in progress is split correctly", func(t *testing.T) {
+		t.Parallel()
+		body := flushed(bytes.Join([][]byte{
+			progress("Compressing: 50%\rCompressing: 100%\rdone\n"),
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+		require.Equal(t, []string{
+			"Compressing: 50%",
+			"Compressing: 100%",
+			"done",
+		}, wrapped.RemoteMessages)
+	})
+
+	t.Run("empty channel-3 packet does not produce an error or wrapper", func(t *testing.T) {
+		t.Parallel()
+		// A packet that is just the side-band channel byte (0x03)
+		// with no payload should not be surfaced as an error —
+		// detectError already converts well-formed "fatal:"/"error:"
+		// prefixed channel-3 packets, and classifyReceivePackLine
+		// surfaces non-empty channel-3 payloads as a generic fatal.
+		// An empty channel-3 packet is a no-op; combined with a
+		// successful unpack ok, the response succeeds.
+		body := flushed(bytes.Join([][]byte{
+			pkt(string([]byte{0x03})),
+			pkt("unpack ok\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.NoError(t, err)
+	})
+
+	t.Run("channel-2 packet with error: prefix becomes GitServerError not progress", func(t *testing.T) {
+		t.Parallel()
+		// detectError converts side-band channel 2 packets prefixed
+		// with "error:" or "fatal:" directly into GitServerError
+		// (see isErrorOrFatalMessageOptimized). Such a packet is the
+		// error itself, not auxiliary progress, and must NOT be
+		// captured as a remote message — otherwise the same text
+		// would appear twice in the surfaced output.
+		body := flushed(progress("error: missing prerequisite object abc123\n"))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var serverErr *protocol.GitServerError
+		require.True(t, errors.As(err, &serverErr))
+		require.Equal(t, "error", serverErr.ErrorType)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.False(t, errors.As(err, &wrapped),
+			"channel-2 error: prefix is the error itself, not progress; got %T: %v", err, err)
+	})
+
+	t.Run("progress emitted after the rejection in the same response is still captured", func(t *testing.T) {
+		t.Parallel()
+		// Servers that interleave progress around the report-status
+		// can emit channel-2 packets after the ng line. The defer in
+		// parseReceivePackResponse runs after the full body is read,
+		// so trailing progress must still be attached.
+		body := flushed(bytes.Join([][]byte{
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+			progress("trailing remote message after rejection\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+		require.Equal(t, []string{"trailing remote message after rejection"}, wrapped.RemoteMessages)
 	})
 }

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -501,3 +501,163 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestReceivePack_RemoteProgressOnError ensures human-readable remote
+// progress messages emitted on side-band channel 2 are attached to any
+// error returned from the same response. Pre-receive hooks and push
+// rules on servers like GitLab write their reason to channel 2; a bare
+// "pre-receive hook declined" reason is rarely actionable on its own,
+// so the wrapper preserves the underlying typed error and enriches the
+// surfaced message with the captured `remote: …` lines.
+func TestReceivePack_RemoteProgressOnError(t *testing.T) {
+	t.Parallel()
+
+	pkt := func(s string) []byte {
+		b, err := protocol.PackLine(s).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+	flushed := func(data []byte) []byte {
+		return append(append([]byte{}, data...), []byte("0000")...)
+	}
+	progress := func(text string) []byte {
+		return pkt(string(append([]byte{0x02}, []byte(text)...)))
+	}
+	rawSideband1 := func(text string) []byte {
+		payload := append([]byte{0x01}, []byte(text)...)
+		b, err := protocol.PackLine(payload).Marshal()
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("ng with channel-2 progress surfaces both reason and remote messages", func(t *testing.T) {
+		t.Parallel()
+		body := flushed(bytes.Join([][]byte{
+			progress("GitLab: You are not allowed to push code to protected branches on this project.\n"),
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		// Underlying typed error is preserved for programmatic inspection.
+		var refErr *protocol.GitReferenceUpdateError
+		require.True(t, errors.As(err, &refErr), "expected GitReferenceUpdateError in chain, got %T: %v", err, err)
+		require.Equal(t, "refs/heads/main", refErr.RefName)
+		require.Equal(t, "pre-receive hook declined", refErr.Reason)
+
+		// Wrapper carries the channel-2 progress lines.
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped), "expected RemoteRejectionError in chain, got %T: %v", err, err)
+		require.Equal(t, []string{
+			"GitLab: You are not allowed to push code to protected branches on this project.",
+		}, wrapped.RemoteMessages)
+
+		// The surfaced message includes both pieces.
+		require.Contains(t, err.Error(), "reference update failed for refs/heads/main: pre-receive hook declined")
+		require.Contains(t, err.Error(), "remote: GitLab: You are not allowed to push code to protected branches on this project.")
+	})
+
+	t.Run("multiline progress is split into separate remote lines and empties dropped", func(t *testing.T) {
+		t.Parallel()
+		body := flushed(bytes.Join([][]byte{
+			progress("\n========================================\n"),
+			progress("GL-HOOK-ERR: Commit message must reference an issue.\n"),
+			progress("GL-HOOK-ERR: See https://example.com/policy\n"),
+			progress("========================================\n\n"),
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.True(t, errors.As(err, &wrapped))
+		require.Equal(t, []string{
+			"========================================",
+			"GL-HOOK-ERR: Commit message must reference an issue.",
+			"GL-HOOK-ERR: See https://example.com/policy",
+			"========================================",
+		}, wrapped.RemoteMessages)
+	})
+
+	t.Run("progress line split across packets is reassembled", func(t *testing.T) {
+		t.Parallel()
+		body := flushed(bytes.Join([][]byte{
+			progress("GitLab: Push rule "),
+			progress("violation: file too large.\n"),
+			rawSideband1("ng refs/heads/main pre-receive hook declined\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "remote: GitLab: Push rule violation: file too large.")
+	})
+
+	t.Run("channel-2 progress on a successful push does not produce a wrapper error", func(t *testing.T) {
+		t.Parallel()
+		body := flushed(bytes.Join([][]byte{
+			progress("Counting objects: 1, done.\n"),
+			pkt("unpack ok\n"),
+		}, nil))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.NoError(t, err)
+	})
+
+	t.Run("error without channel-2 progress is not wrapped", func(t *testing.T) {
+		t.Parallel()
+		body := flushed(rawSideband1("ng refs/heads/main pre-receive hook declined\n"))
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		c, err := NewRawClient(server.URL + "/repo")
+		require.NoError(t, err)
+
+		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
+		require.Error(t, err)
+
+		var wrapped *protocol.RemoteRejectionError
+		require.False(t, errors.As(err, &wrapped), "did not expect RemoteRejectionError when no channel-2 progress was sent, got %T: %v", err, err)
+	})
+}

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -1008,6 +1008,16 @@ func TestReceivePack_RemoteProgressOnError(t *testing.T) {
 			"channel-2 error: prefix is the error itself, not progress; got %T: %v", err, err)
 	})
 
+	// noKeepAliveClient gives a sub-test its own HTTP client whose
+	// transport disables keep-alives, so heavy response-body tests
+	// don't add idle connections to the shared http.DefaultTransport
+	// pool. Without this, a flake in net/http's idle-connection
+	// handling (golang/go#22330) can surface as
+	// "http: CloseIdleConnections called" in any concurrent sub-test.
+	noKeepAliveClient := options.WithHTTPClient(&http.Client{
+		Transport: &http.Transport{DisableKeepAlives: true},
+	})
+
 	t.Run("channel-2 progress is bounded by maxRemoteProgressBytes", func(t *testing.T) {
 		t.Parallel()
 		// A verbose hook that streams more channel-2 bytes than the
@@ -1033,7 +1043,7 @@ func TestReceivePack_RemoteProgressOnError(t *testing.T) {
 		}))
 		defer server.Close()
 
-		c, err := NewRawClient(server.URL + "/repo")
+		c, err := NewRawClient(server.URL+"/repo", noKeepAliveClient)
 		require.NoError(t, err)
 
 		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))
@@ -1072,7 +1082,7 @@ func TestReceivePack_RemoteProgressOnError(t *testing.T) {
 		}))
 		defer server.Close()
 
-		c, err := NewRawClient(server.URL + "/repo")
+		c, err := NewRawClient(server.URL+"/repo", noKeepAliveClient)
 		require.NoError(t, err)
 
 		err = c.ReceivePack(context.Background(), bytes.NewReader([]byte("test data")))

--- a/protocol/client/receivepack_test.go
+++ b/protocol/client/receivepack_test.go
@@ -502,6 +502,90 @@ func TestReceivePack_PositiveValidation(t *testing.T) {
 	}
 }
 
+// TestRemoteProgressBuffer_AppendTruncatesAndCopies verifies that
+// remoteProgressBuffer caps total bytes at maxRemoteProgressBytes and,
+// crucially, copies the truncated prefix into a fresh slice instead
+// of subslicing the input. Subslicing alone would keep the original
+// pkt-line's full backing array (~64 KiB) alive for the lifetime of
+// the buffer, defeating the byte cap in terms of actual memory
+// retention.
+func TestRemoteProgressBuffer_AppendTruncatesAndCopies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero-length payload is a no-op", func(t *testing.T) {
+		t.Parallel()
+		var b remoteProgressBuffer
+		b.append(nil)
+		b.append([]byte{})
+		require.Empty(t, b.payloads)
+		require.Equal(t, 0, b.used)
+	})
+
+	t.Run("payload smaller than budget is appended as-is", func(t *testing.T) {
+		t.Parallel()
+		var b remoteProgressBuffer
+		small := []byte("hello")
+		b.append(small)
+		require.Len(t, b.payloads, 1)
+		require.Equal(t, []byte("hello"), b.payloads[0])
+		require.Equal(t, len(small), b.used)
+	})
+
+	t.Run("packets past the cap are dropped silently", func(t *testing.T) {
+		t.Parallel()
+		var b remoteProgressBuffer
+		b.append(bytes.Repeat([]byte("x"), maxRemoteProgressBytes))
+		require.Equal(t, maxRemoteProgressBytes, b.used)
+
+		// Subsequent packet should be entirely dropped.
+		b.append([]byte("ignored"))
+		require.Len(t, b.payloads, 1)
+		require.Equal(t, maxRemoteProgressBytes, b.used)
+	})
+
+	t.Run("truncated payload is copied so original backing array can be GC'd", func(t *testing.T) {
+		t.Parallel()
+		var b remoteProgressBuffer
+
+		// Pre-fill so the next append must truncate.
+		const headroom = 16
+		b.append(bytes.Repeat([]byte("a"), maxRemoteProgressBytes-headroom))
+
+		// Construct a payload much larger than the remaining
+		// headroom; the kept prefix should be exactly `headroom`
+		// bytes and stored in a fresh allocation, not a subslice
+		// of `payload`.
+		payload := make([]byte, 4*1024)
+		for i := range payload {
+			payload[i] = 'X'
+		}
+		b.append(payload)
+
+		require.Equal(t, maxRemoteProgressBytes, b.used,
+			"buffer should be exactly at the cap after truncation")
+		require.Len(t, b.payloads, 2)
+
+		stored := b.payloads[1]
+		require.Len(t, stored, headroom, "stored prefix size")
+
+		// Capacity equality is the structural proof: a subslice of
+		// `payload` would have cap(stored) == cap(payload)-offset
+		// (~4096), keeping the full 4 KiB allocation alive. A fresh
+		// copy has cap(stored) == len(stored) == headroom.
+		require.Equal(t, headroom, cap(stored),
+			"truncated prefix must be a fresh allocation, not a subslice "+
+				"of the input (subslicing would retain the full input backing array)")
+
+		// Behavioural proof: mutating the original after the fact
+		// must not change the stored bytes.
+		want := append([]byte(nil), stored...)
+		for i := range payload {
+			payload[i] = 0
+		}
+		require.Equal(t, want, stored, "stored bytes must be decoupled from input")
+	})
+}
+
 // TestDecodeRemoteProgress exercises the channel-2 progress decoder
 // directly. Side-band channel 2 is a byte stream — a single line may
 // be split across outer packets, and servers terminate lines with

--- a/protocol/pack.go
+++ b/protocol/pack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -185,6 +186,20 @@ type GitUnpackError struct {
 	Message string
 }
 
+// RemoteRejectionError wraps an error returned from a receive-pack
+// response together with any human-readable progress messages the
+// server emitted on side-band channel 2 in the same response. Pre-
+// receive hooks and push rules on servers like GitLab write their
+// reason to channel 2 (visible to git CLI users as `remote: …` lines),
+// so the underlying typed error (e.g. GitReferenceUpdateError with
+// reason "pre-receive hook declined") often lacks the actionable
+// detail. This wrapper preserves the underlying error for errors.As /
+// errors.Is and only enriches the surfaced message.
+type RemoteRejectionError struct {
+	Err            error
+	RemoteMessages []string
+}
+
 func (e *PackParseError) Error() string {
 	if e.Err == nil {
 		return fmt.Sprintf("error parsing line %q", e.Line)
@@ -222,6 +237,26 @@ func (e *GitUnpackError) Error() string {
 // Unwrap enables errors.Is() compatibility with ErrGitUnpackError
 func (e *GitUnpackError) Unwrap() error {
 	return ErrGitUnpackError
+}
+
+func (e *RemoteRejectionError) Error() string {
+	if len(e.RemoteMessages) == 0 {
+		return e.Err.Error()
+	}
+	var b strings.Builder
+	b.WriteString(e.Err.Error())
+	for _, m := range e.RemoteMessages {
+		b.WriteString("\nremote: ")
+		b.WriteString(m)
+	}
+	return b.String()
+}
+
+// Unwrap returns the underlying receive-pack error so errors.As /
+// errors.Is keep finding the typed cause (GitReferenceUpdateError,
+// GitUnpackError, GitServerError, …).
+func (e *RemoteRejectionError) Unwrap() error {
+	return e.Err
 }
 
 // NewPackParseError creates a new PackParseError with the given line and error.

--- a/protocol/pack.go
+++ b/protocol/pack.go
@@ -240,11 +240,19 @@ func (e *GitUnpackError) Unwrap() error {
 }
 
 func (e *RemoteRejectionError) Error() string {
+	// Defensive nil-guards: the wrapper is only ever constructed
+	// internally with a non-nil Err, but it is an exported type and
+	// external callers can construct zero-valued instances. A
+	// fallback message beats a panic on .Error().
+	underlying := "remote rejection"
+	if e.Err != nil {
+		underlying = e.Err.Error()
+	}
 	if len(e.RemoteMessages) == 0 {
-		return e.Err.Error()
+		return underlying
 	}
 	var b strings.Builder
-	b.WriteString(e.Err.Error())
+	b.WriteString(underlying)
 	for _, m := range e.RemoteMessages {
 		b.WriteString("\nremote: ")
 		b.WriteString(m)
@@ -254,7 +262,8 @@ func (e *RemoteRejectionError) Error() string {
 
 // Unwrap returns the underlying receive-pack error so errors.As /
 // errors.Is keep finding the typed cause (GitReferenceUpdateError,
-// GitUnpackError, GitServerError, …).
+// GitUnpackError, GitServerError, …). Returns nil if Err is unset,
+// which ends the unwrap chain rather than panicking.
 func (e *RemoteRejectionError) Unwrap() error {
 	return e.Err
 }

--- a/protocol/pack_test.go
+++ b/protocol/pack_test.go
@@ -631,6 +631,34 @@ func TestRemoteRejectionError(t *testing.T) {
 		require.Equal(t, "boom", wrapped.Error())
 	})
 
+	t.Run("Error returns fallback when Err is nil and no remote messages", func(t *testing.T) {
+		t.Parallel()
+		// Defensive zero-value behaviour: the type is exported, so
+		// external callers can construct a bare RemoteRejectionError.
+		// .Error() must not panic.
+		wrapped := &protocol.RemoteRejectionError{}
+		require.NotPanics(t, func() { _ = wrapped.Error() })
+		require.NotEmpty(t, wrapped.Error())
+	})
+
+	t.Run("Error returns fallback prefix when Err is nil but remote messages set", func(t *testing.T) {
+		t.Parallel()
+		wrapped := &protocol.RemoteRejectionError{
+			RemoteMessages: []string{"line 1", "line 2"},
+		}
+		require.NotPanics(t, func() { _ = wrapped.Error() })
+		got := wrapped.Error()
+		require.Contains(t, got, "remote: line 1")
+		require.Contains(t, got, "remote: line 2")
+	})
+
+	t.Run("Unwrap returns nil when Err is nil and does not panic", func(t *testing.T) {
+		t.Parallel()
+		wrapped := &protocol.RemoteRejectionError{}
+		require.NotPanics(t, func() { _ = errors.Unwrap(wrapped) })
+		require.Nil(t, errors.Unwrap(wrapped))
+	})
+
 	t.Run("Error appends single remote message on its own line", func(t *testing.T) {
 		t.Parallel()
 		underlying := protocol.NewGitReferenceUpdateError(

--- a/protocol/pack_test.go
+++ b/protocol/pack_test.go
@@ -611,6 +611,108 @@ func TestGitUnpackError(t *testing.T) {
 	})
 }
 
+func TestRemoteRejectionError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Error passes through underlying when no remote messages", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitReferenceUpdateError(
+			[]byte("ng refs/heads/main pre-receive hook declined"),
+			"refs/heads/main", "pre-receive hook declined",
+		)
+		wrapped := &protocol.RemoteRejectionError{Err: underlying}
+		require.Equal(t, underlying.Error(), wrapped.Error())
+	})
+
+	t.Run("Error passes through underlying when RemoteMessages is nil", func(t *testing.T) {
+		t.Parallel()
+		underlying := errors.New("boom")
+		wrapped := &protocol.RemoteRejectionError{Err: underlying, RemoteMessages: nil}
+		require.Equal(t, "boom", wrapped.Error())
+	})
+
+	t.Run("Error appends single remote message on its own line", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitReferenceUpdateError(
+			[]byte("ng refs/heads/main pre-receive hook declined"),
+			"refs/heads/main", "pre-receive hook declined",
+		)
+		wrapped := &protocol.RemoteRejectionError{
+			Err: underlying,
+			RemoteMessages: []string{
+				"GitLab: You are not allowed to push code to protected branches on this project.",
+			},
+		}
+		require.Equal(t,
+			"reference update failed for refs/heads/main: pre-receive hook declined\n"+
+				"remote: GitLab: You are not allowed to push code to protected branches on this project.",
+			wrapped.Error())
+	})
+
+	t.Run("Error appends each remote message on its own line preserving order", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitUnpackError([]byte("unpack failed"), "failed")
+		wrapped := &protocol.RemoteRejectionError{
+			Err: underlying,
+			RemoteMessages: []string{
+				"line 1",
+				"line 2",
+				"line 3",
+			},
+		}
+		require.Equal(t,
+			"pack unpack failed: failed\n"+
+				"remote: line 1\n"+
+				"remote: line 2\n"+
+				"remote: line 3",
+			wrapped.Error())
+	})
+
+	t.Run("Unwrap returns the underlying error", func(t *testing.T) {
+		t.Parallel()
+		underlying := errors.New("underlying")
+		wrapped := &protocol.RemoteRejectionError{Err: underlying}
+		require.Same(t, underlying, errors.Unwrap(wrapped))
+	})
+
+	t.Run("errors.As finds the wrapper through chain", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitReferenceUpdateError(nil, "refs/heads/main", "denied")
+		wrapped := &protocol.RemoteRejectionError{Err: underlying, RemoteMessages: []string{"hello"}}
+		// Wrap once more like callers would.
+		outer := fmt.Errorf("git protocol error: %w", wrapped)
+
+		var got *protocol.RemoteRejectionError
+		require.True(t, errors.As(outer, &got))
+		require.Equal(t, []string{"hello"}, got.RemoteMessages)
+	})
+
+	t.Run("errors.As finds underlying typed error through wrapper", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitReferenceUpdateError(nil, "refs/heads/main", "denied")
+		wrapped := &protocol.RemoteRejectionError{Err: underlying, RemoteMessages: []string{"hello"}}
+
+		var refErr *protocol.GitReferenceUpdateError
+		require.True(t, errors.As(wrapped, &refErr))
+		require.Equal(t, "refs/heads/main", refErr.RefName)
+		require.Equal(t, "denied", refErr.Reason)
+	})
+
+	t.Run("errors.Is finds underlying sentinel through wrapper", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitReferenceUpdateError(nil, "refs/heads/main", "denied")
+		wrapped := &protocol.RemoteRejectionError{Err: underlying, RemoteMessages: []string{"hello"}}
+		require.True(t, errors.Is(wrapped, protocol.ErrGitReferenceUpdateError))
+	})
+
+	t.Run("errors.Is finds GitUnpackError sentinel through wrapper", func(t *testing.T) {
+		t.Parallel()
+		underlying := protocol.NewGitUnpackError(nil, "boom")
+		wrapped := &protocol.RemoteRejectionError{Err: underlying, RemoteMessages: []string{"hello"}}
+		require.True(t, errors.Is(wrapped, protocol.ErrGitUnpackError))
+	})
+}
+
 func TestParsePackNewErrorTypes(t *testing.T) {
 	t.Parallel()
 

--- a/tests/push_remote_progress_integration_test.go
+++ b/tests/push_remote_progress_integration_test.go
@@ -1,0 +1,160 @@
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/grafana/nanogit/protocol"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// setRepoServerHook installs a server-side git hook on a Gitea repo
+// via the admin API. Valid hook IDs are "pre-receive", "update", and
+// "post-receive". The hook script runs inside the Gitea container on
+// every push; stderr/stdout is relayed to the client over side-band
+// channel 2 as `remote: …` lines, which is exactly the path the new
+// RemoteRejectionError wrapper captures.
+//
+// Note: requires GITEA__security__DISABLE_GIT_HOOKS=false on the
+// container (set in gittest.Server) and a site-admin user (test users
+// are created with --admin).
+func setRepoServerHook(ctx context.Context, server *gittest.Server, repo *gittest.RemoteRepository, hookID, content string) error {
+	body, err := json.Marshal(map[string]string{"content": content})
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/api/v1/repos/%s/%s/hooks/git/%s", server.URL(), repo.Owner, repo.Name, hookID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(repo.User.Username, repo.User.Password)
+
+	cli := &http.Client{Timeout: 15 * time.Second}
+	res, err := cli.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("set %s hook: status %d: %s", hookID, res.StatusCode, respBody)
+	}
+	return nil
+}
+
+// These specs exercise the receive-pack error path against a real Git
+// server (Gitea in testcontainers) when a server-side pre-receive hook
+// rejects the push. They verify the end-to-end behavior added by the
+// channel-2 capture: the hook's stderr text is attached to the push
+// error as RemoteRejectionError.RemoteMessages, and the underlying
+// typed error (GitReferenceUpdateError) survives via Unwrap.
+var _ = Describe("Receive-pack remote progress on rejected push", func() {
+	author := nanogit.Author{Name: "Test Author", Email: "test@example.com", Time: time.Now()}
+	committer := nanogit.Committer{Name: "Test Committer", Email: "test@example.com", Time: time.Now()}
+
+	It("attaches pre-receive hook stderr to the error and preserves the typed cause", func() {
+		client, repo, local, _ := QuickSetup()
+
+		By("Seeding the repo with a main branch")
+		_, err := local.Git("branch", "-M", "main")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("push", "-u", "origin", "main", "--force")
+		Expect(err).NotTo(HaveOccurred())
+
+		mainRef, err := client.GetRef(ctx, "refs/heads/main")
+		Expect(err).NotTo(HaveOccurred())
+
+		const hookMsg = "test policy: pushes to this repo are denied for this test"
+		hookScript := "#!/bin/sh\n" +
+			"echo '" + hookMsg + "' 1>&2\n" +
+			"exit 1\n"
+
+		By("Installing a pre-receive hook that prints to stderr and rejects")
+		Expect(setRepoServerHook(ctx, gitServer, repo, "pre-receive", hookScript)).To(Succeed())
+
+		By("Staging a commit and pushing — expect rejection")
+		writer, err := client.NewStagedWriter(ctx, mainRef)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = writer.CreateBlob(ctx, "rejected.txt", []byte("should not land"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = writer.Commit(ctx, "rejected commit", author, committer)
+		Expect(err).NotTo(HaveOccurred())
+
+		pushErr := writer.Push(ctx)
+		Expect(pushErr).To(HaveOccurred(), "hook should reject the push")
+
+		By("Confirming the underlying typed error survives via Unwrap")
+		var refErr *protocol.GitReferenceUpdateError
+		Expect(errors.As(pushErr, &refErr)).To(BeTrue(),
+			"expected GitReferenceUpdateError in chain, got %T: %v", pushErr, pushErr)
+		Expect(refErr.RefName).To(Equal("refs/heads/main"))
+
+		By("Confirming RemoteRejectionError carries the hook stderr line")
+		var wrapped *protocol.RemoteRejectionError
+		Expect(errors.As(pushErr, &wrapped)).To(BeTrue(),
+			"expected RemoteRejectionError in chain, got %T: %v", pushErr, pushErr)
+		Expect(wrapped.RemoteMessages).To(ContainElement(hookMsg),
+			"expected hook stderr line in RemoteMessages, got %v", wrapped.RemoteMessages)
+
+		By("Confirming the surfaced error string includes the remote: line")
+		Expect(pushErr.Error()).To(ContainSubstring("remote: " + hookMsg))
+
+		By("Confirming the branch did not advance — silent-success regression guard")
+		currentMain, err := client.GetRef(ctx, "refs/heads/main")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(currentMain.Hash).To(Equal(mainRef.Hash),
+			"main must not have advanced; if it did, the hook rejection was silently swallowed")
+	})
+
+	It("captures multi-line hook output as separate remote: lines", func() {
+		client, repo, local, _ := QuickSetup()
+
+		_, err := local.Git("branch", "-M", "main")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("push", "-u", "origin", "main", "--force")
+		Expect(err).NotTo(HaveOccurred())
+
+		mainRef, err := client.GetRef(ctx, "refs/heads/main")
+		Expect(err).NotTo(HaveOccurred())
+
+		const (
+			line1 = "GL-HOOK-ERR: Commit message must reference an issue."
+			line2 = "GL-HOOK-ERR: See https://example.com/policy for details."
+		)
+		hookScript := "#!/bin/sh\n" +
+			"echo '" + line1 + "' 1>&2\n" +
+			"echo '" + line2 + "' 1>&2\n" +
+			"exit 1\n"
+
+		Expect(setRepoServerHook(ctx, gitServer, repo, "pre-receive", hookScript)).To(Succeed())
+
+		writer, err := client.NewStagedWriter(ctx, mainRef)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = writer.CreateBlob(ctx, "rejected.txt", []byte("should not land"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = writer.Commit(ctx, "rejected commit", author, committer)
+		Expect(err).NotTo(HaveOccurred())
+
+		pushErr := writer.Push(ctx)
+		Expect(pushErr).To(HaveOccurred())
+
+		var wrapped *protocol.RemoteRejectionError
+		Expect(errors.As(pushErr, &wrapped)).To(BeTrue())
+		Expect(wrapped.RemoteMessages).To(ContainElements(line1, line2))
+	})
+})


### PR DESCRIPTION
## Summary

Pre-receive hooks and push rules on servers like GitLab emit their
human-readable rejection reason on side-band **channel 2** — the same text
the git CLI prints as `remote: …` lines. Before this change, channel-2
payloads were dropped on the floor in `parseReceivePackResponse`, so the
errors surfaced by #270 (e.g. `reference update failed for refs/heads/main:
pre-receive hook declined`) arrived without the actionable detail behind
them.

This is a follow-up to #270: that PR made push errors *visible*; this PR
makes them *actionable*.

## Changes

- **`protocol/pack.go`**: new `RemoteRejectionError` typed wrapper carrying
  the underlying error plus a `[]string` of remote messages. `Unwrap()`
  returns the underlying error, so `errors.As(err, &GitReferenceUpdateError{})`
  and friends keep working — only the surfaced string is enriched.
- **`protocol/client/receivepack.go`**: capture channel-2 payloads in
  `classifyReceivePackLine` (was discarded), accumulate them across the
  whole response, and wrap any error returned with `RemoteRejectionError`
  via a `defer` when progress is non-empty. New helper
  `decodeRemoteProgress` reassembles channel-2 across outer packets before
  splitting on LF/CR — so a progress line fragmented across packets is
  recovered correctly.
- **`protocol/client/receivepack_test.go`**: 5 new sub-tests in
  `TestReceivePack_RemoteProgressOnError` covering the structured cases.

## Concrete impact

For the GitLab case in [grafana/support-escalations#21934][issue], today's
trace ends with:

```
git protocol error: reference update failed for refs/heads/main: pre-receive hook declined
```

After this change, the same response surfaces:

```
git protocol error: reference update failed for refs/heads/main: pre-receive hook declined
remote: GitLab: You are not allowed to push code to protected branches on this project.
```

— which is what `git push` prints from a terminal and is the actual
detail the customer needs to act on (protected-branch policy, push-rule
violation, secret detection, etc.).

[issue]: https://github.com/grafana/support-escalations/issues/21934

## Testing

`TestReceivePack_RemoteProgressOnError` covers:
- `ng` packet + channel-2 progress → both `GitReferenceUpdateError` (via
  `errors.As`) and the new `RemoteRejectionError` are present in the chain;
  `Error()` includes the `remote:` line.
- Multi-line / multi-packet channel-2 progress → split into separate
  `remote:` lines, decorative blank lines dropped.
- Channel-2 progress line fragmented across outer packets → reassembled
  before splitting.
- Channel-2 progress on a *successful* push (`unpack ok`) → no wrapper, no
  error returned.
- `ng` with no channel-2 progress → no wrapper added.

Local runs:
- `go test ./protocol/... ./...` — all green.
- `make lint` — `0 issues`.

## Test plan

- [x] Unit tests added covering channel-2 capture + wrapping.
- [x] Unit tests confirm successful pushes are not affected (no spurious
      error from benign progress).
- [x] `errors.As` still finds the underlying typed error through the
      `RemoteRejectionError` wrapper.
- [ ] Verify against a real GitLab repo with an enforced pre-receive
      policy that the `remote: …` line surfaces in the error.

## Notes

- No breaking changes. `RemoteRejectionError` is a new exported type;
  callers that don't care continue to inspect the unwrapped error.
- Wrapper is only applied when channel-2 progress is non-empty *and* an
  error is being returned, so this is silent on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)