### PR TITLE
chore: revert verified-commit signing in provider tests & S/MIME github skip

### DIFF
--- a/tests/providers_integration_test.go
+++ b/tests/providers_integration_test.go
@@ -31,22 +31,6 @@ var negotiationModes = []struct {
 	{name: "with capability negotiation", extraOpts: []options.Option{options.WithCapabilityNegotiation()}},
 }
 
-// signerForProvider returns the writer options and the committer email to use
-// for provider write flows. When TEST_GPG_KEY and TEST_SIGN_EMAIL are set (the
-// provider CI jobs), every commit is GPG-signed and the committer/author email
-// is set to the signing key's email, so providers that require signed commits
-// accept and verify the push. When unset (local runs), it returns no option and
-// an empty email, leaving commits unsigned with their default identity.
-func signerForProvider(t *testing.T) (opts []nanogit.WriterOption, email string) {
-	t.Helper()
-	gpgKey := os.Getenv("TEST_GPG_KEY")
-	email = os.Getenv("TEST_SIGN_EMAIL")
-	if gpgKey == "" || email == "" {
-		return nil, ""
-	}
-	return []nanogit.WriterOption{nanogit.WithGPGSigner([]byte(gpgKey))}, email
-}
-
 func TestProviders(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping testproviders suite in short mode")
@@ -119,8 +103,7 @@ func runProvidersBaseFlow(t *testing.T, extraOpts ...options.Option) {
 	branchRef, err := client.GetRef(ctx, "refs/heads/"+branchName)
 	require.NoError(t, err)
 
-	signOpts, signEmail := signerForProvider(t)
-	writer, err := client.NewStagedWriter(ctx, branchRef, signOpts...)
+	writer, err := client.NewStagedWriter(ctx, branchRef)
 	require.NoError(t, err)
 
 	author := nanogit.Author{
@@ -132,10 +115,6 @@ func runProvidersBaseFlow(t *testing.T, extraOpts ...options.Option) {
 		Name:  "John Doe",
 		Email: "john.doe@example.com",
 		Time:  time.Now(),
-	}
-	if signEmail != "" {
-		author.Email = signEmail
-		committer.Email = signEmail
 	}
 
 	exists, err = writer.BlobExists(ctx, "a/b/c/test.txt")
@@ -542,8 +521,7 @@ func runProvidersLargeBlobFlow(t *testing.T, extraOpts ...options.Option) {
 	branchRef, err := client.GetRef(ctx, "refs/heads/"+branchName)
 	require.NoError(t, err)
 
-	signOpts, signEmail := signerForProvider(t)
-	writer, err := client.NewStagedWriter(ctx, branchRef, signOpts...)
+	writer, err := client.NewStagedWriter(ctx, branchRef)
 	require.NoError(t, err)
 
 	author := nanogit.Author{
@@ -555,10 +533,6 @@ func runProvidersLargeBlobFlow(t *testing.T, extraOpts ...options.Option) {
 		Name:  "Test User",
 		Email: "test@example.com",
 		Time:  time.Now(),
-	}
-	if signEmail != "" {
-		author.Email = signEmail
-		committer.Email = signEmail
 	}
 
 	t.Log("Creating large blob (3.7MB dashboard)...")
@@ -653,8 +627,7 @@ func runProvidersCloneFlow(t *testing.T, extraOpts ...options.Option) {
 	branchRef, err := client.GetRef(ctx, "refs/heads/"+branchName)
 	require.NoError(t, err)
 
-	signOpts, signEmail := signerForProvider(t)
-	writer, err := client.NewStagedWriter(ctx, branchRef, signOpts...)
+	writer, err := client.NewStagedWriter(ctx, branchRef)
 	require.NoError(t, err)
 
 	author := nanogit.Author{
@@ -666,10 +639,6 @@ func runProvidersCloneFlow(t *testing.T, extraOpts ...options.Option) {
 		Name:  "Clone Test User",
 		Email: "clone-test@example.com",
 		Time:  time.Now(),
-	}
-	if signEmail != "" {
-		author.Email = signEmail
-		committer.Email = signEmail
 	}
 
 	// Create a diverse set of files for comprehensive clone testing
@@ -975,16 +944,11 @@ func TestProvidersWithoutSideBand(t *testing.T) {
 	branchRef, err := client.GetRef(ctx, fullBranch)
 	require.NoError(t, err)
 
-	signOpts, signEmail := signerForProvider(t)
-	writer, err := client.NewStagedWriter(ctx, branchRef, signOpts...)
+	writer, err := client.NewStagedWriter(ctx, branchRef)
 	require.NoError(t, err)
 
 	author := nanogit.Author{Name: "John Doe", Email: "john.doe@example.com", Time: time.Now()}
 	committer := nanogit.Committer{Name: "John Doe", Email: "john.doe@example.com", Time: time.Now()}
-	if signEmail != "" {
-		author.Email = signEmail
-		committer.Email = signEmail
-	}
 
 	blobPath := "no-sideband-test.txt"
 	blobContent := []byte("content pushed without side-band-64k")

--- a/tests/sign_providers_verify_test.go
+++ b/tests/sign_providers_verify_test.go
@@ -131,18 +131,6 @@ func TestSignProvidersVerify(t *testing.T) {
 		if len(s.SMIMEKey) == 0 || len(s.SMIMECert) == 0 {
 			t.Skip("TEST_SMIME_KEY/TEST_SMIME_CERT not set")
 		}
-
-		// TODO: re-enable S/MIME provider verification for github. A self-signed S/MIME test
-		// cert cannot chain to a CA in GitHub's trust store, so GitHub never marks
-		// it "verified"; the nanogit-test ruleset requires verified signatures and
-		// rejects the push (GH013). Proper fix: push the S/MIME commit to a branch
-		// exempt from that ruleset and assert only the X.509 type, or provision a
-		// CA-issued cert. Local structural coverage remains in TestSMIMESignerVerify
-		// (gpgsm reports GOODSIG).
-		if s.Provider == "github" {
-			t.Skip("S/MIME provider verification disabled for github pending proper fix (see TODO above)")
-		}
-
 		sha := s.push(t, nanogit.WithSMIMESigner(s.SMIMEKey, s.SMIMECert))
 		if s.getVerification == nil {
 			return


### PR DESCRIPTION
Reverts commit 19ae77b (#357), which introduced two interim test changes:

1. **Verified-commit signing in provider integration tests** (`tests/providers_integration_test.go`) — added `signerForProvider`, GPG-signing every provider write flow and overriding the committer/author email to the signing key when `TEST_GPG_KEY`/`TEST_SIGN_EMAIL` are set, so providers requiring verified commits would accept the push.
2. **S/MIME provider verification skip on GitHub** (`tests/sign_providers_verify_test.go`) — skipped the S/MIME provider verify case for github because a self-signed test cert can't chain to a CA in GitHub's trust store.

Both interim workarounds are no longer needed: an exception has been added on the `nanogit-test` repository so its ruleset no longer requires verified commits. With that in place, the provider write flows don't need to GPG-sign / override the committer email, and the S/MIME github verification case can run without being rejected (GH013). This PR reverts both changes, restoring the tests to their pre-#357 state.

- `go vet ./tests/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)