### PR TITLE
fix: enforce declared object size limits in packfile parser

### DIFF
--- a/protocol/packfile.go
+++ b/protocol/packfile.go
@@ -155,6 +155,7 @@ const (
 	ErrUnsupportedPackfileVersion = strError("the version of the packfile payload is unsupported")
 	ErrUnsupportedObjectType      = strError("the type of the object is unsupported")
 	ErrInflatedDataIncorrectSize  = strError("the data is the wrong size post-inflation")
+	ErrObjectTooLarge             = strError("the object size exceeds the maximum unpacked object size")
 )
 
 // MaxUnpackedObjectSize is the maximum size of an unpacked object.
@@ -562,6 +563,10 @@ func (p *PackfileReader) readObject(ctx context.Context) (PackfileEntry, error) 
 
 	logger.Debug("Read object type", "type_byte", buf[0], "type", entry.Object.Type, "size", size, "shift", shift)
 
+	if size < 0 || size > MaxUnpackedObjectSize {
+		return entry, fmt.Errorf("%w (%d bytes)", ErrObjectTooLarge, size)
+	}
+
 	err := p.processObjectByType(entry.Object, size, buf[0])
 	if err != nil {
 		return entry, err
@@ -637,34 +642,11 @@ func (p *PackfileReader) processRefDelta(obj *PackfileObject, size int) error {
 }
 
 func (p *PackfileReader) readAndInflate(sz int) ([]byte, error) {
-	// Reuse zlib reader for performance - avoid creating new reader for each object
-	if p.zlibReader == nil {
-		var err error
-		p.zlibReader, err = getPooledZlibReader(p.reader)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// Reset the reader for the next zlib stream
-		if resetter, ok := p.zlibReader.(zlib.Resetter); ok {
-			if err := resetter.Reset(p.reader, nil); err != nil {
-				return nil, err
-			}
-		} else {
-			// Fallback: close and recreate using pool
-			_ = p.zlibReader.Close()
-			var err error
-			p.zlibReader, err = getPooledZlibReader(p.reader)
-			if err != nil {
-				return nil, err
-			}
-		}
+	if err := p.resetZlibReader(); err != nil {
+		return nil, err
 	}
 
-	// TODO(mem): this should be limited to the size the packet says it
-	// carries, and we should limit that size above (i.e. if the packet
-	// says it's carrying a huge amount of data we should bail out).
-	lr := io.LimitReader(p.zlibReader, MaxUnpackedObjectSize)
+	lr := io.LimitReader(p.zlibReader, int64(sz)+1)
 
 	// Use pooled buffer if size is reasonable, otherwise allocate directly
 	var data []byte
@@ -699,7 +681,10 @@ func (p *PackfileReader) readAndInflate(sz int) ([]byte, error) {
 	defer discardBufferPool.Put(discardBuf) //nolint:staticcheck
 
 	for {
-		_, err := lr.Read(discardBuf)
+		n, err := lr.Read(discardBuf)
+		if n > 0 {
+			return nil, ErrInflatedDataIncorrectSize
+		}
 		if err != nil {
 			if err == io.EOF {
 				break // This is expected - we've consumed the entire zlib stream
@@ -717,6 +702,27 @@ func (p *PackfileReader) readAndInflate(sz int) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+// resetZlibReader prepares the reusable zlib reader for the next stream,
+// avoiding a new reader allocation for each object.
+func (p *PackfileReader) resetZlibReader() error {
+	if p.zlibReader == nil {
+		var err error
+		p.zlibReader, err = getPooledZlibReader(p.reader)
+		return err
+	}
+
+	// Reset the reader for the next zlib stream
+	if resetter, ok := p.zlibReader.(zlib.Resetter); ok {
+		return resetter.Reset(p.reader, nil)
+	}
+
+	// Fallback: close and recreate using pool
+	_ = p.zlibReader.Close()
+	var err error
+	p.zlibReader, err = getPooledZlibReader(p.reader)
+	return err
 }
 
 // calculateObjectHash computes the hash of an object using a reusable hasher for performance

--- a/protocol/packfile_test.go
+++ b/protocol/packfile_test.go
@@ -163,6 +163,52 @@ func TestReadObject_RefDeltaShortRead(t *testing.T) {
 	require.Equal(t, []byte("hello"), resolved)
 }
 
+func TestReadObject_TooLarge(t *testing.T) {
+	t.Parallel()
+
+	var pack bytes.Buffer
+	pack.WriteString("PACK")
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(1)))
+	pack.Write(objectHeader(protocol.ObjectTypeBlob, protocol.MaxUnpackedObjectSize+1))
+
+	pr, err := protocol.ParsePackfile(t.Context(), &pack)
+	require.NoError(t, err)
+
+	_, err = pr.ReadObject(t.Context())
+	require.ErrorIs(t, err, protocol.ErrObjectTooLarge)
+}
+
+func TestReadObject_MaxSizeObject(t *testing.T) {
+	t.Parallel()
+
+	bigData := bytes.Repeat([]byte{'a'}, protocol.MaxUnpackedObjectSize)
+	smallData := []byte("hello")
+	smallHash, err := protocol.Object(crypto.SHA1, protocol.ObjectTypeBlob, smallData)
+	require.NoError(t, err)
+
+	var pack bytes.Buffer
+	pack.WriteString("PACK")
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))
+	require.NoError(t, binary.Write(&pack, binary.BigEndian, uint32(2)))
+	pack.Write(objectHeader(protocol.ObjectTypeBlob, len(bigData)))
+	pack.Write(zlibCompress(t, bigData))
+	pack.Write(objectHeader(protocol.ObjectTypeBlob, len(smallData)))
+	pack.Write(zlibCompress(t, smallData))
+	pack.Write(make([]byte, 20))
+
+	pr, err := protocol.ParsePackfile(t.Context(), bytes.NewReader(pack.Bytes()))
+	require.NoError(t, err)
+
+	entry, err := pr.ReadObject(t.Context())
+	require.NoError(t, err)
+	require.Len(t, entry.Object.Data, protocol.MaxUnpackedObjectSize)
+
+	entry, err = pr.ReadObject(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, smallHash, entry.Object.Hash)
+}
+
 func loadGolden(t *testing.T, name string) []byte {
 	t.Helper()
 

--- a/tests/packfile_size_integration_test.go
+++ b/tests/packfile_size_integration_test.go
@@ -1,0 +1,119 @@
+package integration_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Packfile object size limits", func() {
+	var (
+		client nanogit.Client
+		local  *gittest.LocalRepo
+	)
+
+	BeforeEach(func() {
+		client, _, local, _ = QuickSetup()
+	})
+
+	It("should read an object that inflates to exactly the maximum size without corrupting other objects in the pack", func() {
+		By("Creating a blob whose inflated size is exactly the maximum")
+		maxContent := string(bytes.Repeat([]byte("a"), protocol.MaxUnpackedObjectSize))
+		Expect(local.CreateFile("max.bin", maxContent)).To(Succeed())
+
+		By("Creating additional files packed alongside it")
+		Expect(local.CreateFile("before.txt", "before content")).To(Succeed())
+		Expect(local.CreateFile("after.txt", "after content")).To(Succeed())
+		Expect(local.CreateFile("nested/deep.txt", "nested content")).To(Succeed())
+
+		By("Committing and pushing")
+		_, err := local.Git("add", ".")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("commit", "-m", "Add max-size object with neighbours")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("push", "origin", "main", "--force")
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := local.Git("rev-parse", "HEAD")
+		Expect(err).NotTo(HaveOccurred())
+		commitHash, err := hash.FromHex(output)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Cloning so every blob arrives in a single pack")
+		tempDir := GinkgoT().TempDir()
+		_, err = client.Clone(ctx, nanogit.CloneOptions{Path: tempDir, Hash: commitHash})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the max-size object is intact")
+		got, err := os.ReadFile(filepath.Join(tempDir, "max.bin"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(got)).To(Equal(protocol.MaxUnpackedObjectSize))
+		Expect(bytes.Equal(got, []byte(maxContent))).To(BeTrue())
+
+		By("Verifying neighbouring objects are not misaligned")
+		for path, want := range map[string]string{
+			"before.txt":      "before content",
+			"after.txt":       "after content",
+			"nested/deep.txt": "nested content",
+		} {
+			content, err := os.ReadFile(filepath.Join(tempDir, path))
+			Expect(err).NotTo(HaveOccurred(), "path: %q", path)
+			Expect(string(content)).To(Equal(want), "path: %q", path)
+		}
+	})
+
+	It("should read a max-size blob directly via GetBlob", func() {
+		By("Creating and pushing a blob of exactly the maximum size")
+		maxContent := string(bytes.Repeat([]byte("b"), protocol.MaxUnpackedObjectSize))
+		Expect(local.CreateFile("max.bin", maxContent)).To(Succeed())
+		_, err := local.Git("add", "max.bin")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("commit", "-m", "Add max-size blob")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("push", "origin", "main", "--force")
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := local.Git("rev-parse", "HEAD:max.bin")
+		Expect(err).NotTo(HaveOccurred())
+		blobHash, err := hash.FromHex(output)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Fetching it through nanogit")
+		blob, err := client.GetBlob(ctx, blobHash)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(blob.Content)).To(Equal(protocol.MaxUnpackedObjectSize))
+		Expect(bytes.Equal(blob.Content, []byte(maxContent))).To(BeTrue())
+		Expect(blob.Hash).To(Equal(blobHash))
+	})
+
+	It("should reject a blob larger than the maximum unpacked object size", func() {
+		By("Creating and pushing a blob exceeding the maximum size")
+		tooLarge := string(bytes.Repeat([]byte("c"), protocol.MaxUnpackedObjectSize+1))
+		Expect(local.CreateFile("toobig.bin", tooLarge)).To(Succeed())
+		_, err := local.Git("add", "toobig.bin")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("commit", "-m", "Add oversized blob")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("push", "origin", "main", "--force")
+		Expect(err).NotTo(HaveOccurred())
+
+		output, err := local.Git("rev-parse", "HEAD:toobig.bin")
+		Expect(err).NotTo(HaveOccurred())
+		blobHash, err := hash.FromHex(output)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Fetching it through nanogit")
+		_, err = client.GetBlob(ctx, blobHash)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, protocol.ErrObjectTooLarge)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
## What
Validates declared object sizes when reading packfiles and enforces that each object inflates to exactly its declared size.

## Why
Two gaps in packfile object reading:

- A corrupt size varint could drive a multi-GB allocation before any inflation limit applied.
- An object inflating to exactly `MaxUnpackedObjectSize` left the zlib trailer unconsumed, misaligning every subsequent object in the pack — the same silent-corruption failure mode as #343.

## How
- Reject sizes outside `[0, MaxUnpackedObjectSize]` with the new `ErrObjectTooLarge` before allocating.
- Limit inflation to the declared size; any extra byte in the stream fails with `ErrInflatedDataIncorrectSize`, and draining to the stream's real end keeps the next object aligned.

## Remarks
Objects above the 10MB cap already failed before this change, but as `ErrInflatedDataIncorrectSize` after the allocation — callers matching that error for oversized objects now get `ErrObjectTooLarge`.

Related: #343.

## Author Checklist
- [x] Tests added/updated.
- [ ] Documentation updated.
- [x] Changes have been tested locally.

---
*Description generated by Claude Code.*