### PR TITLE
chore(ci): pin npm dependencies in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,12 @@ jobs:
       - name: Install semantic-release
         run: |
           npm install -g \
-            semantic-release@23 \
-            @semantic-release/changelog@6 \
-            @semantic-release/github@10 \
-            @semantic-release/commit-analyzer@12 \
-            @semantic-release/release-notes-generator@13 \
-            conventional-changelog-conventionalcommits@7
+            semantic-release@23.1.1 \
+            @semantic-release/changelog@6.0.3 \
+            @semantic-release/github@10.3.5 \
+            @semantic-release/commit-analyzer@12.0.0 \
+            @semantic-release/release-notes-generator@13.0.0 \
+            conventional-changelog-conventionalcommits@7.0.2
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
## Summary
- Pin all semantic-release packages in `.github/workflows/release.yml` to exact versions instead of major-version selectors (`@23` → `@23.1.1`, etc.).
- Mitigates supply-chain risk: with major-version ranges, any new minor/patch release of these packages (or a compromised one, as we saw with TanStack) flows directly into our release pipeline.

## Changes
Pinned the following packages installed via `npm install -g`:
- `semantic-release@23` → `23.1.1`
- `@semantic-release/changelog@6` → `6.0.3`
- `@semantic-release/github@10` → `10.3.5`
- `@semantic-release/commit-analyzer@12` → `12.0.0`
- `@semantic-release/release-notes-generator@13` → `13.0.0`
- `conventional-changelog-conventionalcommits@7` → `7.0.2`

Versions reflect the current latest within each pinned major as of this PR. Renovate/Dependabot will surface future updates as explicit, reviewable bumps.

## Test plan
- [ ] CI passes
- [ ] Verify release workflow still resolves and installs each pinned package on next release