### PR TITLE
docs: make benchmark claims consistent with the canonical report

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,16 @@ See [Why Git Protocol v2 Only?](https://grafana.github.io/nanogit/architecture/p
 | Use case       | Cloud services, multitenant backends                    | General purpose        |
 | Resource usage | Minimal footprint                                       | Full Git features      |
 
-Because it never materializes a full repository, nanogit is dramatically faster and lighter for typical server-side operations. From the [benchmark suite](perf/) comparing both libraries across repository sizes:
+Because it never materializes a full repository, nanogit is dramatically faster and lighter for typical server-side operations. From the July 2025 run of the [benchmark suite](perf/), on the XL repository tier (15,000 files, 3,000 commits), nanogit vs go-git:
 
-| Scenario                                  | Speed       | Memory usage |
-| ----------------------------------------- | ----------- | ------------ |
-| CreateFile (XL repo)                      | 306x faster | 186x less    |
-| UpdateFile (XL repo)                      | 291x faster | 178x less    |
-| DeleteFile (XL repo)                      | 302x faster | 175x less    |
-| BulkCreateFiles (1000 files, medium repo) | 607x faster | 11x less     |
-| CompareCommits (XL repo)                  | 60x faster  | 96x less     |
-| GetFlatTree (XL repo)                     | 258x faster | 160x less    |
+| Scenario             | Speed         | Memory usage |
+| -------------------- | ------------- | ------------ |
+| CreateFile (XL repo) | 281.6x faster | 198.4x less  |
+| UpdateFile (XL repo) | 297.3x faster | 189.2x less  |
+| DeleteFile (XL repo) | 280.5x faster | 200.5x less  |
+| GetFlatTree (XL repo) | 260.8x faster | 154.3x less  |
 
-See the [latest performance report](perf/LAST_REPORT.md) and the [performance analysis](docs/architecture/performance.md) for methodology and full results.
+(go-git did not complete the bulk-create and commit-comparison scenarios in that run, so no multipliers are quoted for them; nanogit bulk-created 1,000 files in ~103ms.) See the [full performance report](perf/LAST_REPORT.md) and the [performance analysis](docs/architecture/performance.md) for methodology and complete results.
 
 ## Is it production-ready?
 

--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -1,293 +1,66 @@
-# Performance Analysis: Why nanogit Outperforms Traditional Git
+# Performance
 
-## Executive Summary
+nanogit is substantially faster and lighter than a general-purpose Git library for the server-side operations it implements. On the XL benchmark tier (15,000 files, 3,000 commits), measured file operations run **~280–300x faster than [go-git](https://github.com/go-git/go-git) while allocating ~150–200x less memory**. This page explains where that difference comes from, shows the measured results, and documents how to run and profile the benchmarks yourself.
 
-nanogit delivers **50-300x performance improvements** over traditional Git implementations for cloud-native use cases, while consuming **9-212x less memory**. This dramatic performance gain stems from its stateless, streaming-first architecture designed specifically for server-side Git operations, demonstrating the power of **tailored solutions over generic implementations**.
+All performance claims on this page come from the benchmark suite in [`perf/`](https://github.com/grafana/nanogit/tree/main/perf); the full raw output lives in [`perf/LAST_REPORT.md`](https://github.com/grafana/nanogit/blob/main/perf/LAST_REPORT.md).
 
-## Core Performance Advantages
+## Why nanogit is fast
 
-### 1. Stateless Operations Architecture
+### 1. Stateless operations
 
-**Traditional Git Problem**: Requires local `.git` directory with filesystem I/O for every operation
-**nanogit Solution**: Completely stateless operations with no local filesystem dependency
+Traditional Git implementations operate on a local `.git` directory: every operation reads and writes loose objects, index files, and packfiles on disk. nanogit keeps no local repository state at all — it fetches exactly the objects an operation needs over HTTPS and holds operation state in memory:
 
-**Performance Impact**:
+- No `.git` directory, index, or object-database I/O
+- No file locking; operations on different repositories share nothing
+- No per-repository state to create or clean up, which matters for cold starts in containers and serverless environments
 
-- **Eliminates File I/O**: No reading/writing `.git` directories, index files, or object databases
-- **Zero File Locking**: Operations can run concurrently without coordination
-- **Container-Optimized**: Perfect cold-start performance for serverless and containers
-- **Memory-Only State**: All operation state maintained in memory with efficient cleanup
+### 2. Streaming-first data pipeline
 
-### 2. Streaming-First Data Pipeline
+Writes stream directly from packfile creation to the network (`io.Pipe`), with no intermediate files:
 
-**Traditional Git Problem**: Multi-stage file writing (loose objects � packfiles � network)
-**nanogit Solution**: Direct streaming from packfile creation to network transmission
+- Data begins transmitting while the packfile is still being built
+- Memory stays bounded regardless of repository size, because objects are processed as streams rather than materialized
 
-**Performance Impact**:
+### 3. Fetch only what the operation needs
 
-- **Zero Intermediate Files**: Uses `io.Pipe` for direct memory-to-network streaming
-- **Reduced Memory Copies**: Minimal data copying between operations
-- **Lower Latency**: Data begins transmitting immediately during packfile creation
-- **Predictable Memory Usage**: Bounded memory consumption regardless of repository size
+Because nanogit speaks the [Smart HTTP protocol v2](protocol-v2.md) directly, it can be precise about what it asks the server for: shallow fetches, path-filtered clones, and batched object requests. Most operations on a large repository touch a small subpath — nanogit's cost scales with the size of the change, not the size of the repository.
 
-### 3. HTTPS-Only Protocol Optimization
+### 4. Configurable storage
 
-**Traditional Git Problem**: Multiple protocol implementations (SSH, git://, HTTP) with complex negotiation
-**nanogit Solution**: Single, optimized Git Smart HTTP Protocol v2 implementation
+Two layers can be tuned per workload (see [Storage Backend](storage.md)):
 
-**Performance Impact**:
+- **Write-time storage**: `PackfileStorageAuto` (≤10 staged objects in memory, more on disk), `PackfileStorageMemory` (fastest), or `PackfileStorageDisk` (minimal memory for bulk operations)
+- **Object caching**: a context-injected, pluggable object cache so repeated reads across operations can share fetched objects
 
-- **Reduced Protocol Overhead**: Single code path eliminates protocol selection complexity
-- **Optimized Authentication**: Direct token-based auth without SSH key management
-- **Better Connection Reuse**: HTTP/2 connection pooling and multiplexing
-- **Cloud-Native Integration**: Native support for modern authentication systems
+## Benchmark results
 
-### 4. Intelligent Storage Architecture
+Numbers below are from the July 2025 run of the [benchmark suite](https://github.com/grafana/nanogit/tree/main/perf) ([full report](https://github.com/grafana/nanogit/blob/main/perf/LAST_REPORT.md)), comparing nanogit against go-git on the XL repository tier (15,000 files, 3,000 commits). Durations are averages over the run; memory multipliers compare peak allocations.
 
-nanogit implements a two-layer storage system optimized for different operation patterns:
+| Operation (XL tier) | nanogit | go-git | Speed        | Memory      |
+| ------------------- | ------- | ------ | ------------ | ----------- |
+| CreateFile          | 79.4ms  | 22.3s  | 281.6x faster | 198.4x less |
+| UpdateFile          | 75.1ms  | 22.3s  | 297.3x faster | 189.2x less |
+| DeleteFile          | 79.6ms  | 22.3s  | 280.5x faster | 200.5x less |
+| GetFlatTree         | 76.1ms  | 19.8s  | 260.8x faster | 154.3x less |
 
-#### Write-Time Storage (Configurable)
+Two caveats, in the interest of honest numbers:
 
-- **`PackfileStorageAuto`**: d10 objects in memory, >10 objects on disk
-- **`PackfileStorageMemory`**: Always in-memory for maximum speed
-- **`PackfileStorageDisk`**: Always disk-based for minimal memory usage
+- **go-git did not complete the `BulkCreateFiles` and `CompareCommits` scenarios** in that run (0% success in the report), so no comparison multipliers are quoted for them. For scale, nanogit completed a 1,000-file bulk create against the medium repository in 102.8ms and a full-history XL commit comparison in 333.5ms.
+- The report also benchmarks the **`git` CLI**, which nanogit outperforms by ~86–93x on wall-clock time in the same four XL scenarios (and by 2.6–119x across all scenarios and sizes). Memory comparisons against a subprocess are less meaningful (the CLI's working set lives in the OS page cache rather than process memory), so the library-to-library comparison above is the one that matters for embedding.
 
-#### Object Caching (Context-Based)
+The report predates the v1.0 release. Re-running the suite against a current release is tracked as follow-up work; the suite itself is reproducible with `cd perf && make test-perf-setup && make test-perf-all` (requires Docker).
 
-- **In-Memory Cache**: TTL-based object cache for frequently accessed data
-- **Pluggable Storage**: Custom storage backends via context injection
-- **Smart Deduplication**: Hash-based object deduplication in packfiles
+## The trade-off: tailored vs. generic
 
-## Benchmark Results
+go-git is a comprehensive Git implementation: all transports, all storage backends, the full feature surface. That breadth has a cost — abstraction layers, full-repository data structures, and local-disk semantics — that it pays on every operation.
 
-Based on performance testing against traditional Git implementations:
+nanogit makes the opposite trade. It implements one transport (Smart HTTP v2), one workload shape (server-side reads and writes), and only the object plumbing those need. The performance gap in the table above is mostly this: **go-git materializes and maintains a repository; nanogit fetches, transforms, and streams exactly the objects one operation requires.**
 
-| Operation       | Repository Size | Performance Gain | Memory Reduction     |
-| --------------- | --------------- | ---------------- | -------------------- |
-| UpdateFile      | XL repos        | **275x faster**  | **47x less memory**  |
-| BulkCreateFiles | 1000 files      | **50x faster**   | **15x less memory**  |
-| GetFlatTree     | XL repos        | **303x faster**  | **212x less memory** |
-| CompareCommits  | XL repos        | **111x faster**  | **89x less memory**  |
+That trade is only a win when the constraints fit. If you need SSH, local worktrees, merges, or the rest of full Git, go-git's breadth is worth its cost — see [When should I not use it?](../index.md#when-should-i-not-use-it).
 
-_XL repos = repositories with >100MB of data and >10,000 files_
+## Profiling infrastructure
 
-## Tailored vs Generic Implementation Philosophy
-
-### The Performance Cost of Universal Solutions
-
-**go-git's Generic Approach**: Designed as a comprehensive Git implementation supporting all protocols, all storage backends, and all Git features, go-git necessarily includes significant abstraction layers to accommodate diverse use cases.
-
-**nanogit's Tailored Approach**: Built exclusively for cloud-native HTTPS operations, nanogit eliminates unnecessary abstractions and optimizes every layer for its specific use case.
-
-### Abstraction Layer Performance Impact
-
-**Multi-Protocol Abstraction Overhead**:
-
-- go-git maintains protocol negotiation logic for SSH, git://, HTTP, and file protocols
-- nanogit hardcodes HTTPS-only operations, eliminating protocol selection overhead
-- **Result**: CPU reduction from removed protocol abstraction.
-
-**Storage Backend Abstraction**:
-
-- go-git's pluggable storage requires interface virtualization and type assertions
-- nanogit uses direct struct access with compile-time optimization
-- **Result**: memory allocation reduction and faster object access.
-
-**Feature Completeness Tax**:
-
-- go-git includes hooks, signing, complex permissions, and full clone capabilities
-- nanogit strips non-essential features, reducing code paths and memory footprint
-- **Result**: smaller binary size and reduced instruction cache pressure
-
-### Direct Implementation Benefits
-
-**Zero-Cost Abstractions**: nanogit eliminates abstraction layers where go-git requires them:
-
-```go
-// go-git approach (simplified)
-type Storage interface {
-    GetObject(hash Hash) (Object, error)
-    SetObject(Object) error
-}
-func (r *Repository) getObject(h Hash) Object {
-    return r.storage.GetObject(h) // Interface call + virtual dispatch
-}
-
-// nanogit approach (simplified)
-type Client struct {
-    objects map[Hash]*Object // Direct access
-}
-func (c *Client) getObject(h Hash) *Object {
-    return c.objects[h] // Direct memory access
-}
-```
-
-**Compile-Time Optimizations**: Single-purpose design enables aggressive compiler optimizations that generic solutions cannot achieve.
-
-## Architecture-Driven Performance
-
-### Memory Efficiency
-
-```
-Traditional Git Flow:
-Repository � .git directory � Index � Packfiles � Network
-Memory Peak: ~500MB for large operations
-
-nanogit Flow:
-Repository � Memory Cache � Direct Stream � Network
-Memory Peak: ~25MB for equivalent operations
-```
-
-### CPU Efficiency
-
-- **Reduced System Calls**: No filesystem operations eliminates thousands of syscalls per operation
-- **Optimized Data Structures**: Flat tree representation with O(1) path lookups via `map[string]*FlatTreeEntry`
-- **Minimal Context Switching**: Streaming architecture reduces thread coordination overhead
-- **Efficient Concurrency**: Go's goroutines enable lightweight parallelization
-
-### Network Efficiency
-
-- **HTTP/2 Multiplexing**: Multiple operations over single connection
-- **Streaming Compression**: Compression happens during streaming, not pre-computed
-- **Smart Chunking**: Adaptive chunk sizes based on network conditions
-- **Connection Reuse**: Persistent connections with automatic keepalive
-
-## Cloud-Native Optimizations
-
-### Serverless & Container Benefits
-
-1. **Fast Cold Starts**: <50ms initialization vs >2s for traditional Git
-2. **Predictable Memory**: Memory usage scales linearly with operation size
-3. **Stateless Scaling**: Perfect horizontal scaling without coordination
-4. **Resource Isolation**: Each operation has bounded, predictable resource usage
-
-### Multitenant Performance
-
-1. **Shared Object Cache**: Common objects cached across repositories
-2. **Isolated Operations**: No cross-tenant state contamination
-3. **Resource Pooling**: Efficient memory and connection pooling
-4. **Per-Tenant Configuration**: Context-based storage and caching policies
-
-## Enhancement Opportunities
-
-### 1. Advanced Caching Strategies
-
-**Current State**: Simple TTL-based in-memory object cache
-**Enhancement Opportunities**:
-
-- **Distributed Caching**: Redis/Memcached integration for shared object cache
-- **Intelligent Pre-warming**: Predictive caching based on access patterns
-- **Compression Caching**: Store compressed objects to reduce memory footprint
-- **Multi-Level Caching**: L1 (memory) + L2 (SSD) + L3 (distributed) cache hierarchy
-
-**Potential Impact**: 2-5x additional performance improvement for read-heavy workloads
-
-### 2. Protocol Optimizations
-
-**Current State**: Git Smart HTTP Protocol v2
-**Enhancement Opportunities**:
-
-- **HTTP/3 Support**: QUIC protocol for improved connection handling
-- **Binary Protocol Extensions**: Custom binary protocol for internal operations
-- **Compression Optimization**: Adaptive compression algorithms (zstd, brotli)
-- **Delta Compression**: Improved delta compression for similar objects
-
-**Potential Impact**: 20-40% reduction in network transfer times
-
-### 3. Parallel Processing Enhancements
-
-**Current State**: Limited parallelization within operations
-**Enhancement Opportunities**:
-
-- **Parallel Object Processing**: Concurrent processing of independent objects
-- **Streaming Parallelization**: Parallel packfile creation with ordered streaming
-- **Tree Walking Optimization**: Parallel tree traversal for large repositories
-- **Batch Operation Optimization**: Optimized batching of small operations
-
-**Potential Impact**: 3-10x improvement for operations on repositories with >50,000 objects
-
-### 4. Memory Management Optimizations
-
-**Current State**: Go garbage collector with basic object pooling
-**Enhancement Opportunities**:
-
-- **Custom Memory Allocators**: Pool-based allocators for frequent object types
-- **Zero-Copy Optimizations**: Eliminate remaining memory copies in hot paths
-- **Memory-Mapped Files**: Memory mapping for large objects with smart prefetching
-- **Streaming Decompression**: On-the-fly decompression without intermediate buffers
-
-**Potential Impact**: 30-50% memory reduction with maintained performance
-
-### 5. Storage Backend Optimizations
-
-**Current State**: Simple in-memory and disk-based storage
-**Enhancement Opportunities**:
-
-- **Cloud Storage Integration**: Native S3/GCS/Azure Blob storage backends
-- **Columnar Storage**: Optimized storage format for analytical queries
-- **Compression at Rest**: Transparent compression for stored objects
-- **Storage Tiering**: Automatic migration between storage tiers based on access patterns
-
-**Potential Impact**: Unlimited scalability with cost optimization
-
-## Use Case Performance Characteristics
-
-### API Backends (Primary Use Case)
-
-- **Webhook Processing**: 50-100x faster than traditional Git for file updates
-- **Branch Operations**: 200x faster for branch creation and switching
-- **Diff Generation**: 75x faster for commit comparisons and diff generation
-
-### Content Management
-
-- **File Updates**: 275x faster for single file modifications
-- **Bulk Operations**: 50x faster for batch file creation/updates
-- **Search Operations**: 150x faster for content search and tree traversal
-
-## Conclusion
-
-nanogit's performance advantages stem from fundamental architectural decisions that prioritize cloud-native operations over compatibility with traditional Git workflows. The combination of stateless operations, streaming data pipelines, and intelligent caching delivers unprecedented performance for server-side Git operations.
-
-### The Tailored Solution Advantage
-
-The **50-300x performance improvements** are not incremental optimizations but represent a paradigm shift from generic, abstraction-heavy implementations to **purpose-built, direct-access architectures**. This demonstrates a critical principle in high-performance systems:
-
-**Specialized solutions consistently outperform general-purpose solutions when requirements are well-defined.**
-
-Key lessons from nanogit's approach:
-
-1. **Abstraction Elimination**: Every removed abstraction layer improves performance by 10-25%
-2. **Single-Purpose Design**: Focusing on one protocol (HTTPS) and one use case (cloud operations) enables aggressive optimization
-3. **Direct Implementation**: Compile-time optimizations beat runtime flexibility for performance-critical applications
-4. **Constraint-Driven Architecture**: Accepting limitations (no SSH, no local operations) unlocks dramatic performance gains
-
-### When to Choose Tailored vs Generic
-
-**Choose nanogit (tailored)** when:
-
-- Performance is critical (>100 operations/second)
-- Use case is well-defined (cloud APIs, CI/CD, webhooks)
-- HTTPS-only operations are sufficient
-- Memory efficiency matters (containers, serverless)
-
-**Choose go-git (generic)** when:
-
-- Full Git compatibility required
-- Multiple protocols needed (SSH, git://)
-- Local filesystem operations required
-- Development tooling or complex Git workflows
-
-With the identified enhancement opportunities, nanogit has the potential to deliver even greater performance gains while maintaining its core simplicity and reliability advantages - proving that **sometimes less is exponentially more**.
-
-## Performance Analysis and Optimization Workflow
-
-### Profiling Infrastructure
-
-nanogit includes comprehensive profiling tools specifically designed for performance analysis and optimization validation. These tools are essential for maintaining performance advantages and identifying optimization opportunities.
-
-### Built-in Profiling Targets
-
-Located in `perf/Makefile`, the profiling infrastructure provides:
+nanogit includes profiling tools for performance analysis and optimization validation, located in `perf/Makefile`:
 
 ```bash
 # Establish performance baseline
@@ -306,112 +79,72 @@ make profile-all
 make profile-compare
 ```
 
-### Optimization Methodology
+### Optimization methodology
 
-**1. Baseline Establishment**
+**1. Baseline establishment**
 ```bash
 cd perf
 make profile-baseline  # Creates baseline profiles
 ```
 This captures performance characteristics before optimization attempts.
 
-**2. Targeted Profiling**
+**2. Targeted profiling**
 ```bash
 # Profile specific operations
 make profile-all-tree    # Tree operations
-make profile-all-commit  # Commit operations  
+make profile-all-commit  # Commit operations
 make profile-cpu         # File operations
 ```
 
-**3. Performance Analysis**
+**3. Performance analysis**
 ```bash
 # Interactive analysis
 go tool pprof profiles/cpu.prof
 go tool pprof profiles/mem.prof
 
-# Web-based analysis  
+# Web-based analysis
 go tool pprof -http=:8080 profiles/cpu.prof
 
 # Comparative analysis
 go tool pprof -diff_base=profiles/baseline_cpu.prof profiles/cpu.prof
 ```
 
-**4. Optimization Validation**
+**4. Optimization validation**
 ```bash
 make profile-compare  # Shows improvement metrics
 ```
 
-### Key Performance Metrics
+### Real optimization examples
 
-**CPU Profile Analysis**:
-- Function-level CPU consumption
-- Call graph analysis for hotspot identification
-- Optimization impact measurement (e.g., `readAndInflate`: 120ms → 110ms)
-
-**Memory Profile Analysis**:
-- Allocation patterns and memory leaks
-- Memory-intensive operations identification  
-- Memory reduction validation (e.g., `compareTrees`: 53.15MB → 11.44MB, 78% reduction)
-
-### Real Optimization Examples
-
-**Tree Comparison Optimization**:
+**Tree comparison optimization**:
 - **Before**: 53.15MB memory usage
-- **After**: 11.44MB memory usage  
+- **After**: 11.44MB memory usage
 - **Method**: Pre-allocation and capacity estimation
 - **Result**: 78% memory reduction
 
-**Packet Length Reading Optimization**:
+**Packet length reading optimization**:
 - **Issue**: 19% CPU regression from frequent allocations
 - **Solution**: Buffer pooling with `sync.Pool`
 - **Method**: Replace per-call allocations with pooled buffers
 - **Result**: Restored CPU performance to baseline
 
-### Performance Monitoring Best Practices
+### Performance regression prevention
 
-**1. Continuous Profiling**
-- Profile before and after every optimization
-- Maintain baseline profiles for regression detection
-- Use consistent test scenarios for reliable comparisons
+- Profile before and after every optimization, against a maintained baseline
+- Focus on functions consuming >1% of total resources, and on allocations in hot paths
+- Measure both CPU and memory impact, and validate across repository sizes
 
-**2. Bottleneck Identification**
-- Focus on functions consuming >1% of total resources
-- Prioritize memory allocations in hot paths
-- Analyze GC pressure and object lifecycle
-
-**3. Optimization Validation**
-- Measure both CPU and memory impact
-- Verify no performance regressions in other areas
-- Validate optimization benefits across repository sizes
-
-### Advanced Analysis Techniques
-
-**Differential Profiling**:
+**Differential profiling**:
 ```bash
-# Compare optimization impact
 go tool pprof -diff_base=baseline.prof current.prof -top
 ```
 
-**Flame Graph Generation**:
+**Flame graph generation**:
 ```bash
-# Visual CPU usage analysis
 go tool pprof -png profiles/cpu.prof > cpu_flame.png
 ```
 
-**Memory Allocation Tracking**:
+**Memory allocation tracking**:
 ```bash
-# Identify allocation hotspots
 go tool pprof -alloc_space profiles/mem.prof
 ```
-
-### Performance Regression Prevention
-
-The profiling infrastructure enables systematic performance regression prevention:
-
-1. **Automated Baseline Creation**: Establish performance benchmarks
-2. **Continuous Monitoring**: Regular profile comparisons
-3. **Optimization Validation**: Quantify improvement impact
-4. **Regression Detection**: Identify performance degradations early
-
-This profiling methodology ensures nanogit maintains its performance advantages while supporting continued optimization efforts.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,18 +61,16 @@ See [Why Git Protocol v2 Only?](architecture/protocol-v2.md) for the rationale b
 | Use case       | Cloud services, multitenant backends                    | General purpose        |
 | Resource usage | Minimal footprint                                       | Full Git features      |
 
-Because it never materializes a full repository, nanogit is dramatically faster and lighter for typical server-side operations. From the [benchmark suite](https://github.com/grafana/nanogit/tree/main/perf) comparing both libraries across repository sizes:
+Because it never materializes a full repository, nanogit is dramatically faster and lighter for typical server-side operations. From the July 2025 run of the [benchmark suite](https://github.com/grafana/nanogit/tree/main/perf), on the XL repository tier (15,000 files, 3,000 commits), nanogit vs go-git:
 
-| Scenario                                  | Speed       | Memory usage |
-| ----------------------------------------- | ----------- | ------------ |
-| CreateFile (XL repo)                      | 306x faster | 186x less    |
-| UpdateFile (XL repo)                      | 291x faster | 178x less    |
-| DeleteFile (XL repo)                      | 302x faster | 175x less    |
-| BulkCreateFiles (1000 files, medium repo) | 607x faster | 11x less     |
-| CompareCommits (XL repo)                  | 60x faster  | 96x less     |
-| GetFlatTree (XL repo)                     | 258x faster | 160x less    |
+| Scenario             | Speed         | Memory usage |
+| -------------------- | ------------- | ------------ |
+| CreateFile (XL repo) | 281.6x faster | 198.4x less  |
+| UpdateFile (XL repo) | 297.3x faster | 189.2x less  |
+| DeleteFile (XL repo) | 280.5x faster | 200.5x less  |
+| GetFlatTree (XL repo) | 260.8x faster | 154.3x less  |
 
-See the [performance analysis](architecture/performance.md) for methodology and full results.
+(go-git did not complete the bulk-create and commit-comparison scenarios in that run, so no multipliers are quoted for them; nanogit bulk-created 1,000 files in ~103ms.) See the [performance analysis](architecture/performance.md) for methodology and complete results.
 
 ## Is it production-ready?
 

--- a/perf/README.md
+++ b/perf/README.md
@@ -22,10 +22,12 @@ make help                  # See all available targets
 - **Client-Specific**: Focus on individual Git implementations
 
 ### Repository Sizes
-- **Small**: 50 files, 32 commits
-- **Medium**: 500 files, 165 commits  
-- **Large**: 2000 files, 692 commits
-- **XLarge**: 10000 files, 2602 commits
+- **Small**: 100 files, 50 commits
+- **Medium**: 750 files, 200 commits
+- **Large**: 3000 files, 800 commits
+- **XLarge**: 15000 files, 3000 commits
+
+(Defined in `cmd/generate_repo/main.go`; the generated archives land in `testdata/`.)
 
 ## Common Targets
 


### PR DESCRIPTION
Part of the repo-maturity polish series. Fixes the three-way benchmark inconsistency found in the audit.

## Problem

- README/docs-home cited e.g. CreateFile XL "306x faster / 186x less"; `docs/architecture/performance.md` said "275x / 47x less"; the canonical `perf/LAST_REPORT.md` says **281.6x / 198.4x less**. Three pages, three different sets, none matching the cited source.
- The "BulkCreateFiles 607x" and "CompareCommits 60x" rows were derived from scenarios where **the report records go-git at 0.0% success** — comparisons against failed runs. (Sweep of the report: go-git completed only CreateFile/UpdateFile/DeleteFile/GetFlatTree; it failed all BulkCreateFiles and CompareCommits scenarios.)
- performance.md contained mojibake (`≤`/`→` → `�`), unmeasured claims presented as fact (`<50ms cold starts`, `200x branch operations`, `150x search operations`), placeholder "**Result**:" bullets, a misleading code sample, and speculative roadmap impact numbers.
- perf/README.md defined the repository tiers two contradictory ways.

## Fix

- **One source of truth**: README, docs home, and performance.md now quote LAST_REPORT.md verbatim — only the four scenarios where every client completed, labeled "July 2025 run, XL tier (15,000 files, 3,000 commits), vs go-git", with an explicit note about the scenarios go-git failed to complete (plus nanogit's absolute times for those).
- **performance.md rewritten** to be sober and sourced: architecture rationale, the measured table, an honest git-CLI comparison note (~86–93x on the same XL scenarios, 2.6–119x across all), the tailored-vs-generic trade-off, and the unchanged profiling workflow. Marketing superlatives, fabricated numbers, and the fake code sample are gone.
- **perf/README.md** tier definitions now match `cmd/generate_repo/main.go` (100/750/3000/15000 files).

## Verification

- Script-checked: every multiplier and absolute time cited in the three pages appears verbatim in `perf/LAST_REPORT.md`, and each cited row has 100% success for both clients
- No replacement characters remain
- `./scripts/prepare-docs.sh && npm run docs:build` passes

## Follow-up

The report itself is from 2025-07-09 (pre-v1.0). Re-running `cd perf && make test-perf-setup && make test-perf-all` against a current release needs Docker (unavailable in this workspace) — worth a fresh run and a table regeneration afterwards; the pages now state the run date so they stay honest either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)