### PR TITLE
feat: Make gitea test user customisable in `gittest`

### DIFF
--- a/gittest/README.md
+++ b/gittest/README.md
@@ -70,6 +70,9 @@ defer server.Cleanup()
 // Create a user
 user, err := server.CreateUser(ctx)
 
+// Create a user with an exact username
+customUser, err := server.CreateUser(ctx, gittest.WithUsername("alice"))
+
 // Create a repository
 repo, err := server.CreateRepo(ctx, "myrepo", user)
 
@@ -85,6 +88,9 @@ url := server.URL()
 - `WithTimeout(duration)` - Set container startup timeout
 - `WithGiteaImage(image)` - Set Docker image name
 - `WithGiteaVersion(version)` - Set Gitea version tag
+
+**User Options:**
+- `WithUsername(username)` - Set the exact username for `CreateUser`
 
 ### LocalRepo
 

--- a/gittest/doc.go
+++ b/gittest/doc.go
@@ -16,6 +16,8 @@
 //	defer server.Cleanup()
 //
 //	user, _ := server.CreateUser(ctx)
+//	// Or use an exact username:
+//	// user, _ := server.CreateUser(ctx, gittest.WithUsername("alice"))
 //	repo, _ := server.CreateRepo(ctx, gittest.RandomRepoName(), user)
 //
 //	local, _ := gittest.NewLocalRepo(ctx)

--- a/gittest/example_test.go
+++ b/gittest/example_test.go
@@ -97,6 +97,25 @@ func ExampleServer_CreateUser() {
 	// user.Password and user.Token are also available
 }
 
+// ExampleServer_CreateUser_withUsername demonstrates creating a test user with
+// an exact username.
+func ExampleServer_CreateUser_withUsername() {
+	ctx := context.Background()
+
+	server, err := gittest.NewServer(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer server.Cleanup()
+
+	user, err := server.CreateUser(ctx, gittest.WithUsername("alice"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Created user: %s\n", user.Username)
+}
+
 // ExampleServer_CreateRepo demonstrates creating a repository.
 func ExampleServer_CreateRepo() {
 	ctx := context.Background()

--- a/gittest/options.go
+++ b/gittest/options.go
@@ -41,6 +41,24 @@ func WithTrustedSSHKeys(keys ...string) ServerOption {
 	}
 }
 
+// userConfig holds configuration for creating a test user.
+type userConfig struct {
+	username *string
+}
+
+// UserOption configures a test user created by Server.CreateUser.
+type UserOption func(*userConfig)
+
+// WithUsername sets the exact username for a test user. This is useful for
+// tests that need stable repository URLs or server-side ownership paths.
+//
+// When this option is not provided, CreateUser generates a unique username.
+func WithUsername(username string) UserOption {
+	return func(c *userConfig) {
+		c.username = &username
+	}
+}
+
 // repoConfig holds configuration for LocalRepo.
 type repoConfig struct {
 	logger   Logger

--- a/gittest/server.go
+++ b/gittest/server.go
@@ -193,14 +193,14 @@ func NewServer(ctx context.Context, opts ...ServerOption) (*Server, error) {
 // CreateUser creates a new test user in the Gitea server.
 //
 // The user is automatically configured with:
-//   - Auto-generated unique username (e.g., "user-1234567890ab")
+//   - Auto-generated unique username, unless WithUsername is provided
 //   - Auto-generated email address
 //   - Auto-generated password
 //   - Admin privileges for repository creation
 //   - Pre-generated access token for authentication
 //
-// The username includes a timestamp and random suffix to prevent collisions
-// in parallel test execution.
+// The generated username includes a timestamp and random suffix to prevent
+// collisions in parallel test execution.
 //
 // Returns the created User with all credentials, or an error if creation fails.
 //
@@ -211,29 +211,22 @@ func NewServer(ctx context.Context, opts ...ServerOption) (*Server, error) {
 //		t.Fatal(err)
 //	}
 //	// user.Username, user.Password, user.Token are now available
-func (s *Server) CreateUser(ctx context.Context) (*User, error) {
-	// Generate a unique suffix using nanosecond timestamp + random bytes
-	// This ensures uniqueness even when tests run in parallel
-	now := time.Now().UnixNano()
-	var randomBytes [4]byte
-	if _, err := rand.Read(randomBytes[:]); err != nil {
-		return nil, fmt.Errorf("failed to generate random bytes: %w", err)
+func (s *Server) CreateUser(ctx context.Context, opts ...UserOption) (*User, error) {
+	suffix, err := randomUserSuffix()
+	if err != nil {
+		return nil, err
 	}
 
-	// Combine timestamp and random data for a unique suffix
-	suffix := fmt.Sprintf("%d%x", now, randomBytes)
-
-	user := &User{
-		Username: fmt.Sprintf("testuser-%s", suffix),
-		Email:    fmt.Sprintf("test-%s@example.com", suffix),
-		Password: fmt.Sprintf("testpass-%s", suffix),
+	user, err := newUser(suffix, opts...)
+	if err != nil {
+		return nil, err
 	}
 	s.logger.Logf("👤 Creating test user '%s'...", user.Username)
 
 	execResult, reader, err := s.container.Exec(ctx, []string{
 		"su", "git", "-c",
 		fmt.Sprintf("gitea admin user create --username %s --email %s --password %s --must-change-password=false --admin",
-			user.Username, user.Email, user.Password),
+			shellQuote(user.Username), shellQuote(user.Email), shellQuote(user.Password)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute user creation command: %w", err)
@@ -252,6 +245,50 @@ func (s *Server) CreateUser(ctx context.Context) (*User, error) {
 
 	s.logger.Logf("✅ Test user '%s' created successfully", user.Username)
 	return user, nil
+}
+
+// randomUserSuffix returns the unique suffix used for generated user fields.
+// Keeping this separate lets CreateUser share one suffix across username,
+// email, and password generation.
+func randomUserSuffix() (string, error) {
+	now := time.Now().UnixNano()
+	var randomBytes [4]byte
+	if _, err := rand.Read(randomBytes[:]); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	return fmt.Sprintf("%d%x", now, randomBytes), nil
+}
+
+// newUser builds a User from a generated suffix and caller options before any
+// container commands run. This keeps validation independent from the Gitea CLI.
+func newUser(suffix string, opts ...UserOption) (*User, error) {
+	cfg := userConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	username := fmt.Sprintf("testuser-%s", suffix)
+	if cfg.username != nil {
+		username = *cfg.username
+	}
+	if strings.TrimSpace(username) == "" {
+		return nil, fmt.Errorf("username cannot be empty")
+	}
+
+	return &User{
+		Username: username,
+		Email:    fmt.Sprintf("test-%s@example.com", suffix),
+		Password: fmt.Sprintf("testpass-%s", suffix),
+	}, nil
+}
+
+// shellQuote returns value as a single POSIX shell argument. CreateUser and
+// CreateToken pass command strings through "su -c", so user-controlled values
+// must be quoted before they reach the shell.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 // CreateToken creates a new access token for the specified user in the Gitea server.
@@ -273,7 +310,7 @@ func (s *Server) CreateToken(ctx context.Context, username string) (string, erro
 
 	execResult, reader, err := s.container.Exec(ctx, []string{
 		"su", "git", "-c",
-		fmt.Sprintf("gitea admin user generate-access-token --username %s --scopes all", username),
+		fmt.Sprintf("gitea admin user generate-access-token --username %s --scopes all", shellQuote(username)),
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to execute token generation command: %w", err)

--- a/gittest/server.go
+++ b/gittest/server.go
@@ -247,9 +247,9 @@ func (s *Server) CreateUser(ctx context.Context, opts ...UserOption) (*User, err
 	return user, nil
 }
 
-// randomUserSuffix returns the unique suffix used for generated user fields.
-// Keeping this separate lets CreateUser share one suffix across username,
-// email, and password generation.
+// randomUserSuffix returns the unique suffix used for generated usernames.
+// Keeping this separate makes the default username construction explicit while
+// still allowing callers to provide an exact username.
 func randomUserSuffix() (string, error) {
 	now := time.Now().UnixNano()
 	var randomBytes [4]byte
@@ -279,8 +279,8 @@ func newUser(suffix string, opts ...UserOption) (*User, error) {
 
 	return &User{
 		Username: username,
-		Email:    fmt.Sprintf("test-%s@example.com", suffix),
-		Password: fmt.Sprintf("testpass-%s", suffix),
+		Email:    fmt.Sprintf("%s@example.com", username),
+		Password: fmt.Sprintf("%s-password", username),
 	}, nil
 }
 

--- a/gittest/types.go
+++ b/gittest/types.go
@@ -8,8 +8,8 @@ import (
 
 // User represents a test user account in the Git server.
 //
-// All fields are automatically generated when created via Server.CreateUser():
-//   - Username: Unique identifier with timestamp suffix (e.g., "user-1234567890ab")
+// Fields are populated when created via Server.CreateUser():
+//   - Username: Generated unique identifier, or exact value from WithUsername
 //   - Email: Auto-generated email address
 //   - Password: Auto-generated password for HTTPS authentication
 //   - Token: Pre-generated access token for API operations

--- a/gittest/types.go
+++ b/gittest/types.go
@@ -10,8 +10,8 @@ import (
 //
 // Fields are populated when created via Server.CreateUser():
 //   - Username: Generated unique identifier, or exact value from WithUsername
-//   - Email: Auto-generated email address
-//   - Password: Auto-generated password for HTTPS authentication
+//   - Email: Auto-generated email address derived from the username
+//   - Password: Auto-generated password derived from the username
 //   - Token: Pre-generated access token for API operations
 //
 // Example:


### PR DESCRIPTION
## Summary

- Add `gittest.WithUsername` to create a Gitea test user with an exact username.
- Keep `Server.CreateUser(ctx)` backward compatible with generated usernames, email, and password.
- Quote Gitea CLI arguments passed through `su -c` before user-controlled values reach the shell.
- Document the new user option in README, package docs, and examples.