### PR TITLE
fix(writer): reject commits with unchanged trees

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -906,6 +906,10 @@ func (w *stagedWriter) Commit(ctx context.Context, message string, author Author
 		return nil, fmt.Errorf("build pending trees: %w", err)
 	}
 
+	if w.lastTree.Hash.Is(w.lastCommit.Tree) {
+		return nil, ErrNothingToCommit
+	}
+
 	if !w.writer.HasObjects() {
 		return nil, ErrNothingToCommit
 	}

--- a/writer.go
+++ b/writer.go
@@ -907,6 +907,18 @@ func (w *stagedWriter) Commit(ctx context.Context, message string, author Author
 	}
 
 	if w.lastTree.Hash.Is(w.lastCommit.Tree) {
+		// Tree construction may have staged blobs and trees even though the
+		// resulting tree is identical to the parent. Discard those objects so a
+		// follow-up Push reports ErrNothingToPush and later commits start clean.
+		cleanupErr := w.writer.Cleanup()
+		caps, capsErr := w.client.effectiveReceivePackCapabilities(ctx)
+		if capsErr != nil {
+			return nil, fmt.Errorf("resolve receive-pack capabilities after unchanged tree: %w", capsErr)
+		}
+		w.writer = protocol.NewPackfileWriter(crypto.SHA1, w.storageMode, caps...)
+		if cleanupErr != nil {
+			return nil, fmt.Errorf("cleanup packfile after unchanged tree: %w", cleanupErr)
+		}
 		return nil, ErrNothingToCommit
 	}
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -288,6 +288,53 @@ func (m *mockSigner) Sign(data []byte) (string, error) {
 	return m.signature, nil
 }
 
+func TestStagedWriter_Commit_UnchangedTree(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	content := []byte("unchanged")
+
+	blobHash, err := protocol.Object(crypto.SHA1, protocol.ObjectTypeBlob, content)
+	require.NoError(t, err)
+	treeObj, err := protocol.BuildTreeObject(crypto.SHA1, []protocol.PackfileTreeEntry{{
+		FileMode: 0o100644,
+		FileName: "dashboard.json",
+		Hash:     blobHash.String(),
+	}})
+	require.NoError(t, err)
+
+	parentHash := hash.MustFromHex("1234567890123456789012345678901234567890")
+	writer := &stagedWriter{
+		client:     &httpClient{RawClient: &mockRawClient{}},
+		ref:        Ref{Name: "refs/heads/main", Hash: parentHash},
+		writer:     protocol.NewPackfileWriter(crypto.SHA1, protocol.PackfileStorageMemory),
+		objStorage: storage.NewInMemoryStorage(ctx),
+		treeEntries: map[string]*FlatTreeEntry{
+			"dashboard.json": {
+				Path: "dashboard.json",
+				Hash: blobHash,
+				Type: protocol.ObjectTypeBlob,
+				Mode: 0o100644,
+			},
+		},
+		dirtyPaths:  make(map[string]bool),
+		storageMode: protocol.PackfileStorageMemory,
+		lastTree:    &treeObj,
+		lastCommit:  &Commit{Hash: parentHash, Tree: treeObj.Hash, Parent: hash.Zero},
+	}
+
+	updatedHash, err := writer.UpdateBlob(ctx, "dashboard.json", content)
+	require.NoError(t, err)
+	require.Equal(t, blobHash, updatedHash)
+
+	when := time.Unix(1234567890, 0).UTC()
+	commit, err := writer.Commit(ctx, "no-op update",
+		Author{Name: "A", Email: "a@b", Time: when},
+		Committer{Name: "A", Email: "a@b", Time: when})
+	require.ErrorIs(t, err, ErrNothingToCommit)
+	require.Nil(t, commit)
+	require.Equal(t, parentHash, writer.lastCommit.Hash)
+}
+
 func TestStagedWriter_Commit_SignerError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -305,7 +352,7 @@ func TestStagedWriter_Commit_SignerError(t *testing.T) {
 		dirtyPaths:  make(map[string]bool),
 		storageMode: protocol.PackfileStorageMemory,
 		lastTree:    &treeObj,
-		lastCommit:  &Commit{Hash: hash.Zero, Tree: treeObj.Hash, Parent: hash.Zero},
+		lastCommit:  &Commit{Hash: hash.Zero, Tree: hash.Zero, Parent: hash.Zero},
 		signer:      &mockSigner{err: sentinel},
 	}
 
@@ -336,7 +383,7 @@ func TestStagedWriter_Commit_SignerInvoked(t *testing.T) {
 		dirtyPaths:  make(map[string]bool),
 		storageMode: protocol.PackfileStorageMemory,
 		lastTree:    &treeObj,
-		lastCommit:  &Commit{Hash: hash.Zero, Tree: treeObj.Hash, Parent: hash.Zero},
+		lastCommit:  &Commit{Hash: hash.Zero, Tree: hash.Zero, Parent: hash.Zero},
 		signer:      m,
 	}
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -333,6 +333,19 @@ func TestStagedWriter_Commit_UnchangedTree(t *testing.T) {
 	require.ErrorIs(t, err, ErrNothingToCommit)
 	require.Nil(t, commit)
 	require.Equal(t, parentHash, writer.lastCommit.Hash)
+	require.False(t, writer.writer.HasObjects())
+	require.ErrorIs(t, writer.Push(ctx), ErrNothingToPush)
+
+	changedHash, err := writer.UpdateBlob(ctx, "dashboard.json", []byte("changed"))
+	require.NoError(t, err)
+	require.NotEqual(t, blobHash, changedHash)
+
+	commit, err = writer.Commit(ctx, "real update",
+		Author{Name: "A", Email: "a@b", Time: when},
+		Committer{Name: "A", Email: "a@b", Time: when})
+	require.NoError(t, err)
+	require.NotNil(t, commit)
+	require.Equal(t, parentHash, commit.Parent)
 }
 
 func TestStagedWriter_Commit_SignerError(t *testing.T) {


### PR DESCRIPTION
## What

- Return `ErrNothingToCommit` when staged operations rebuild the same root tree as the parent commit.
- Add a regression test for updating an existing blob with identical content.

## Why

`PackfileWriter.HasObjects()` reports whether blob or tree objects were staged, not whether the resulting repository tree changed. Re-staging identical content therefore rebuilt the same root tree but still allowed `Commit()` to create an empty commit, which could then produce a no-op receive-pack request.

Good catch by @jdstrand; the reproduction clearly isolated the distinction between staged packfile objects and an unchanged commit tree.

Fixes #378

## How

After pending trees are built, `Commit()` compares the rebuilt root tree hash with the parent commit's tree hash before creating a commit object. A match returns the existing `ErrNothingToCommit` error. Commits whose final tree differs from the parent continue through the existing path unchanged.

The signer unit-test fixtures now use a distinct parent tree so they continue to represent a real changed-tree commit.

## Remarks

Behavioral effect: callers now receive `ErrNothingToCommit` for semantically unchanged staged updates, including an identical `UpdateBlob`, instead of receiving a new commit. There is no public API change and changed-tree commits are unaffected.

Checks performed:

- `go test -race -parallel 6 --short -count=1` across all packages except `protocol/signing`
- `go test . -run '^TestStagedWriter_Commit_(UnchangedTree|SignerError|SignerInvoked)$' -count=1`
- `make lint`
- `make lint-staticcheck`
- `git diff --check`

`make test-unit` could not complete locally because the host does not have the `gpg` and `gpgsm` executables required by `protocol/signing`; all other packages passed with the race detector. `make test-integration` could not start its Gitea fixture because no local Docker provider is available, so 0 of 321 integration specs ran locally.

## Author Checklist

- [x] Tests added/updated.
- [x] Documentation is not required for this internal behavior correction.
- [x] Changes have been tested locally.
