### PR TITLE
feat: add MergeBase and multi-parent commit support

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,6 +94,7 @@ type Client interface {
 	GetCommit(ctx context.Context, hash hash.Hash) (*Commit, error)
 	CompareCommits(ctx context.Context, baseCommit, headCommit hash.Hash, opts ...CompareCommitsOption) ([]CommitFile, error)
 	ListCommits(ctx context.Context, startCommit hash.Hash, options ListCommitsOptions) ([]Commit, error)
+	MergeBase(ctx context.Context, commitA, commitB hash.Hash, opts ...MergeBaseOption) (hash.Hash, error)
 	// Clone operations
 	Clone(ctx context.Context, opts CloneOptions) (*CloneResult, error)
 	// Write operations

--- a/commit.go
+++ b/commit.go
@@ -48,9 +48,13 @@ type Commit struct {
 	// Tree is the hash of the root tree object that represents the state
 	// of the repository at the time of the commit
 	Tree hash.Hash
-	// Parent is the hash of the parent commit
-	// TODO: Merge commits can have multiple parents, but currently only single parent is supported
+	// Parent is the hash of the first parent commit.
+	// For merge commits this is the first parent; use Parents for the full list.
 	Parent hash.Hash
+	// Parents holds the hashes of all parent commits in order. A root commit has
+	// no parents, a regular commit has one, and a merge commit has two or more.
+	// Parent mirrors Parents[0] when Parents is non-empty.
+	Parents []hash.Hash
 	// Author is the person who created the changes in the commit
 	Author Author
 	// Committer is the person who created the commit object
@@ -228,9 +232,9 @@ func (c *httpClient) CompareCommits(ctx context.Context, baseCommit, headCommit 
 // Additional optimizations considered:
 // - Could use byte enum for common modes (0o100644, 0o100755, 0o040000) + overflow field
 type entryInfo struct {
-	hash     hash.Hash
-	mode     uint16              // uint16 is sufficient for Git file modes (max 0o160000)
-	objType  protocol.ObjectType // Git object type (blob, tree, etc.)
+	hash    hash.Hash
+	mode    uint16              // uint16 is sufficient for Git file modes (max 0o160000)
+	objType protocol.ObjectType // Git object type (blob, tree, etc.)
 }
 
 // compareTrees recursively compares two trees and collects changes between them.
@@ -519,9 +523,10 @@ func packfileObjectToCommit(commit *protocol.PackfileObject) (*Commit, error) {
 	}
 
 	return &Commit{
-		Hash:   commit.Hash,
-		Tree:   commit.Commit.Tree,
-		Parent: commit.Commit.Parent,
+		Hash:    commit.Hash,
+		Tree:    commit.Commit.Tree,
+		Parent:  commit.Commit.Parent,
+		Parents: commit.Commit.Parents,
 		Author: Author{
 			Name:  commit.Commit.Author.Name,
 			Email: commit.Commit.Author.Email,

--- a/errors.go
+++ b/errors.go
@@ -44,6 +44,16 @@ var (
 	// This error should only be used with errors.Is() for comparison, not for type assertions.
 	ErrEmptyPath = errors.New("empty path")
 
+	// ErrNoMergeBase is returned when two commits share no common ancestor
+	// (for example, histories from unrelated roots).
+	// This error should only be used with errors.Is() for comparison, not for type assertions.
+	ErrNoMergeBase = errors.New("no merge base found")
+
+	// ErrMergeBaseLimitExceeded is returned when MergeBase walks more commits
+	// than its configured budget without finding a common ancestor.
+	// This error should only be used with errors.Is() for comparison, not for type assertions.
+	ErrMergeBaseLimitExceeded = errors.New("merge base search limit exceeded")
+
 	// ErrEmptyRefName is returned when a ref name is empty.
 	// This error should only be used with errors.Is() for comparison, not for type assertions.
 	ErrEmptyRefName = errors.New("empty ref name")

--- a/merge_base.go
+++ b/merge_base.go
@@ -1,0 +1,325 @@
+package nanogit
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/nanogit/log"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/client"
+	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/grafana/nanogit/storage"
+)
+
+// Reachability flags used while painting the commit graph during MergeBase.
+const (
+	flagReachableFromA uint8 = 1 << iota // commit is an ancestor of (or equal to) commitA
+	flagReachableFromB                   // commit is an ancestor of (or equal to) commitB
+	flagStale                            // commit is a common ancestor (or ancestor of one); no longer interesting
+	flagResult                           // commit has been recorded as a merge-base candidate
+)
+
+const (
+	// defaultMergeBaseMaxCommits bounds how many distinct commits MergeBase will
+	// examine before giving up. It prevents an unbounded walk (and unbounded
+	// network fetches) on pathological or unrelated histories.
+	defaultMergeBaseMaxCommits = 2000
+
+	// mergeBaseFetchDepth is how deep each commit fetch reaches so ancestors are
+	// warmed into storage in batches, reducing round-trips during the walk.
+	mergeBaseFetchDepth = 100
+)
+
+// MergeBaseOptions configures the behavior of MergeBase.
+type MergeBaseOptions struct {
+	// MaxCommits bounds the number of distinct commits examined during the walk.
+	// When the walk exceeds this budget without finding a common ancestor,
+	// MergeBase returns ErrMergeBaseLimitExceeded. If <= 0, a default is used.
+	MaxCommits int
+}
+
+// MergeBaseOption configures MergeBase behavior.
+type MergeBaseOption func(*MergeBaseOptions)
+
+// WithMergeBaseMaxCommits overrides the maximum number of commits MergeBase will
+// examine before returning ErrMergeBaseLimitExceeded.
+func WithMergeBaseMaxCommits(max int) MergeBaseOption {
+	return func(opts *MergeBaseOptions) {
+		opts.MaxCommits = max
+	}
+}
+
+func defaultMergeBaseOptions() *MergeBaseOptions {
+	return &MergeBaseOptions{MaxCommits: defaultMergeBaseMaxCommits}
+}
+
+// MergeBase finds the best common ancestor (merge base) of two commits, i.e. the
+// commit where their histories diverged. This is the commit Git uses as the base
+// for a three-dot diff (a...b): comparing the merge base against a ref yields only
+// the changes that ref actually introduced, excluding commits that landed on the
+// other branch after the fork point.
+//
+// The graph is walked from both commits following all parents (merge commits
+// included), ordered by committer time so the walk terminates as soon as a common
+// ancestor is reached rather than descending to the repository root.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - commitA: Hash of the first commit
+//   - commitB: Hash of the second commit
+//   - opts: Optional configuration (e.g. WithMergeBaseMaxCommits)
+//
+// Returns:
+//   - hash.Hash: Hash of the merge base commit
+//   - error: ErrNoMergeBase if the commits share no common ancestor,
+//     ErrMergeBaseLimitExceeded if the walk exceeds its commit budget, or a
+//     fetch/parse error if a commit cannot be retrieved.
+//
+// Limitation: in the presence of criss-cross merges a pair of commits can have
+// more than one merge base. MergeBase returns a single one (the most recent by
+// committer time), which is sufficient for computing a three-dot file diff.
+//
+// Example:
+//
+//	base, err := client.MergeBase(ctx, mainTip, prBranchTip)
+//	if err != nil {
+//	    return err
+//	}
+//	changes, err := client.CompareCommits(ctx, base, prBranchTip) // three-dot diff
+func (c *httpClient) MergeBase(ctx context.Context, commitA, commitB hash.Hash, opts ...MergeBaseOption) (hash.Hash, error) {
+	options := defaultMergeBaseOptions()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(options)
+	}
+	if options.MaxCommits <= 0 {
+		options.MaxCommits = defaultMergeBaseMaxCommits
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Debug("Merge base",
+		"commit_a", commitA.String(),
+		"commit_b", commitB.String(),
+		"max_commits", options.MaxCommits)
+
+	// A commit is its own merge base with itself.
+	if commitA.Is(commitB) {
+		return commitA, nil
+	}
+
+	ctx, store := storage.FromContextOrInMemory(ctx)
+	walk := &mergeBaseWalk{
+		client: c,
+		store:  store,
+		flags:  make(map[string]uint8),
+		pq:     &commitHeap{},
+		max:    options.MaxCommits,
+	}
+	heap.Init(walk.pq)
+
+	if err := walk.seed(ctx, commitA, flagReachableFromA); err != nil {
+		return hash.Zero, err
+	}
+	if err := walk.seed(ctx, commitB, flagReachableFromB); err != nil {
+		return hash.Zero, err
+	}
+
+	results, err := walk.run(ctx)
+	if err != nil {
+		return hash.Zero, err
+	}
+	if len(results) == 0 {
+		return hash.Zero, ErrNoMergeBase
+	}
+
+	best := results[0]
+	for _, candidate := range results[1:] {
+		if mergeBaseMoreRecent(candidate, best) {
+			best = candidate
+		}
+	}
+
+	logger.Debug("Merge base found",
+		"commit_a", commitA.String(),
+		"commit_b", commitB.String(),
+		"merge_base", best.Hash.String(),
+		"candidates", len(results),
+		"examined", walk.distinct)
+	return best.Hash, nil
+}
+
+// mergeBaseWalk holds the mutable state of a single merge-base graph walk.
+type mergeBaseWalk struct {
+	client   *httpClient
+	store    storage.PackfileStorage
+	flags    map[string]uint8 // reachability flags keyed by commit hash
+	pq       *commitHeap      // frontier ordered by committer time (newest first)
+	distinct int              // number of distinct commits introduced into the walk
+	max      int              // upper bound on distinct commits before giving up
+}
+
+// mark records bits on a commit, counting it the first time it is seen.
+func (w *mergeBaseWalk) mark(h hash.Hash, bits uint8) {
+	key := h.String()
+	if _, seen := w.flags[key]; !seen {
+		w.distinct++
+	}
+	w.flags[key] |= bits
+}
+
+// seed fetches a starting commit, flags it, and pushes it onto the frontier.
+func (w *mergeBaseWalk) seed(ctx context.Context, h hash.Hash, bits uint8) error {
+	commit, err := w.client.fetchCommitForMergeBase(ctx, h, w.store)
+	if err != nil {
+		return err
+	}
+	w.mark(h, bits)
+	heap.Push(w.pq, commit)
+	return nil
+}
+
+// run paints the graph from the seeded frontier until every queued commit is
+// stale, returning the common-ancestor candidates discovered along the way.
+func (w *mergeBaseWalk) run(ctx context.Context) ([]*Commit, error) {
+	var results []*Commit
+	for w.pq.Len() > 0 {
+		// Once every queued commit is stale, all remaining work is below merge
+		// bases we have already found; stop.
+		if w.pq.allStale(w.flags) {
+			break
+		}
+
+		current := heap.Pop(w.pq).(*Commit)
+		key := current.Hash.String()
+		fl := w.flags[key] & (flagReachableFromA | flagReachableFromB)
+
+		if fl == (flagReachableFromA | flagReachableFromB) {
+			// Reachable from both inputs: a common ancestor. Record it once and
+			// propagate as stale so its ancestors are pruned from the search.
+			if w.flags[key]&flagResult == 0 {
+				w.flags[key] |= flagResult
+				results = append(results, current)
+			}
+			fl |= flagStale
+		}
+
+		if err := w.expand(ctx, current, fl); err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+// expand propagates flags fl to the parents of current, fetching and queueing
+// any parent that gains new reachability information.
+func (w *mergeBaseWalk) expand(ctx context.Context, current *Commit, fl uint8) error {
+	for _, parent := range current.Parents {
+		key := parent.String()
+		// Skip parents that already carry all of these flags: no new
+		// reachability information would be propagated.
+		if w.flags[key]&fl == fl {
+			continue
+		}
+		if _, seen := w.flags[key]; !seen && w.distinct >= w.max {
+			return ErrMergeBaseLimitExceeded
+		}
+		w.mark(parent, fl)
+		parentCommit, err := w.client.fetchCommitForMergeBase(ctx, parent, w.store)
+		if err != nil {
+			return err
+		}
+		heap.Push(w.pq, parentCommit)
+	}
+	return nil
+}
+
+// mergeBaseMoreRecent reports whether candidate should be preferred over best as
+// the returned merge base: later committer time wins, with the larger hash as a
+// deterministic tie-breaker.
+func mergeBaseMoreRecent(candidate, best *Commit) bool {
+	ct, bt := candidate.Committer.Time, best.Committer.Time
+	if ct.Equal(bt) {
+		return candidate.Hash.String() > best.Hash.String()
+	}
+	return ct.After(bt)
+}
+
+// fetchCommitForMergeBase returns a commit, reading it from storage when present
+// and otherwise fetching it (warming a batch of ancestors into storage to reduce
+// round-trips). It mirrors the fetch strategy used by ListCommits.
+func (c *httpClient) fetchCommitForMergeBase(ctx context.Context, commitHash hash.Hash, store storage.PackfileStorage) (*Commit, error) {
+	if obj, ok := store.GetByType(commitHash, protocol.ObjectTypeCommit); ok {
+		return packfileObjectToCommit(obj)
+	}
+
+	objects, err := c.Fetch(ctx, client.FetchOptions{
+		NoProgress:       true,
+		NoBlobFilter:     true,
+		Want:             []hash.Hash{commitHash},
+		Deepen:           mergeBaseFetchDepth,
+		Done:             true,
+		NoExtraObjects:   false, // we want ancestor commits to warm the walk
+		MaxResponseBytes: c.limits.MultiObjectFetchMaxBytes,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "not our ref") {
+			return nil, NewObjectNotFoundError(commitHash)
+		}
+		return nil, fmt.Errorf("fetch commit %s: %w", commitHash.String(), err)
+	}
+
+	obj, ok := objects[commitHash.String()]
+	if !ok || obj.Type != protocol.ObjectTypeCommit {
+		obj, ok = store.GetByType(commitHash, protocol.ObjectTypeCommit)
+		if !ok {
+			return nil, NewObjectNotFoundError(commitHash)
+		}
+	}
+
+	return packfileObjectToCommit(obj)
+}
+
+// commitHeap is a max-heap of commits ordered by committer time so that the most
+// recent commit is popped first during the merge-base walk.
+type commitHeap []*Commit
+
+func (h commitHeap) Len() int { return len(h) }
+
+func (h commitHeap) Less(i, j int) bool {
+	// Pop the newest commit first. Break ties by hash for deterministic ordering.
+	ti, tj := h[i].Committer.Time, h[j].Committer.Time
+	if ti.Equal(tj) {
+		return h[i].Hash.String() > h[j].Hash.String()
+	}
+	return ti.After(tj)
+}
+
+func (h commitHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *commitHeap) Push(x any) {
+	*h = append(*h, x.(*Commit))
+}
+
+func (h *commitHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	return item
+}
+
+// allStale reports whether every commit currently queued is stale, meaning all
+// remaining work lies below merge bases already discovered.
+func (h commitHeap) allStale(flags map[string]uint8) bool {
+	for _, commit := range h {
+		if flags[commit.Hash.String()]&flagStale == 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/merge_base_test.go
+++ b/merge_base_test.go
@@ -1,0 +1,85 @@
+package nanogit
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+
+	"github.com/grafana/nanogit/protocol/hash"
+	"github.com/stretchr/testify/require"
+)
+
+func commitAt(hexByte byte, unix int64) *Commit {
+	var h hash.Hash
+	for i := range h {
+		h[i] = hexByte
+	}
+	return &Commit{
+		Hash:      h,
+		Committer: Committer{Time: time.Unix(unix, 0)},
+	}
+}
+
+func TestCommitHeap_PopsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	older := commitAt(0x01, 1000)
+	newest := commitAt(0x02, 3000)
+	middle := commitAt(0x03, 2000)
+
+	h := &commitHeap{}
+	heap.Init(h)
+	heap.Push(h, older)
+	heap.Push(h, newest)
+	heap.Push(h, middle)
+
+	require.Equal(t, newest.Hash, heap.Pop(h).(*Commit).Hash)
+	require.Equal(t, middle.Hash, heap.Pop(h).(*Commit).Hash)
+	require.Equal(t, older.Hash, heap.Pop(h).(*Commit).Hash)
+}
+
+func TestCommitHeap_TieBreaksByHash(t *testing.T) {
+	t.Parallel()
+
+	// Equal timestamps must resolve deterministically (larger hash first) so the
+	// walk is reproducible regardless of insertion order.
+	low := commitAt(0x0a, 1000)
+	high := commitAt(0x0b, 1000)
+
+	h := &commitHeap{}
+	heap.Init(h)
+	heap.Push(h, low)
+	heap.Push(h, high)
+
+	require.Equal(t, high.Hash, heap.Pop(h).(*Commit).Hash)
+	require.Equal(t, low.Hash, heap.Pop(h).(*Commit).Hash)
+}
+
+func TestCommitHeap_AllStale(t *testing.T) {
+	t.Parallel()
+
+	a := commitAt(0x01, 1000)
+	b := commitAt(0x02, 2000)
+	h := commitHeap{a, b}
+
+	flags := map[string]uint8{a.Hash.String(): flagStale}
+	require.False(t, h.allStale(flags), "b is not stale yet")
+
+	flags[b.Hash.String()] = flagStale
+	require.True(t, h.allStale(flags))
+}
+
+func TestMergeBaseMoreRecent(t *testing.T) {
+	t.Parallel()
+
+	older := commitAt(0x01, 1000)
+	newer := commitAt(0x02, 2000)
+	require.True(t, mergeBaseMoreRecent(newer, older))
+	require.False(t, mergeBaseMoreRecent(older, newer))
+
+	// Same time: larger hash wins.
+	low := commitAt(0x0a, 1000)
+	high := commitAt(0x0b, 1000)
+	require.True(t, mergeBaseMoreRecent(high, low))
+	require.False(t, mergeBaseMoreRecent(low, high))
+}

--- a/mocks/client.go
+++ b/mocks/client.go
@@ -246,6 +246,22 @@ type FakeClient struct {
 		result1 []nanogit.Ref
 		result2 error
 	}
+	MergeBaseStub        func(context.Context, hash.Hash, hash.Hash, ...nanogit.MergeBaseOption) (hash.Hash, error)
+	mergeBaseMutex       sync.RWMutex
+	mergeBaseArgsForCall []struct {
+		arg1 context.Context
+		arg2 hash.Hash
+		arg3 hash.Hash
+		arg4 []nanogit.MergeBaseOption
+	}
+	mergeBaseReturns struct {
+		result1 hash.Hash
+		result2 error
+	}
+	mergeBaseReturnsOnCall map[int]struct {
+		result1 hash.Hash
+		result2 error
+	}
 	NewStagedWriterStub        func(context.Context, nanogit.Ref, ...nanogit.WriterOption) (nanogit.StagedWriter, error)
 	newStagedWriterMutex       sync.RWMutex
 	newStagedWriterArgsForCall []struct {
@@ -1385,6 +1401,73 @@ func (fake *FakeClient) ListRefsReturnsOnCall(i int, result1 []nanogit.Ref, resu
 	}
 	fake.listRefsReturnsOnCall[i] = struct {
 		result1 []nanogit.Ref
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) MergeBase(arg1 context.Context, arg2 hash.Hash, arg3 hash.Hash, arg4 ...nanogit.MergeBaseOption) (hash.Hash, error) {
+	fake.mergeBaseMutex.Lock()
+	ret, specificReturn := fake.mergeBaseReturnsOnCall[len(fake.mergeBaseArgsForCall)]
+	fake.mergeBaseArgsForCall = append(fake.mergeBaseArgsForCall, struct {
+		arg1 context.Context
+		arg2 hash.Hash
+		arg3 hash.Hash
+		arg4 []nanogit.MergeBaseOption
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.MergeBaseStub
+	fakeReturns := fake.mergeBaseReturns
+	fake.recordInvocation("MergeBase", []interface{}{arg1, arg2, arg3, arg4})
+	fake.mergeBaseMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) MergeBaseCallCount() int {
+	fake.mergeBaseMutex.RLock()
+	defer fake.mergeBaseMutex.RUnlock()
+	return len(fake.mergeBaseArgsForCall)
+}
+
+func (fake *FakeClient) MergeBaseCalls(stub func(context.Context, hash.Hash, hash.Hash, ...nanogit.MergeBaseOption) (hash.Hash, error)) {
+	fake.mergeBaseMutex.Lock()
+	defer fake.mergeBaseMutex.Unlock()
+	fake.MergeBaseStub = stub
+}
+
+func (fake *FakeClient) MergeBaseArgsForCall(i int) (context.Context, hash.Hash, hash.Hash, []nanogit.MergeBaseOption) {
+	fake.mergeBaseMutex.RLock()
+	defer fake.mergeBaseMutex.RUnlock()
+	argsForCall := fake.mergeBaseArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) MergeBaseReturns(result1 hash.Hash, result2 error) {
+	fake.mergeBaseMutex.Lock()
+	defer fake.mergeBaseMutex.Unlock()
+	fake.MergeBaseStub = nil
+	fake.mergeBaseReturns = struct {
+		result1 hash.Hash
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) MergeBaseReturnsOnCall(i int, result1 hash.Hash, result2 error) {
+	fake.mergeBaseMutex.Lock()
+	defer fake.mergeBaseMutex.Unlock()
+	fake.MergeBaseStub = nil
+	if fake.mergeBaseReturnsOnCall == nil {
+		fake.mergeBaseReturnsOnCall = make(map[int]struct {
+			result1 hash.Hash
+			result2 error
+		})
+	}
+	fake.mergeBaseReturnsOnCall[i] = struct {
+		result1 hash.Hash
 		result2 error
 	}{result1, result2}
 }

--- a/protocol/packfile.go
+++ b/protocol/packfile.go
@@ -357,11 +357,19 @@ func (e *PackfileObject) parseAuthor(data string) error {
 	return nil
 }
 
-// parseParent parses the parent field
+// parseParent parses a parent field. Commits may list multiple parent lines
+// (merge commits), so each parsed parent is appended to Parents while Parent
+// tracks the first one for backward compatibility.
 func (e *PackfileObject) parseParent(data string) error {
-	var err error
-	e.Commit.Parent, err = hash.FromHex(data)
-	return err
+	h, err := hash.FromHex(data)
+	if err != nil {
+		return err
+	}
+	if len(e.Commit.Parents) == 0 {
+		e.Commit.Parent = h
+	}
+	e.Commit.Parents = append(e.Commit.Parents, h)
+	return nil
 }
 
 // parseCustomField stores custom fields in the Fields map
@@ -410,8 +418,14 @@ type PackfileCommit struct {
 	Tree      hash.Hash
 	Author    *Identity
 	Committer *Identity
-	Parent    hash.Hash
-	Message   string
+	// Parent is the first parent of the commit, kept for backward compatibility.
+	// For merge commits it holds the first parent; use Parents for the full list.
+	Parent hash.Hash
+	// Parents holds all parents in the order they appear in the commit object.
+	// A root commit has no parents; a regular commit has one; a merge commit has
+	// two or more. Parent mirrors Parents[0] when Parents is non-empty.
+	Parents []hash.Hash
+	Message string
 	// Signature, when non-empty, is an armored block embedded as the gpgsig header.
 	Signature string
 	// Fields contains any fields beyond the fields that are statically defined.
@@ -434,7 +448,14 @@ func (c *PackfileCommit) BuildUnsigned() []byte {
 func (c *PackfileCommit) build(includeSig bool) []byte {
 	var data bytes.Buffer
 	fmt.Fprintf(&data, "tree %s\n", c.Tree.String())
-	if !c.Parent.Is(hash.Zero) {
+	// Prefer the full Parents list (populated when parsing merge commits) and
+	// fall back to the single Parent field used by writer-created commits, so
+	// commit hashes for objects nanogit builds itself stay byte-for-byte stable.
+	if len(c.Parents) > 0 {
+		for _, p := range c.Parents {
+			fmt.Fprintf(&data, "parent %s\n", p.String())
+		}
+	} else if !c.Parent.Is(hash.Zero) {
 		fmt.Fprintf(&data, "parent %s\n", c.Parent.String())
 	}
 	fmt.Fprintf(&data, "author %s\n", c.Author.String())

--- a/protocol/packfile_test.go
+++ b/protocol/packfile_test.go
@@ -442,10 +442,63 @@ func TestParseCommit_Signature(t *testing.T) {
 	})
 }
 
+func TestParseCommit_Parents(t *testing.T) {
+	t.Parallel()
+
+	ident := &protocol.Identity{Name: "A", Email: "a@b", Timestamp: 1234567890, Timezone: "+0000"}
+	p1 := hash.MustFromHex("1111111111111111111111111111111111111111")
+	p2 := hash.MustFromHex("2222222222222222222222222222222222222222")
+
+	t.Run("single parent populates Parent and Parents", func(t *testing.T) {
+		t.Parallel()
+		c := &protocol.PackfileCommit{Tree: hash.Zero, Parent: p1, Author: ident, Committer: ident, Message: "m\n"}
+		obj := &protocol.PackfileObject{Type: protocol.ObjectTypeCommit, Data: c.Build()}
+		require.NoError(t, obj.Parse())
+		require.Equal(t, p1, obj.Commit.Parent)
+		require.Equal(t, []hash.Hash{p1}, obj.Commit.Parents)
+	})
+
+	t.Run("merge commit keeps every parent", func(t *testing.T) {
+		t.Parallel()
+		// Two parent lines are how Git encodes a merge commit; the parser must
+		// preserve both while keeping Parent pointing at the first.
+		raw := "tree " + hash.Zero.String() + "\n" +
+			"parent " + p1.String() + "\n" +
+			"parent " + p2.String() + "\n" +
+			"author " + ident.String() + "\n" +
+			"committer " + ident.String() + "\n" +
+			"\n" +
+			"merge\n"
+		obj := &protocol.PackfileObject{Type: protocol.ObjectTypeCommit, Data: []byte(raw)}
+		require.NoError(t, obj.Parse())
+		require.Equal(t, p1, obj.Commit.Parent, "Parent mirrors the first parent")
+		require.Equal(t, []hash.Hash{p1, p2}, obj.Commit.Parents)
+	})
+
+	t.Run("root commit has no parents", func(t *testing.T) {
+		t.Parallel()
+		c := &protocol.PackfileCommit{Tree: hash.Zero, Parent: hash.Zero, Author: ident, Committer: ident, Message: "m\n"}
+		obj := &protocol.PackfileObject{Type: protocol.ObjectTypeCommit, Data: c.Build()}
+		require.NoError(t, obj.Parse())
+		require.True(t, obj.Commit.Parent.Is(hash.Zero))
+		require.Empty(t, obj.Commit.Parents)
+	})
+}
+
 func TestPackfileCommit_Build(t *testing.T) {
 	t.Parallel()
 
 	ident := &protocol.Identity{Name: "A", Email: "a@b", Timestamp: 1234567890, Timezone: "+0000"}
+
+	t.Run("emits all parents for merge commits", func(t *testing.T) {
+		t.Parallel()
+		p1 := hash.MustFromHex("1111111111111111111111111111111111111111")
+		p2 := hash.MustFromHex("2222222222222222222222222222222222222222")
+		c := &protocol.PackfileCommit{Tree: hash.Zero, Parents: []hash.Hash{p1, p2}, Author: ident, Committer: ident, Message: "m\n"}
+		got := string(c.Build())
+		require.Contains(t, got, "parent "+p1.String()+"\n")
+		require.Contains(t, got, "parent "+p2.String()+"\n")
+	})
 
 	t.Run("omits parent when zero", func(t *testing.T) {
 		t.Parallel()

--- a/tests/merge_base_integration_test.go
+++ b/tests/merge_base_integration_test.go
@@ -1,0 +1,188 @@
+package integration_test
+
+import (
+	"errors"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/grafana/nanogit/protocol"
+	"github.com/grafana/nanogit/protocol/hash"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MergeBase", func() {
+	var (
+		client nanogit.Client
+		local  *gittest.LocalRepo
+	)
+
+	revParse := func(rev string) hash.Hash {
+		output, err := local.Git("rev-parse", rev)
+		Expect(err).NotTo(HaveOccurred())
+		h, err := hash.FromHex(output)
+		Expect(err).NotTo(HaveOccurred())
+		return h
+	}
+
+	commitFile := func(path, content, message string) hash.Hash {
+		Expect(local.CreateFile(path, content)).To(Succeed())
+		_, err := local.Git("add", ".")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = local.Git("commit", "-m", message)
+		Expect(err).NotTo(HaveOccurred())
+		return revParse("HEAD")
+	}
+
+	BeforeEach(func() {
+		client, _, local, _ = QuickSetup()
+	})
+
+	// This is the support-escalations #23127 scenario: a PR branch forks from
+	// main, then an unrelated commit lands on main. A two-dot diff (main..branch)
+	// wrongly reports the unrelated file; the three-dot diff via the merge base
+	// reports only what the branch actually changed.
+	Context("PR preview scenario", func() {
+		var (
+			forkPoint hash.Hash
+			branchTip hash.Hash
+			mainTip   hash.Hash
+		)
+
+		BeforeEach(func() {
+			By("Recording the fork point on main")
+			forkPoint = revParse("HEAD")
+
+			By("Creating a PR branch that adds dashboard-a.json")
+			_, err := local.Git("checkout", "-b", "feature-a")
+			Expect(err).NotTo(HaveOccurred())
+			branchTip = commitFile("dashboard-a.json", "{\"branch\":\"a\"}", "Add dashboard A")
+			_, err = local.Git("push", "origin", "feature-a")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Landing an unrelated commit on main after the fork point")
+			_, err = local.Git("checkout", "main")
+			Expect(err).NotTo(HaveOccurred())
+			mainTip = commitFile("dashboard-b.json", "{\"main\":\"b\"}", "Add dashboard B")
+			_, err = local.Git("push", "origin", "main")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("resolves the merge base to the fork point", func() {
+			base, err := client.MergeBase(ctx, mainTip, branchTip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(base).To(Equal(forkPoint))
+		})
+
+		It("is order-independent", func() {
+			base1, err := client.MergeBase(ctx, mainTip, branchTip)
+			Expect(err).NotTo(HaveOccurred())
+			base2, err := client.MergeBase(ctx, branchTip, mainTip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(base1).To(Equal(base2))
+			Expect(base1).To(Equal(forkPoint))
+		})
+
+		It("two-dot compare wrongly includes the unrelated main file (the bug)", func() {
+			changes, err := client.CompareCommits(ctx, mainTip, branchTip)
+			Expect(err).NotTo(HaveOccurred())
+
+			paths := changePaths(changes)
+			// dashboard-a.json is added on the branch; dashboard-b.json shows up
+			// as a deletion purely because it exists on main but not the branch.
+			Expect(paths).To(ContainElement("dashboard-a.json"))
+			Expect(paths).To(ContainElement("dashboard-b.json"))
+		})
+
+		It("three-dot compare via merge base returns only the branch's change (the fix)", func() {
+			base, err := client.MergeBase(ctx, mainTip, branchTip)
+			Expect(err).NotTo(HaveOccurred())
+
+			changes, err := client.CompareCommits(ctx, base, branchTip)
+			Expect(err).NotTo(HaveOccurred())
+
+			paths := changePaths(changes)
+			Expect(paths).To(ConsistOf("dashboard-a.json"))
+			Expect(changes[0].Status).To(Equal(protocol.FileStatusAdded))
+		})
+	})
+
+	Context("edge cases", func() {
+		It("returns the commit itself when both inputs are identical", func() {
+			tip := revParse("HEAD")
+			base, err := client.MergeBase(ctx, tip, tip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(base).To(Equal(tip))
+		})
+
+		It("returns the ancestor when one commit is an ancestor of the other", func() {
+			ancestor := revParse("HEAD")
+			descendant := commitFile("later.json", "{}", "Later commit")
+			_, err := local.Git("push", "origin", "main")
+			Expect(err).NotTo(HaveOccurred())
+
+			base, err := client.MergeBase(ctx, ancestor, descendant)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(base).To(Equal(ancestor))
+		})
+
+		It("errors when the commits share no common ancestor", func() {
+			original := revParse("HEAD")
+
+			By("Creating an orphan branch with unrelated history")
+			_, err := local.Git("checkout", "--orphan", "orphan-branch")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = local.Git("rm", "-rf", ".")
+			Expect(err).NotTo(HaveOccurred())
+			orphanTip := commitFile("orphan.json", "{}", "Orphan root")
+			_, err = local.Git("push", "origin", "orphan-branch")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.MergeBase(ctx, original, orphanTip)
+			Expect(errors.Is(err, nanogit.ErrNoMergeBase)).To(BeTrue())
+		})
+	})
+
+	Context("merge commits", func() {
+		It("preserves all parents and finds the merge base across a merge", func() {
+			forkPoint := revParse("HEAD")
+
+			By("Creating and merging a feature branch back into main")
+			_, err := local.Git("checkout", "-b", "feature-merge")
+			Expect(err).NotTo(HaveOccurred())
+			featureTip := commitFile("feature.json", "{}", "Feature work")
+
+			_, err = local.Git("checkout", "main")
+			Expect(err).NotTo(HaveOccurred())
+			mainWork := commitFile("main-work.json", "{}", "Main work")
+
+			_, err = local.Git("merge", "--no-ff", "-m", "Merge feature-merge", "feature-merge")
+			Expect(err).NotTo(HaveOccurred())
+			mergeCommit := revParse("HEAD")
+			_, err = local.Git("push", "origin", "main")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the merge commit exposes both parents")
+			commit, err := client.GetCommit(ctx, mergeCommit)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commit.Parents).To(HaveLen(2))
+			Expect(commit.Parents).To(ContainElements(mainWork, featureTip))
+			Expect(commit.Parent).To(Equal(commit.Parents[0]))
+
+			By("Verifying merge base of the merge commit and the fork point")
+			base, err := client.MergeBase(ctx, mergeCommit, forkPoint)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(base).To(Equal(forkPoint))
+		})
+	})
+})
+
+// changePaths extracts the head-side paths from a list of file changes.
+func changePaths(changes []nanogit.CommitFile) []string {
+	paths := make([]string, 0, len(changes))
+	for _, change := range changes {
+		paths = append(paths, change.Path)
+	}
+	return paths
+}


### PR DESCRIPTION
## Summary

Adds a **merge-base** (common-ancestor) primitive to the `Client` interface, the building block for three-dot diffs (`a...b`). Comparing the merge base against a ref yields only what that ref actually introduced, excluding commits that landed on the other branch after the fork point.

This is **Stage 1** of the fix for the Git Sync PR-preview issue (support-escalations #23127), where the preview listed files the PR author never touched because `CompareCommits` does a two-dot (`main..branch`) snapshot diff with no common-ancestor step. nanogit had no merge-base primitive and only tracked a single commit parent, so the fix has to originate here.

Stage 2 (wiring a three-dot path into `apps/provisioning`'s PR-preview and bumping nanogit) is a separate PR in the Grafana repo, gated on a tagged release of this change.

## Changes

- **`MergeBase(ctx, a, b, ...MergeBaseOption) (hash.Hash, error)`** on the `Client` interface (`merge_base.go`): walks the commit graph from both inputs following **all** parents, ordered by committer time, painting reachability flags and terminating as soon as common ancestors are found rather than descending to the root. Bounded by `WithMergeBaseMaxCommits` (default 2000).
- **Multi-parent commit support** (correctness prerequisite for merge commits):
  - `protocol`: `PackfileCommit` gains `Parents`; the parser appends each `parent` line instead of overwriting, and `Build()` emits all parents. `Parent` still mirrors `Parents[0]`, and writer-created single-parent commits serialize byte-for-byte as before (object hashes unchanged).
  - `nanogit.Commit` gains `Parents`, populated from the parsed object.
- New sentinel errors: `ErrNoMergeBase`, `ErrMergeBaseLimitExceeded`.
- Regenerated `mocks/client.go`.

## Testing

- **Unit**: multi-parent parse/build round-trips (single / merge / root commits); heap ordering, tie-break, `allStale`, and candidate selection.
- **Integration (Gitea via testcontainers)** — reproduces the escalation: two-dot compare wrongly includes the unrelated `main` file while three-dot via the merge base returns only the branch's change; plus order-independence, identical/ancestor inputs, the no-common-ancestor error, and a real merge commit exposing both parents.
- Verified locally: `go build ./...`, unit tests, `make lint` (0 issues), `make lint-staticcheck` (0 issues), `MergeBase` integration specs (8/8), and the full `Commit`-focused integration regression (53/53).

## Notes / limitations

- In the presence of criss-cross merges a pair of commits can have more than one merge base; `MergeBase` returns a single one (most recent by committer time), which is sufficient for computing a three-dot file diff. Documented in the godoc.
- **No breaking changes**: `Parents` is additive; `Parent` behavior is preserved.

## Checklist

- [x] Tests added/updated
- [x] Godoc for new exported APIs
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)