### PR TITLE
chore(security): ignore install scripts in npm and yarn configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false


### PR DESCRIPTION
## Summary

Adds `.npmrc`, `.yarnrc`, and `.yarnrc.yml` to disable lifecycle scripts (`preinstall` / `install` / `postinstall`) for npm, Yarn Classic, and Yarn Berry. Requested by security as a precondition for re-enabling GitHub Actions after the TanStack npm supply-chain incident.

## Why

Install-time scripts in transitive npm dependencies were the exfiltration path in the recent incident. With these configs in place, even if a poisoned dependency version makes it into `package-lock.json`, no code from it will execute on `npm ci` in CI or on local installs.

All three files exist because the honored config file depends on which tool (npm vs Yarn Classic vs Yarn Berry) is invoked — covering all three closes the loop regardless of how someone runs an install.

## Changes

- `.npmrc` &rarr; `ignore-scripts=true` (npm + Yarn Classic)
- `.yarnrc` &rarr; `ignore-scripts true` (Yarn Classic legacy syntax)
- `.yarnrc.yml` &rarr; `enableScripts: false` (Yarn Berry)

## Impact assessment

This repo's only JS deps are `vitepress` and `vue` (docs site). Notable:

- `esbuild` is already pinned via `package.json` `overrides` to `^0.27.0`. Modern esbuild ships platform-specific binaries through optional dependencies rather than running a `postinstall` build script, so docs builds (`npm run docs:build`) are unaffected.
- No native modules (`node-sass`, `puppeteer`, `cypress`, etc.) in the dep tree, so no allowlisting needed today.
- If a future dep needs a build script, prefer prebuilt binaries or an explicit manual `npm rebuild <pkg>` step rather than weakening this global setting.

## Testing

- [ ] `npm ci` succeeds locally with the new configs
- [ ] `npm run docs:build` succeeds (vitepress build unaffected)
- [ ] Verify the same in CI once Actions are re-enabled

## Follow-ups (not in this PR)

Worth considering as separate hardenings before turning Actions back on:
- Pin third-party Actions by commit SHA, not floating tag
- Set workflow-level `permissions: contents: read` and grant more per-job
- Pass `--ignore-scripts` explicitly on `npm ci` as belt-and-braces
- OIDC for any publish/deploy step instead of long-lived tokens
- `actions/checkout` with `persist-credentials: false` for non-pushing jobs