### PR TITLE
docs: explain why nanogit implements Git protocol v2 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The following features are explicitly not supported:
 - "Dumb" servers
 - Complex permissions (all objects use mode 0644)
 
+## Why Git Protocol v2 Only?
+
+nanogit speaks **only** Git Smart HTTP Protocol v2. It does not implement the legacy v1 protocol (neither the original "smart" v1 negotiation nor the "dumb" HTTP protocol), and it will not silently fall back to it. This is a deliberate design decision, not a missing feature:
+
+- **Stateless by design** — Protocol v2 replaces v1's stateful, multi-round `want`/`have` negotiation with a command-oriented request model that completes in a single stateless HTTP round trip. That maps directly onto nanogit's stateless, serverless-friendly architecture. v1's negotiation assumes connection state that nanogit deliberately does not keep.
+- **Server-side ref filtering** — v2's `ls-refs` command lets the client request only the references it needs (via `ref-prefix`). v1 dumps the *entire* ref advertisement on every `info/refs` request, which is wasteful for repositories with thousands of branches and tags — exactly the multitenant, large-repo case nanogit targets.
+- **Smaller surface area** — Supporting both protocols would double the negotiation and parsing code paths. Minimal surface area is a core design principle: less code means fewer bugs and a smaller attack surface.
+- **Broad (not universal) provider support** — Protocol v2 has been available since Git 2.18 (2018) and the default fetch protocol since Git 2.26 (2020). GitHub, GitLab, and Bitbucket all support it. The notable exception is **Azure DevOps / Azure Repos**, which only speaks protocol v1 — nanogit cannot talk to it, and there is no fallback. For nanogit's target audience (cloud-native services talking to modern hosted Git), the trade-off is worth it: v1 support would add complexity to serve a shrinking set of servers.
+
+When a server only speaks v1, `nanogit check` reports it as incompatible and every operation fails fast rather than silently degrading. Always run it against a new provider before integrating. See the [Server Compatibility guide](https://grafana.github.io/nanogit/getting-started/server-compatibility/) for how to verify support.
+
 ## Why nanogit?
 
 While [go-git](https://github.com/go-git/go-git) is a mature Git implementation, nanogit is designed for cloud-native, multitenant environments requiring minimal, stateless operations.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,6 +10,14 @@ nanogit operates without requiring a local .git directory, making it ideal for s
 ### HTTPS-Only Protocol
 Focuses exclusively on Git Smart HTTP Protocol v2, eliminating the complexity of supporting multiple transport protocols and simplifying authentication in cloud environments.
 
+#### Why protocol v2 only (and not v1)?
+nanogit implements Git Smart HTTP Protocol **v2** and intentionally does not implement the legacy v1 protocol. `IsServerCompatible` (see `protocol/client/compatibility.go`) detects the server's protocol version up front and treats a v1-only server as incompatible rather than falling back. The reasons are architectural, not incidental:
+
+- **Statelessness.** v2 replaced v1's stateful, multi-round `want`/`have` negotiation with a command-oriented model that completes in a single stateless HTTP round trip. That matches nanogit's stateless design (no local `.git`, no persistent connection state); v1's negotiation assumes connection state nanogit deliberately does not keep.
+- **Server-side ref filtering.** v2's `ls-refs` command lets the client ask for only the refs it needs via `ref-prefix`. v1 advertises *every* ref on each `info/refs` request, which does not scale for the large, multitenant repositories nanogit targets.
+- **Minimal surface area.** Supporting both wire protocols would double the negotiation and parsing paths. Keeping to v2 alone honors the minimal-surface-area principle below — less code, fewer bugs, smaller attack surface.
+- **Broad, though not universal, reach.** Protocol v2 has shipped since Git 2.18 (2018) and been the default fetch protocol since Git 2.26 (2020). GitHub, GitLab, and Bitbucket support it. The known exception is **Azure DevOps / Azure Repos**, which only advertises protocol v1; nanogit treats it as incompatible and does not fall back. For nanogit's intended audience the trade-off is deliberate — v1 support would add complexity to reach a shrinking set of servers.
+
 ### Pluggable Storage
 Features a flexible two-layer storage architecture:
 - **Writing modes**: Control temporary storage during packfile creation

--- a/docs/getting-started/server-compatibility.md
+++ b/docs/getting-started/server-compatibility.md
@@ -4,6 +4,14 @@ nanogit requires **Git Smart HTTP Protocol v2**. Before integrating it into your
 
 If any step fails, nanogit is not the right fit for that server and you'll want to fall back to the standard `git` CLI or a provider that supports protocol v2.
 
+::: info Why v2 only?
+nanogit does not implement the legacy v1 protocol and will not fall back to it. v2's stateless, command-oriented model matches nanogit's stateless architecture, lets it request only the refs it needs, and keeps the codebase small. v2 is the Git default (2.26+) and is supported by GitHub, GitLab, and Bitbucket. See [Why protocol v2 only](../architecture/overview.md#why-protocol-v2-only-and-not-v1) for the full rationale.
+:::
+
+::: warning Azure DevOps is not supported
+**Azure DevOps / Azure Repos only speaks Git protocol v1**, so nanogit cannot read from or write to it. `nanogit check` will report it as incompatible. There is no workaround — use the standard `git` CLI for Azure Repos.
+:::
+
 ## Prerequisites
 
 - A scratch repository you can write to (GitHub, GitLab, Bitbucket, or a self-hosted server)


### PR DESCRIPTION
## Summary

nanogit speaks **only** Git Smart HTTP Protocol v2 and rejects v1-only servers with no fallback (see `IsServerCompatible` in `protocol/client/compatibility.go`). That decision wasn't documented anywhere. This PR adds the rationale to the README and docs site, and honestly calls out **Azure DevOps / Azure Repos** as the notable provider nanogit cannot talk to because it only speaks v1.

## Changes

- **`README.md`** — new `## Why Git Protocol v2 Only?` section (statelessness, server-side ref filtering, minimal surface area, provider support).
- **`docs/architecture/overview.md`** — `#### Why protocol v2 only (and not v1)?` subsection under the HTTPS-Only design principle, referencing the compatibility-detection code.
- **`docs/getting-started/server-compatibility.md`** — a VitePress `::: info` callout plus a `::: warning` making it unambiguous that Azure DevOps is unsupported with no workaround.

## Rationale documented

1. **Stateless by design** — v2's single-round-trip command model fits nanogit's stateless architecture; v1's multi-round `want`/`have` negotiation assumes connection state nanogit doesn't keep.
2. **Server-side ref filtering** — v2's `ls-refs` + `ref-prefix` avoids v1's full ref dump on every `info/refs`.
3. **Smaller surface area** — supporting both would double negotiation/parsing paths.
4. **Broad, not universal, reach** — v2 default since Git 2.26 (2020); GitHub/GitLab/Bitbucket support it, but **Azure DevOps only speaks v1**.

## Testing

- Docs-only change (markdown); no Go code touched, so the Go test/lint suite is not applicable.
- Verified the cross-page anchor link `#why-protocol-v2-only-and-not-v1` matches VitePress's slugify output for the heading, and switched from mkdocs `!!!` syntax to VitePress `:::` containers after confirming the docs build with VitePress (not mkdocs).

## Checklist

- [ ] Docs updated (this is the change)
- [ ] No breaking changes
- [ ] VitePress build verified in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)