### PR TITLE
fix: handle short reads of ref-delta base hash in packfile parser

### DIFF
--- a/protocol/client/fetch.go
+++ b/protocol/client/fetch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
 	"io"
 
@@ -207,8 +208,11 @@ func (c *rawClient) processPackfileResponse(ctx context.Context, response *proto
 	for {
 		obj, err := response.Packfile.ReadObject(ctx)
 		if err != nil {
-			logger.Debug("Finished reading objects", "error", err, "totalObjects", objectCount, "foundWanted", foundWantedCount, "totalDeltas", totalDelta)
-			break
+			if errors.Is(err, io.EOF) {
+				logger.Debug("Finished reading objects", "totalObjects", objectCount, "foundWanted", foundWantedCount, "totalDeltas", totalDelta)
+				break
+			}
+			return fmt.Errorf("reading packfile object %d: %w", count+1, err)
 		}
 
 		if obj.Object == nil {

--- a/protocol/client/fetch_test.go
+++ b/protocol/client/fetch_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +42,7 @@ func TestFetch_CorruptPackfile(t *testing.T) {
 	want, err := hash.FromHex("0123456789abcdef0123456789abcdef01234567")
 	require.NoError(t, err)
 
-	_, err = client.Fetch(context.Background(), FetchOptions{Want: []hash.Hash{want}, Done: true})
+	_, err = client.Fetch(t.Context(), FetchOptions{Want: []hash.Hash{want}, Done: true})
 	require.ErrorContains(t, err, "reading packfile object 1")
 	require.ErrorContains(t, err, "zlib: invalid header")
 }

--- a/protocol/client/fetch_test.go
+++ b/protocol/client/fetch_test.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/nanogit/protocol/hash"
+)
+
+func TestFetch_CorruptPackfile(t *testing.T) {
+	t.Parallel()
+
+	var body bytes.Buffer
+	writePkt := func(b []byte) {
+		fmt.Fprintf(&body, "%04x", len(b)+4)
+		body.Write(b)
+	}
+	writePkt([]byte("packfile\n"))
+	pack := []byte("PACK" +
+		"\x00\x00\x00\x02" + // version 2
+		"\x00\x00\x00\x01" + // 1 object
+		"\x33" + // blob, size 3
+		"\xff\xff") // invalid zlib stream
+	writePkt(append([]byte{1}, pack...))
+	body.WriteString("0000")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write(body.Bytes()); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewRawClient(server.URL + "/repo")
+	require.NoError(t, err)
+
+	want, err := hash.FromHex("0123456789abcdef0123456789abcdef01234567")
+	require.NoError(t, err)
+
+	_, err = client.Fetch(context.Background(), FetchOptions{Want: []hash.Hash{want}, Done: true})
+	require.ErrorContains(t, err, "reading packfile object 1")
+	require.ErrorContains(t, err, "zlib: invalid header")
+}

--- a/protocol/packfile.go
+++ b/protocol/packfile.go
@@ -155,7 +155,6 @@ const (
 	ErrUnsupportedPackfileVersion = strError("the version of the packfile payload is unsupported")
 	ErrUnsupportedObjectType      = strError("the type of the object is unsupported")
 	ErrInflatedDataIncorrectSize  = strError("the data is the wrong size post-inflation")
-	ErrObjectTooLarge             = strError("the object size exceeds the maximum unpacked object size")
 )
 
 // MaxUnpackedObjectSize is the maximum size of an unpacked object.
@@ -562,10 +561,6 @@ func (p *PackfileReader) readObject(ctx context.Context) (PackfileEntry, error) 
 	}
 
 	logger.Debug("Read object type", "type_byte", buf[0], "type", entry.Object.Type, "size", size, "shift", shift)
-
-	if size < 0 || size > MaxUnpackedObjectSize {
-		return entry, fmt.Errorf("%w (%d bytes)", ErrObjectTooLarge, size)
-	}
 
 	err := p.processObjectByType(entry.Object, size, buf[0])
 	if err != nil {

--- a/protocol/packfile.go
+++ b/protocol/packfile.go
@@ -662,7 +662,8 @@ func (p *PackfileReader) readAndInflate(sz int) ([]byte, error) {
 	}
 
 	// TODO(mem): this should be limited to the size the packet says it
-	// carries.
+	// carries, and we should limit that size above (i.e. if the packet
+	// says it's carrying a huge amount of data we should bail out).
 	lr := io.LimitReader(p.zlibReader, MaxUnpackedObjectSize)
 
 	// Use pooled buffer if size is reasonable, otherwise allocate directly

--- a/protocol/packfile.go
+++ b/protocol/packfile.go
@@ -155,6 +155,7 @@ const (
 	ErrUnsupportedPackfileVersion = strError("the version of the packfile payload is unsupported")
 	ErrUnsupportedObjectType      = strError("the type of the object is unsupported")
 	ErrInflatedDataIncorrectSize  = strError("the data is the wrong size post-inflation")
+	ErrObjectTooLarge             = strError("the object size exceeds the maximum unpacked object size")
 )
 
 // MaxUnpackedObjectSize is the maximum size of an unpacked object.
@@ -562,6 +563,10 @@ func (p *PackfileReader) readObject(ctx context.Context) (PackfileEntry, error) 
 
 	logger.Debug("Read object type", "type_byte", buf[0], "type", entry.Object.Type, "size", size, "shift", shift)
 
+	if size < 0 || size > MaxUnpackedObjectSize {
+		return entry, fmt.Errorf("%w (%d bytes)", ErrObjectTooLarge, size)
+	}
+
 	err := p.processObjectByType(entry.Object, size, buf[0])
 	if err != nil {
 		return entry, err
@@ -623,7 +628,7 @@ func (p *PackfileReader) parseObjectContent(obj *PackfileObject) error {
 // processRefDelta handles reference delta objects
 func (p *PackfileReader) processRefDelta(obj *PackfileObject, size int) error {
 	ref := make([]byte, p.algo.Size())
-	if _, err := p.reader.Read(ref); err != nil {
+	if _, err := io.ReadFull(p.reader, ref); err != nil {
 		return err
 	}
 
@@ -662,8 +667,7 @@ func (p *PackfileReader) readAndInflate(sz int) ([]byte, error) {
 	}
 
 	// TODO(mem): this should be limited to the size the packet says it
-	// carries, and we should limit that size above (i.e. if the packet
-	// says it's carrying a huge amount of data we should bail out).
+	// carries.
 	lr := io.LimitReader(p.zlibReader, MaxUnpackedObjectSize)
 
 	// Use pooled buffer if size is reasonable, otherwise allocate directly

--- a/protocol/packfile_test.go
+++ b/protocol/packfile_test.go
@@ -2,13 +2,16 @@ package protocol_test
 
 import (
 	"bytes"
+	"compress/zlib"
 	"context"
 	"crypto"
+	"encoding/binary"
 	"errors"
 	"io"
 	"os"
 	"path"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/require"
 
@@ -112,6 +115,68 @@ func TestGolden(t *testing.T) {
 			require.ErrorIs(t, err, io.EOF)
 		})
 	}
+}
+
+func TestReadObject_RefDeltaShortRead(t *testing.T) {
+	t.Parallel()
+
+	baseData := []byte("some base object data here")
+	baseHash, err := protocol.Object(crypto.SHA1, protocol.ObjectTypeBlob, baseData)
+	require.NoError(t, err)
+
+	deltaPayload := []byte{
+		byte(len(baseData)), // 1a: source size 26
+		5,                   // 05: target size 5
+		5,                   // 05: insert the next 5 bytes
+		'h', 'e', 'l', 'l', 'o',
+	}
+
+	var pack bytes.Buffer
+	pack.WriteString("PACK")                                                 // 50 41 43 4b
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))     // 00 00 00 02: version 2
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))     // 00 00 00 02: 2 objects
+	pack.Write(objectHeader(protocol.ObjectTypeBlob, len(baseData)))         // ba 01: blob, size 26
+	pack.Write(zlibCompress(t, baseData))                                    // zlib stream
+	pack.Write(objectHeader(protocol.ObjectTypeRefDelta, len(deltaPayload))) // 78: ref-delta, size 8
+	pack.Write(baseHash[:])                                                  // 20-byte base object hash
+	pack.Write(zlibCompress(t, deltaPayload))                                // zlib stream
+	pack.Write(make([]byte, 20))                                             // trailer checksum
+
+	pr, err := protocol.ParsePackfile(context.Background(), iotest.OneByteReader(bytes.NewReader(pack.Bytes())))
+	require.NoError(t, err)
+
+	entry, err := pr.ReadObject(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, entry.Object)
+	require.Equal(t, protocol.ObjectTypeBlob, entry.Object.Type)
+	require.Equal(t, baseHash, entry.Object.Hash)
+
+	entry, err = pr.ReadObject(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, entry.Object)
+	require.Equal(t, protocol.ObjectTypeRefDelta, entry.Object.Type)
+	require.NotNil(t, entry.Object.Delta)
+	require.Equal(t, baseHash.String(), entry.Object.Delta.Parent)
+
+	resolved, err := protocol.ApplyDelta(baseData, entry.Object.Delta)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), resolved)
+}
+
+func TestReadObject_TooLarge(t *testing.T) {
+	t.Parallel()
+
+	var pack bytes.Buffer
+	pack.WriteString("PACK")
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(1)))
+	pack.Write(objectHeader(protocol.ObjectTypeBlob, protocol.MaxUnpackedObjectSize+1))
+
+	pr, err := protocol.ParsePackfile(context.Background(), &pack)
+	require.NoError(t, err)
+
+	_, err = pr.ReadObject(context.Background())
+	require.ErrorIs(t, err, protocol.ErrObjectTooLarge)
 }
 
 func loadGolden(t *testing.T, name string) []byte {
@@ -424,3 +489,26 @@ type fakeSigner struct {
 }
 
 func (f fakeSigner) Sign([]byte) (string, error) { return f.sig, f.err }
+
+func objectHeader(objType protocol.ObjectType, size int) []byte {
+	b := byte(objType)<<4 | byte(size&0xF)
+	size >>= 4
+	var out []byte
+	for size > 0 {
+		out = append(out, b|0x80)
+		b = byte(size & 0x7F)
+		size >>= 7
+	}
+	return append(out, b)
+}
+
+func zlibCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	_, err := zw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}

--- a/protocol/packfile_test.go
+++ b/protocol/packfile_test.go
@@ -163,22 +163,6 @@ func TestReadObject_RefDeltaShortRead(t *testing.T) {
 	require.Equal(t, []byte("hello"), resolved)
 }
 
-func TestReadObject_TooLarge(t *testing.T) {
-	t.Parallel()
-
-	var pack bytes.Buffer
-	pack.WriteString("PACK")
-	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))
-	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(1)))
-	pack.Write(objectHeader(protocol.ObjectTypeBlob, protocol.MaxUnpackedObjectSize+1))
-
-	pr, err := protocol.ParsePackfile(t.Context(), &pack)
-	require.NoError(t, err)
-
-	_, err = pr.ReadObject(t.Context())
-	require.ErrorIs(t, err, protocol.ErrObjectTooLarge)
-}
-
 func loadGolden(t *testing.T, name string) []byte {
 	t.Helper()
 

--- a/protocol/packfile_test.go
+++ b/protocol/packfile_test.go
@@ -142,16 +142,16 @@ func TestReadObject_RefDeltaShortRead(t *testing.T) {
 	pack.Write(zlibCompress(t, deltaPayload))                                // zlib stream
 	pack.Write(make([]byte, 20))                                             // trailer checksum
 
-	pr, err := protocol.ParsePackfile(context.Background(), iotest.OneByteReader(bytes.NewReader(pack.Bytes())))
+	pr, err := protocol.ParsePackfile(t.Context(), iotest.OneByteReader(bytes.NewReader(pack.Bytes())))
 	require.NoError(t, err)
 
-	entry, err := pr.ReadObject(context.Background())
+	entry, err := pr.ReadObject(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, entry.Object)
 	require.Equal(t, protocol.ObjectTypeBlob, entry.Object.Type)
 	require.Equal(t, baseHash, entry.Object.Hash)
 
-	entry, err = pr.ReadObject(context.Background())
+	entry, err = pr.ReadObject(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, entry.Object)
 	require.Equal(t, protocol.ObjectTypeRefDelta, entry.Object.Type)
@@ -172,10 +172,10 @@ func TestReadObject_TooLarge(t *testing.T) {
 	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(1)))
 	pack.Write(objectHeader(protocol.ObjectTypeBlob, protocol.MaxUnpackedObjectSize+1))
 
-	pr, err := protocol.ParsePackfile(context.Background(), &pack)
+	pr, err := protocol.ParsePackfile(t.Context(), &pack)
 	require.NoError(t, err)
 
-	_, err = pr.ReadObject(context.Background())
+	_, err = pr.ReadObject(t.Context())
 	require.ErrorIs(t, err, protocol.ErrObjectTooLarge)
 }
 


### PR DESCRIPTION
## What
Fixes packfile parsing failures on large fetches that surfaced as `object not found` errors and propagates mid-stream packfile read errors instead of swallowing them.

## Why
Fetching a file by path from a sufficiently large repository fails even though the object exists on the remote:

```
nanogit cat-file https://github.com/<org>/<large-repo>.git master README.md
Error: failed to get file "README.md": get final tree <tree-hash>: get tree object <tree-hash>: object <tree-hash> not found
```

Running with `NANOGIT_TRACE=1` shows the underlying failure: parsing aborts mid-pack with `zlib: invalid header` and the remaining objects — including the wanted one — are silently dropped.

A packfile has no separators between objects: the parser only finds object N+1 by consuming object N exactly to the byte. The 20-byte base hash of a ref-delta object is read with a single `Read` call without checking how many bytes came back. Go readers may legally return fewer bytes than requested, and the parser's 64KB buffered reader does so at buffer boundaries. A short read mid-hash misaligns every subsequent object, and since read errors are treated as end-of-stream, the fetch reports the wanted object as not found instead of failing. Small fetches fit in one buffer window, which is why only large repositories hit this.

## How
The actual fix is one line: read the base hash with `io.ReadFull` instead of a bare `Read`, so it always gets all 20 bytes. Additionally, mid-stream read errors now surface from fetch instead of being swallowed; only a genuine end-of-stream EOF terminates reading.

## Remarks
The regression test feeds the parser through `iotest.OneByteReader` so every multi-byte read is short, covering all alignments deterministically; without the fix it fails with the same `zlib: invalid header`. A second test serves a corrupt pack through a fetch and asserts the error reads `reading packfile object 1: zlib: invalid header` instead of `object not found`.

Related: object size validation is split out into #344.
