### PR TITLE
docs: fix non-compiling snippets, CLI docs, Go version claims, and badges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ cd perf && make profile-compare    # Compare current vs baseline performance
 ## Development Notes
 
 ### Dependencies
-- **Go 1.25+** required
+- **Go 1.26+** required
 - Minimal external dependencies, heavy use of standard library
 - Key test frameworks: Ginkgo/Gomega, testify, counterfeiter
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md) to keep our com
 Before you begin contributing, ensure you have the following installed:
 
 * [Docker](https://docs.docker.com/get-docker/) - Required for running integration tests
-* Go 1.25 or later
+* Go 1.26 or later
 * Git
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 <p align="center">
   <a href="https://github.com/grafana/nanogit/releases"><img src="https://img.shields.io/github/v/release/grafana/nanogit" alt="GitHub Release"></a>
   <a href="LICENSE.md"><img src="https://img.shields.io/github/license/grafana/nanogit" alt="License"></a>
+  <a href="https://github.com/grafana/nanogit/actions/workflows/ci.yml"><img src="https://github.com/grafana/nanogit/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://goreportcard.com/report/github.com/grafana/nanogit"><img src="https://goreportcard.com/badge/github.com/grafana/nanogit" alt="Go Report Card"></a>
-  <a href="https://godoc.org/github.com/grafana/nanogit"><img src="https://godoc.org/github.com/grafana/nanogit?status.svg" alt="GoDoc"></a>
+  <a href="https://pkg.go.dev/github.com/grafana/nanogit"><img src="https://pkg.go.dev/badge/github.com/grafana/nanogit.svg" alt="Go Reference"></a>
   <a href="https://codecov.io/gh/grafana/nanogit"><img src="https://codecov.io/gh/grafana/nanogit/branch/main/graph/badge.svg" alt="codecov"></a>
 </p>
 
@@ -85,7 +86,7 @@ Releases follow [semantic versioning](https://semver.org/): the v1 API is stable
 
 ## Try it in 5 minutes
 
-Install the library (requires **Go 1.25+**):
+Install the library (requires **Go 1.26+**):
 
 ```bash
 go get github.com/grafana/nanogit@latest

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -99,6 +99,10 @@ The following flags are available for all commands:
 - `--token` - Authentication token for private repositories
 - `--json` - Output results in JSON format (where applicable)
 - `-v`, `--verbose` - Emit Info-level logs to stderr (see [Verbose mode](#verbose-mode))
+- `--max-bytes-single-object` - Cap (bytes) on responses to single-object fetches: `cat-file`-style reads (GetBlob, GetTree, GetCommit). 0 = no limit
+- `--max-bytes-multi-object` - Cap (bytes) on responses to multi-object fetches: GetFlatTree, ListCommits, CompareCommits, Clone. 0 = no limit
+- `--max-bytes-refs` - Cap (bytes) on ref-listing and protocol-detection responses. 0 = no limit (a 1 MB floor still applies to the protocol-detection path)
+- `--max-bytes-receive-pack` - Cap (bytes) on the server's reply to a receive-pack push. 0 = no limit
 
 These flags can also be set via environment variables:
 - `NANOGIT_USERNAME` - Authentication username
@@ -299,10 +303,13 @@ Clone a repository to a local directory with optional path filtering.
 
 **Usage**:
 ```bash
-nanogit clone <repository> <ref> <destination> [flags]
+nanogit clone [<repository>] [<destination>] [flags]
 ```
 
+Both arguments are optional: `<repository>` falls back to `NANOGIT_REPO`, and `<destination>` defaults to the current directory. The ref to clone is selected with the `--ref` flag (defaults to the remote HEAD).
+
 **Flags**:
+- `--ref` - Git reference to clone: branch, tag, or commit (default: remote HEAD)
 - `--include` - Include paths (glob patterns, can be specified multiple times)
 - `--exclude` - Exclude paths (glob patterns, can be specified multiple times)
 - `--batch-size` - Number of blobs to fetch per request (default: 50)
@@ -343,10 +350,10 @@ nanogit clone https://github.com/grafana/nanogit.git ./my-repo --exclude 'node_m
 Adjust performance settings (defaults are batch-size=50, concurrency=10):
 ```bash
 # Increase for better performance with large repositories
-nanogit clone https://github.com/grafana/nanogit.git main ./my-repo --batch-size 100 --concurrency 20
+nanogit clone https://github.com/grafana/nanogit.git ./my-repo --ref main --batch-size 100 --concurrency 20
 
 # Sequential mode for constrained environments
-nanogit clone https://github.com/grafana/nanogit.git main ./my-repo --batch-size 1 --concurrency 1
+nanogit clone https://github.com/grafana/nanogit.git ./my-repo --ref main --batch-size 1 --concurrency 1
 ```
 
 **Path Filtering**:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Go 1.25 or later** - nanogit requires Go 1.25+ for building and using the library
+- **Go 1.26 or later** - nanogit requires Go 1.26+ for building and using the library
 - **Git** (for development) - Only needed if you're contributing to nanogit
 
 ## Installing nanogit

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -65,14 +65,14 @@ if err != nil {
     panic(err)
 }
 
-// Create a new file
-err = writer.CreateBlob(ctx, "docs/new-feature.md", []byte("# New Feature"))
+// Create a new file (returns the hash of the staged blob)
+_, err = writer.CreateBlob(ctx, "docs/new-feature.md", []byte("# New Feature"))
 if err != nil {
     panic(err)
 }
 
 // Update an existing file
-err = writer.UpdateBlob(ctx, "README.md", []byte("Updated content"))
+_, err = writer.UpdateBlob(ctx, "README.md", []byte("Updated content"))
 if err != nil {
     panic(err)
 }
@@ -107,7 +107,7 @@ fmt.Printf("Committed: %s\n", commit.Hash)
 
 ```go
 // Get the commit to clone
-ref, err := client.GetRef(ctx, "main")
+ref, err := client.GetRef(ctx, "refs/heads/main")
 if err != nil {
     panic(err)
 }
@@ -254,7 +254,7 @@ ctx = retry.ToContext(ctx, retrier)
 
 // All HTTP operations will now use retry logic
 client, err := nanogit.NewHTTPClient(repo)
-ref, err := client.GetRef(ctx, "main")
+ref, err := client.GetRef(ctx, "refs/heads/main")
 ```
 
 ### Custom Retry Configuration
@@ -272,11 +272,12 @@ ctx = retry.ToContext(ctx, retrier)
 
 **What gets retried:**
 - Network timeout errors
-- 5xx server errors (for GET requests)
+- 5xx server errors (for GET and DELETE requests only)
+- 429 Too Many Requests (rate limiting, for all request types)
 - Temporary errors
 
 **What does NOT get retried:**
-- 4xx client errors (bad requests, auth failures)
+- 4xx client errors (bad requests, auth failures) — except 429
 - Context cancellation
 - POST request 5xx errors (request body is consumed and cannot be re-read, so retries are not possible)
 
@@ -292,8 +293,9 @@ nanogit provides generated mocks for easy unit testing:
 import (
     "testing"
 
+    "github.com/grafana/nanogit"
     "github.com/grafana/nanogit/mocks"
-    "github.com/stretchr/testify/mock"
+    "github.com/grafana/nanogit/protocol/hash"
 )
 
 func TestMyService(t *testing.T) {
@@ -301,9 +303,13 @@ func TestMyService(t *testing.T) {
     mockClient := &mocks.FakeClient{}
 
     // Set up expectations
-    mockClient.GetRefReturns(&nanogit.Ref{
+    testHash, err := hash.FromHex("abcdef1234567890abcdef1234567890abcdef12")
+    if err != nil {
+        t.Fatal(err)
+    }
+    mockClient.GetRefReturns(nanogit.Ref{
         Name: "refs/heads/main",
-        Hash: hash.FromString("abc123"),
+        Hash: testHash,
     }, nil)
 
     // Use the mock in your tests
@@ -311,6 +317,8 @@ func TestMyService(t *testing.T) {
     // ... test your service
 }
 ```
+
+See [mocks/example_test.go](https://github.com/grafana/nanogit/blob/main/mocks/example_test.go) for complete working examples, including the `StagedWriter` mock.
 
 ### Integration Testing with gittest
 
@@ -321,7 +329,15 @@ go get github.com/grafana/nanogit/gittest@latest
 ```
 
 ```go
-import "github.com/grafana/nanogit/gittest"
+import (
+    "context"
+    "testing"
+
+    "github.com/grafana/nanogit"
+    "github.com/grafana/nanogit/gittest"
+    "github.com/grafana/nanogit/options"
+    "github.com/stretchr/testify/require"
+)
 
 func TestGitOperations(t *testing.T) {
     ctx := context.Background()
@@ -338,13 +354,17 @@ func TestGitOperations(t *testing.T) {
     repo, err := server.CreateRepo(ctx, "myrepo", user)
     require.NoError(t, err)
 
-    // Create local repository
+    // Create local repository and initialize it with the remote
     local, err := gittest.NewLocalRepo(ctx)
     require.NoError(t, err)
     defer local.Cleanup()
 
-    // Initialize with remote
-    client, err := local.QuickInit(user, repo.AuthURL)
+    connInfo, err := local.InitWithRemote(user, repo)
+    require.NoError(t, err)
+
+    // Create a nanogit client from the connection info
+    client, err := nanogit.NewHTTPClient(connInfo.URL,
+        options.WithBasicAuth(connInfo.Username, connInfo.Password))
     require.NoError(t, err)
 
     // Test your Git operations
@@ -363,7 +383,7 @@ func TestGitOperations(t *testing.T) {
     // Verify with nanogit client
     ref, err := client.GetRef(ctx, "refs/heads/main")
     require.NoError(t, err)
-    require.NotNil(t, ref)
+    require.NotEmpty(t, ref.Hash)
 }
 ```
 

--- a/docs/getting-started/server-compatibility.md
+++ b/docs/getting-started/server-compatibility.md
@@ -141,7 +141,7 @@ Typed helpers (`CapReportStatusV2`, `CapSideBand64k`, `CapQuiet`, `CapObjectForm
 
 ### Programmatic negotiation
 
-Knowing the right subset to advertise requires knowing what the server supports. `options.WithCapabilityNegotiation()` flips that around: nanogit fetches `GET info/refs?service=git-receive-pack` once per client lifetime, parses the v1-style capability advertisement, and intersects it with the desired set on every subsequent ref update. The fetch result is cached behind `sync.Once`, so writer resets after `Push` and `Cleanup` reuse the same negotiated set without extra round-trips.
+Knowing the right subset to advertise requires knowing what the server supports. `options.WithCapabilityNegotiation()` flips that around: nanogit fetches `GET info/refs?service=git-receive-pack` once, parses the v1-style capability advertisement, and intersects it with the desired set on every subsequent ref update. A successful negotiation is cached for the client's lifetime, so writer resets after `Push` and `Cleanup` reuse the same negotiated set without extra round-trips. A failed negotiation is not cached — the next operation retries it, so a transient error on the first call doesn't poison the client.
 
 ```go
 client, err := nanogit.NewHTTPClient(repoURL,

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@
   <a href="https://github.com/grafana/nanogit/releases"><img src="https://img.shields.io/github/v/release/grafana/nanogit" alt="GitHub Release"></a>
   <a href="https://github.com/grafana/nanogit/stargazers"><img src="https://img.shields.io/github/stars/grafana/nanogit?style=social" alt="GitHub Stars"></a>
   <a href="https://github.com/grafana/nanogit/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/grafana/nanogit" alt="License"></a>
+  <a href="https://github.com/grafana/nanogit/actions/workflows/ci.yml"><img src="https://github.com/grafana/nanogit/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://goreportcard.com/report/github.com/grafana/nanogit"><img src="https://goreportcard.com/badge/github.com/grafana/nanogit" alt="Go Report Card"></a>
-  <a href="https://godoc.org/github.com/grafana/nanogit"><img src="https://godoc.org/github.com/grafana/nanogit?status.svg" alt="GoDoc"></a>
+  <a href="https://pkg.go.dev/github.com/grafana/nanogit"><img src="https://pkg.go.dev/badge/github.com/grafana/nanogit.svg" alt="Go Reference"></a>
   <a href="https://codecov.io/gh/grafana/nanogit"><img src="https://codecov.io/gh/grafana/nanogit/branch/main/graph/badge.svg" alt="codecov"></a>
 </p>
 
@@ -82,7 +83,7 @@ Releases follow [semantic versioning](https://semver.org/): the v1 API is stable
 
 ## Getting started
 
-Install the library (requires **Go 1.25+**):
+Install the library (requires **Go 1.26+**):
 
 ```bash
 go get github.com/grafana/nanogit@latest

--- a/gittest/README.md
+++ b/gittest/README.md
@@ -17,7 +17,7 @@ go get github.com/grafana/nanogit/gittest@latest
 
 **Prerequisites:**
 - Docker must be running (required by testcontainers)
-- Go 1.25 or later
+- Go 1.26 or later
 
 ## Quick Start
 


### PR DESCRIPTION
Part of the repo-maturity polish series (audit follow-up to #380). Every claim below was verified by running the code, not just reading it.

## Broken snippets fixed (quick-start)

- **`CreateBlob`/`UpdateBlob`** return `(hash.Hash, error)`; the snippets assigned a single `err` and did not compile.
- **`GetRef(ctx, "main")` does not work** — GetRef resolves via ls-refs prefix matching, so short names return `RefNotFoundError` (reproduced against the live repo; `refs/heads/main` returns the commit). Two snippets fixed.
- **Mocks snippet**: called nonexistent `hash.FromString`, passed `*nanogit.Ref` where the fake takes a value, imported `testify/mock` unused. Rewritten to mirror `mocks/example_test.go`, with a link to it.
- **gittest snippet**: called nonexistent `local.QuickInit`; rewritten to the real `InitWithRemote` + `NewHTTPClient` pattern (matches the Testing Guide, which was already correct).
- **Retry summary** now matches `retry.md`: 5xx retried for **GET and DELETE** only; **429** retried for all request types.

## CLI docs

- `clone` synopsis showed `<ref>` as a positional argument; it's a `--ref` flag and the CLI rejects 3 positionals, so two documented examples failed on copy-paste. Fixed synopsis/examples, added `--ref` to the flags list.
- Documented the four global `--max-bytes-*` response-limit flags that were missing.
- Verified: `clone --help` text matches, and the documented filtered clone runs successfully against the live repo.

## Consistency

- **Go version**: docs said "Go 1.25+" in six places while `go.mod` requires `1.26.x` — a Go 1.25 toolchain cannot build the module (without toolchain auto-switching). Now "Go 1.26 or later" everywhere (README, docs home, installation, CONTRIBUTING, gittest README, CLAUDE.md).
- **server-compatibility.md** claimed capability negotiation is "cached behind `sync.Once`"; the implementation (client.go) uses `negotiateMu sync.RWMutex` and deliberately does **not** cache failures. Wording fixed to describe the actual retry-after-failure semantics. (The matching stale comments in `writer.go` are queued for the godoc PR.)

## Badges (README + docs home)

- godoc.org was retired in 2021 — replaced with the pkg.go.dev badge.
- Added a CI status badge.

## Verification

- All touched snippets extracted into a scratch module → `go vet` + `go test` pass
- `go run ./cli/cmd/nanogit clone https://github.com/grafana/nanogit.git /tmp/x --ref main --include 'docs/**'` → succeeds
- `./scripts/prepare-docs.sh && npm run docs:build` → passes (dead-link check included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)