### PR TITLE
docs: explain why nanogit was built (Git Sync) and who uses it

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ So we built nanogit around the constraints Git Sync actually has:
 
 nanogit is open source and usable on its own, but its design — and the performance numbers below — come directly from this workload: doing the Git plumbing behind Git Sync efficiently, safely, and for many tenants at scale.
 
-## Used by
+## Known usage
 
 - **[grafana/grafana](https://github.com/grafana/grafana)** — nanogit is the Git engine behind [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) provisioning (`apps/provisioning/pkg/repository/git`). It resolves refs, reads and writes dashboards and folders, stages commits, and pushes to each tenant's repository over HTTPS.
 - **[grafana/grafana-bench](https://github.com/grafana/grafana-bench)** — nanogit is the **default Git driver** for fetching the test-suite repository before a benchmark run. grafana-bench pulls its k6/Playwright suites from Git; nanogit's lightweight, HTTP-only client with parallel object fetching and sparse/subpath checkout pulls large monorepos faster and with less overhead than the alternative go-git driver, keeping benchmark setup fast and repeatable. (go-git stays available via `--git-driver gogit` when SSH or full Git features are needed.)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@
 
 nanogit is a lightweight, cloud-native Git implementation designed for applications that need efficient Git operations over HTTPS without the complexity and resource overhead of traditional Git implementations.
 
+## Why we built nanogit in the first place
+
+nanogit was created by Grafana to power [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) — the [Observability as Code](https://grafana.com/docs/grafana/latest/as-code/) feature that lets you store Grafana dashboards and folders as files in your own Git repository and manage them as code: auditable, reviewable, and reproducible, editing in the UI and opening pull requests without leaving Grafana.
+
+Git Sync needed a real Git engine embedded in Grafana's backend, and none of the obvious options fit:
+
+- **A GitHub API wasn't enough.** The goal grew from "sync with GitHub" to "sync with any Git provider." That means speaking the standard Git Smart HTTP protocol directly, so GitLab, Bitbucket, and self-hosted servers work without provider-specific code.
+- **The `git` CLI and libgit2** assume a local `.git` working directory. Maintaining a checkout per tenant, and shelling out to a binary, is impractical and hard to reason about operationally in a shared, multitenant backend.
+- **[go-git](https://github.com/go-git/go-git)** is mature, but its abstraction and overhead were too heavy for this use case. It is built around local-disk operations and full clones — stateful and memory-heavy once multiplied across thousands of tenants and large repositories.
+
+So we built nanogit around the constraints Git Sync actually has:
+
+- **Provider-agnostic** — talks the Git wire protocol over HTTPS, so any compliant provider works without bespoke integrations.
+- **Stateless** — no local `.git`, no per-tenant working tree. Every operation completes over HTTPS, which fits Grafana Cloud's horizontally scaled, multitenant backend.
+- **Lean and fast** — parses only what Git Sync needs. Streaming packfiles, path filtering, shallow reads, and delta handling keep it fast and memory-efficient on Grafana-scale repositories, where an operation usually touches a subpath rather than the whole repo.
+- **Safe and controllable** — a focused, embeddable library with a minimal surface area is easier to secure and operate than a general-purpose tool, and it needs only token auth (no SSH key management).
+
+nanogit is open source and usable on its own, but its design — and the performance numbers below — come directly from this workload: doing the Git plumbing behind Git Sync efficiently, safely, and for many tenants at scale.
+
+## Used by
+
+- **[grafana/grafana](https://github.com/grafana/grafana)** — nanogit is the Git engine behind [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) provisioning (`apps/provisioning/pkg/repository/git`). It resolves refs, reads and writes dashboards and folders, stages commits, and pushes to each tenant's repository over HTTPS.
+- **[grafana/grafana-bench](https://github.com/grafana/grafana-bench)** — nanogit is the **default Git driver** for fetching the test-suite repository before a benchmark run. grafana-bench pulls its k6/Playwright suites from Git; nanogit's lightweight, HTTP-only client with parallel object fetching and sparse/subpath checkout pulls large monorepos faster and with less overhead than the alternative go-git driver, keeping benchmark setup fast and repeatable. (go-git stays available via `--git-driver gogit` when SSH or full Git features are needed.)
+
 ## Features
 
 - **HTTPS-only Git operations** - Works with any Git service supporting Smart HTTP Protocol v2 (GitHub, GitLab, Bitbucket, etc.), eliminating the need for SSH key management in cloud environments

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ So we built nanogit around the constraints Git Sync actually has:
 - **Provider-agnostic** — talks the Git wire protocol over HTTPS, so any compliant provider works without bespoke integrations.
 - **Stateless** — no local `.git`, no per-tenant working tree. Every operation completes over HTTPS, which fits Grafana Cloud's horizontally scaled, multitenant backend.
 - **Lean and fast** — parses only what Git Sync needs. Streaming packfiles, path filtering, shallow reads, and delta handling keep it fast and memory-efficient on Grafana-scale repositories, where an operation usually touches a subpath rather than the whole repo.
+- **Operational control** — speaking the Git protocol directly lets Grafana control exactly how it talks to each provider: how many requests it makes and how large each response is (to stay within provider rate limits and byte budgets), what objects get cached and reused across operations, and how many round trips a sync costs. Hosted provider APIs and general-purpose clients don't expose that level of control.
 - **Safe and controllable** — a focused, embeddable library with a minimal surface area is easier to secure and operate than a general-purpose tool, and it needs only token auth (no SSH key management).
 
 nanogit is open source and usable on its own, but its design — and the performance numbers below — come directly from this workload: doing the Git plumbing behind Git Sync efficiently, safely, and for many tenants at scale.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Git Sync needed a real Git engine embedded in Grafana's backend, and none of the
 So we built nanogit around the constraints Git Sync actually has:
 
 - **Provider-agnostic** — talks the Git wire protocol over HTTPS, so any compliant provider works without bespoke integrations.
-- **Stateless** — no local `.git`, no per-tenant working tree. Every operation completes over HTTPS, which fits Grafana Cloud's horizontally scaled, multitenant backend.
+- **Stateless — no clones, no `.git`** — a defining goal was to avoid full clones and never persist a `.git` directory or per-tenant working tree. nanogit reads and writes objects directly over HTTPS, so there is no local repository state to store, clean up, or keep consistent across a horizontally scaled, multitenant backend.
 - **Lean and fast** — parses only what Git Sync needs. Streaming packfiles, path filtering, shallow reads, and delta handling keep it fast and memory-efficient on Grafana-scale repositories, where an operation usually touches a subpath rather than the whole repo.
 - **Operational control** — speaking the Git protocol directly lets Grafana control exactly how it talks to each provider: how many requests it makes and how large each response is (to stay within provider rate limits and byte budgets), what objects get cached and reused across operations, and how many round trips a sync costs. Hosted provider APIs and general-purpose clients don't expose that level of control.
 - **Safe and controllable** — a focused, embeddable library with a minimal surface area is easier to secure and operate than a general-purpose tool, and it needs only token auth (no SSH key management).

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Git Sync needed a real Git engine embedded in Grafana's backend, and none of the
 So we built nanogit around the constraints Git Sync actually has:
 
 - **Provider-agnostic** — talks the Git wire protocol over HTTPS, so any compliant provider works without bespoke integrations.
-- **Stateless** — no local `.git`, no per-tenant working tree. Every operation completes over HTTPS, which fits Grafana Cloud's horizontally scaled, multitenant backend.
+- **Stateless — no clones, no `.git`** — a defining goal was to avoid full clones and never persist a `.git` directory or per-tenant working tree. nanogit reads and writes objects directly over HTTPS, so there is no local repository state to store, clean up, or keep consistent across a horizontally scaled, multitenant backend.
 - **Lean and fast** — parses only what Git Sync needs. Streaming packfiles, path filtering, shallow reads, and delta handling keep it fast and memory-efficient on Grafana-scale repositories, where an operation usually touches a subpath rather than the whole repo.
 - **Operational control** — speaking the Git protocol directly lets Grafana control exactly how it talks to each provider: how many requests it makes and how large each response is (to stay within provider rate limits and byte budgets), what objects get cached and reused across operations, and how many round trips a sync costs. Hosted provider APIs and general-purpose clients don't expose that level of control.
 - **Safe and controllable** — a focused, embeddable library with a minimal surface area is easier to secure and operate than a general-purpose tool, and it needs only token auth (no SSH key management).

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,30 @@
 
 nanogit is a lightweight, cloud-native Git implementation designed for applications that need efficient Git operations over HTTPS without the complexity and resource overhead of traditional Git implementations.
 
+## Why we built nanogit in the first place
+
+nanogit was created by Grafana to power [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) — the [Observability as Code](https://grafana.com/docs/grafana/latest/as-code/) feature that lets you store Grafana dashboards and folders as files in your own Git repository and manage them as code: auditable, reviewable, and reproducible, editing in the UI and opening pull requests without leaving Grafana.
+
+Git Sync needed a real Git engine embedded in Grafana's backend, and none of the obvious options fit:
+
+- **A GitHub API wasn't enough.** The goal grew from "sync with GitHub" to "sync with any Git provider." That means speaking the standard Git Smart HTTP protocol directly, so GitLab, Bitbucket, and self-hosted servers work without provider-specific code.
+- **The `git` CLI and libgit2** assume a local `.git` working directory. Maintaining a checkout per tenant, and shelling out to a binary, is impractical and hard to reason about operationally in a shared, multitenant backend.
+- **[go-git](https://github.com/go-git/go-git)** is mature, but its abstraction and overhead were too heavy for this use case. It is built around local-disk operations and full clones — stateful and memory-heavy once multiplied across thousands of tenants and large repositories.
+
+So we built nanogit around the constraints Git Sync actually has:
+
+- **Provider-agnostic** — talks the Git wire protocol over HTTPS, so any compliant provider works without bespoke integrations.
+- **Stateless** — no local `.git`, no per-tenant working tree. Every operation completes over HTTPS, which fits Grafana Cloud's horizontally scaled, multitenant backend.
+- **Lean and fast** — parses only what Git Sync needs. Streaming packfiles, path filtering, shallow reads, and delta handling keep it fast and memory-efficient on Grafana-scale repositories, where an operation usually touches a subpath rather than the whole repo.
+- **Safe and controllable** — a focused, embeddable library with a minimal surface area is easier to secure and operate than a general-purpose tool, and it needs only token auth (no SSH key management).
+
+nanogit is open source and usable on its own, but its design — and the performance numbers below — come directly from this workload: doing the Git plumbing behind Git Sync efficiently, safely, and for many tenants at scale.
+
+## Used by
+
+- **[grafana/grafana](https://github.com/grafana/grafana)** — nanogit is the Git engine behind [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) provisioning (`apps/provisioning/pkg/repository/git`). It resolves refs, reads and writes dashboards and folders, stages commits, and pushes to each tenant's repository over HTTPS.
+- **[grafana/grafana-bench](https://github.com/grafana/grafana-bench)** — nanogit is the **default Git driver** for fetching the test-suite repository before a benchmark run. grafana-bench pulls its k6/Playwright suites from Git; nanogit's lightweight, HTTP-only client with parallel object fetching and sparse/subpath checkout pulls large monorepos faster and with less overhead than the alternative go-git driver, keeping benchmark setup fast and repeatable. (go-git stays available via `--git-driver gogit` when SSH or full Git features are needed.)
+
 ## Features
 
 - **HTTPS-only Git operations** - Works with any Git service supporting Smart HTTP Protocol v2 (GitHub, GitLab, Bitbucket, etc.), eliminating the need for SSH key management in cloud environments

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ So we built nanogit around the constraints Git Sync actually has:
 - **Provider-agnostic** — talks the Git wire protocol over HTTPS, so any compliant provider works without bespoke integrations.
 - **Stateless** — no local `.git`, no per-tenant working tree. Every operation completes over HTTPS, which fits Grafana Cloud's horizontally scaled, multitenant backend.
 - **Lean and fast** — parses only what Git Sync needs. Streaming packfiles, path filtering, shallow reads, and delta handling keep it fast and memory-efficient on Grafana-scale repositories, where an operation usually touches a subpath rather than the whole repo.
+- **Operational control** — speaking the Git protocol directly lets Grafana control exactly how it talks to each provider: how many requests it makes and how large each response is (to stay within provider rate limits and byte budgets), what objects get cached and reused across operations, and how many round trips a sync costs. Hosted provider APIs and general-purpose clients don't expose that level of control.
 - **Safe and controllable** — a focused, embeddable library with a minimal surface area is easier to secure and operate than a general-purpose tool, and it needs only token auth (no SSH key management).
 
 nanogit is open source and usable on its own, but its design — and the performance numbers below — come directly from this workload: doing the Git plumbing behind Git Sync efficiently, safely, and for many tenants at scale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ So we built nanogit around the constraints Git Sync actually has:
 
 nanogit is open source and usable on its own, but its design — and the performance numbers below — come directly from this workload: doing the Git plumbing behind Git Sync efficiently, safely, and for many tenants at scale.
 
-## Used by
+## Known usage
 
 - **[grafana/grafana](https://github.com/grafana/grafana)** — nanogit is the Git engine behind [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) provisioning (`apps/provisioning/pkg/repository/git`). It resolves refs, reads and writes dashboards and folders, stages commits, and pushes to each tenant's repository over HTTPS.
 - **[grafana/grafana-bench](https://github.com/grafana/grafana-bench)** — nanogit is the **default Git driver** for fetching the test-suite repository before a benchmark run. grafana-bench pulls its k6/Playwright suites from Git; nanogit's lightweight, HTTP-only client with parallel object fetching and sparse/subpath checkout pulls large monorepos faster and with less overhead than the alternative go-git driver, keeping benchmark setup fast and repeatable. (go-git stays available via `--git-driver gogit` when SSH or full Git features are needed.)


### PR DESCRIPTION
## Summary

nanogit's README and docs describe *what* it is and *how* it differs from go-git, but never *why it exists in the first place*. This PR adds that origin story — nanogit was built by Grafana to power **Git Sync** — and documents its current consumers.

Follows the README↔docs pattern established in #372 (mirror the same rationale in both places).

## Changes

- **New `## Why we built nanogit in the first place` section** (in `README.md` and `docs/index.md`, right after the Overview):
  - Ties nanogit to [Git Sync](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/git-sync/) / Observability as Code.
  - Explains why the obvious options didn't fit a provider-agnostic, stateless, multitenant, performance-sensitive backend: GitHub APIs weren't enough (need any provider via the Git wire protocol), `git` CLI/libgit2 assume a local working tree, and go-git is too heavy/stateful at multitenant scale.
- **New `## Used by` section** documenting current consumers:
  - **grafana/grafana** — Git engine behind Git Sync provisioning (`apps/provisioning/pkg/repository/git`).
  - **grafana/grafana-bench** — the **default git driver** (`pkg/git/nanogit/`) for fetching test-suite repos before a benchmark run; lightweight HTTP-only client with parallel fetching + sparse checkout keeps benchmark setup fast (go-git available via `--git-driver gogit`).

## Testing

- Docs-only change (Markdown); no Go code touched, so the Go test/lint suite is not applicable.
- Facts verified against source: grafana/grafana `apps/provisioning/pkg/repository/git/*` imports nanogit; grafana-bench `docs/architecture.md` describes the Nanogit Driver as the default (*"lightweight HTTP-only client, parallel object fetching, efficient for monorepos, default driver (faster)"*).
- Internal Notion source links from the drafting notes were intentionally **excluded** from public docs; public-facing links point to Grafana docs and the consumer repos.

## Checklist

- [x] Documentation updated (this is the change)
- [ ] No breaking changes
- [ ] VitePress build verified in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)