### PR TITLE
docs: complete the pkg.go.dev surface — package docs, Client docs, examples

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,37 +66,110 @@ type StagedWriter interface {
 	Cleanup(ctx context.Context) error
 }
 
-// Client defines the interface for interacting with a Git repository.
-// It provides methods for repository operations, reference management,
-//
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -header internal/tools/fake_header.txt -o mocks/client.go . Client
+
+// Client is the interface for interacting with a single remote Git repository
+// over the Smart HTTP protocol v2. It covers repository probes, reference
+// management, object reads (blobs, trees, commits), history comparison,
+// path-filtered cloning, and creating a StagedWriter for transactional writes.
+//
+// Instances are created with NewHTTPClient. All operations are stateless HTTP
+// exchanges: nothing is written to the local filesystem unless explicitly
+// requested (Clone), and no per-repository state outlives the client.
 type Client interface {
-	// Repo operations
+	// CanRead reports whether the client can read from the repository, by
+	// probing the git-upload-pack service with the configured credentials.
 	CanRead(ctx context.Context) (bool, error)
+
+	// CanWrite reports whether the client has repository-level write access,
+	// by probing the git-receive-pack service. It cannot see branch-level
+	// restrictions (e.g. protected branches); a push may still be rejected.
 	CanWrite(ctx context.Context) (bool, error)
-	IsAuthorized(ctx context.Context) (bool, error) // Deprecated: Use CanRead instead
+
+	// IsAuthorized reports whether the client can communicate with the
+	// repository using the configured credentials.
+	//
+	// Deprecated: Use CanRead instead.
+	IsAuthorized(ctx context.Context) (bool, error)
+
+	// RepoExists reports whether the repository exists on the server, by
+	// attempting to fetch its refs. It returns false (without error) when the
+	// server answers with 404.
 	RepoExists(ctx context.Context) (bool, error)
+
+	// IsServerCompatible reports whether the server supports Git protocol v2,
+	// which nanogit requires. It returns false for servers that only speak
+	// protocol v1 (for example Azure DevOps).
 	IsServerCompatible(ctx context.Context) (bool, error)
-	// Ref operations
+
+	// ListRefs retrieves all references (branches, tags, and others)
+	// advertised by the remote repository, without downloading object data.
 	ListRefs(ctx context.Context) ([]Ref, error)
+
+	// GetRef retrieves a single reference by its fully qualified name, such
+	// as "refs/heads/main" or "refs/tags/v1.0.0". It returns a
+	// RefNotFoundError if the reference does not exist; short names like
+	// "main" are not resolved.
 	GetRef(ctx context.Context, refName string) (Ref, error)
+
+	// CreateRef creates a new reference pointing at ref.Hash. The reference
+	// must not already exist.
 	CreateRef(ctx context.Context, ref Ref) error
+
+	// UpdateRef moves an existing reference to point at ref.Hash. The
+	// reference must already exist.
 	UpdateRef(ctx context.Context, ref Ref) error
+
+	// DeleteRef removes a reference from the remote repository. Only the
+	// reference is removed, not the objects it pointed to.
 	DeleteRef(ctx context.Context, refName string) error
-	// Blob operations
+
+	// GetBlob retrieves a blob (file content) by its object hash.
 	GetBlob(ctx context.Context, hash hash.Hash) (*Blob, error)
+
+	// GetBlobByPath retrieves a file by walking the tree hierarchy from
+	// rootHash to the given slash-separated path, e.g. "docs/README.md".
+	// Tip: pass Commit.Tree as the root.
 	GetBlobByPath(ctx context.Context, rootHash hash.Hash, path string) (*Blob, error)
-	// Tree operations
+
+	// GetFlatTree retrieves a recursive listing of every file and directory
+	// reachable from the given commit or tree hash, with each entry carrying
+	// its full path from the repository root.
 	GetFlatTree(ctx context.Context, hash hash.Hash) (*FlatTree, error)
+
+	// GetTree retrieves a single tree object (one directory level) by its
+	// hash.
 	GetTree(ctx context.Context, hash hash.Hash) (*Tree, error)
+
+	// GetTreeByPath retrieves the tree object for a directory at the given
+	// slash-separated path, walking down from rootHash. The path "" or "."
+	// returns the root tree itself.
 	GetTreeByPath(ctx context.Context, rootHash hash.Hash, path string) (*Tree, error)
-	// Commit operations
+
+	// GetCommit retrieves a single commit object, including its author,
+	// committer, message, parent hashes, and root tree hash.
 	GetCommit(ctx context.Context, hash hash.Hash) (*Commit, error)
+
+	// CompareCommits returns the file-level differences between two commits:
+	// files added, modified, or deleted between baseCommit and headCommit,
+	// sorted by path. Rename detection is enabled with WithRenameDetection.
 	CompareCommits(ctx context.Context, baseCommit, headCommit hash.Hash, opts ...CompareCommitsOption) ([]CommitFile, error)
+
+	// ListCommits walks the history backwards from startCommit and returns
+	// the matching commits. ListCommitsOptions provides pagination (Page,
+	// PerPage) and filtering (Path, Since, Until).
 	ListCommits(ctx context.Context, startCommit hash.Hash, options ListCommitsOptions) ([]Commit, error)
-	// Clone operations
+
+	// Clone writes a snapshot of the repository at CloneOptions.Hash to a
+	// local directory, optionally filtered to specific paths with glob
+	// patterns. It fetches only the objects the filtered snapshot needs; it
+	// does not create a .git directory or a working clone.
 	Clone(ctx context.Context, opts CloneOptions) (*CloneResult, error)
-	// Write operations
+
+	// NewStagedWriter creates a StagedWriter that stages changes on top of
+	// the commit currently referenced by ref, to be committed and pushed as
+	// one atomic update. WriterOption values choose where staged objects are
+	// buffered (memory, disk, or automatic).
 	NewStagedWriter(ctx context.Context, ref Ref, options ...WriterOption) (StagedWriter, error)
 }
 
@@ -132,29 +205,28 @@ type httpClient struct {
 }
 
 // NewHTTPClient creates a new Git client for the specified repository URL.
-// The client implements the Git Smart Protocol version 2 over HTTP/HTTPS transport.
-// It supports both HTTP and HTTPS URLs and can be configured with various options
-// for authentication, logging, and HTTP client customization.
+// The client implements the Git Smart Protocol version 2 over HTTP/HTTPS
+// transport and is configured with functional options from the
+// [github.com/grafana/nanogit/options] package (authentication, response
+// limits, receive-pack capabilities, HTTP client customization).
 //
-// Parameters:
-//   - repo: Repository URL (must be HTTP or HTTPS)
-//   - options: Configuration options for authentication, logging, etc.
-//
-// Returns:
-//   - Client: Configured Git client interface
-//   - error: Error if URL is invalid or configuration fails
+// It returns an error if the URL is not a valid HTTP or HTTPS repository URL
+// or if an option fails to apply.
 //
 // Example:
 //
-//	// Create client with basic authentication
+//	// Create a client with basic authentication.
 //	client, err := nanogit.NewHTTPClient(
 //	    "https://github.com/user/repo",
 //	    options.WithBasicAuth("username", "password"),
-//	    options.WithLogger(logger),
 //	)
 //	if err != nil {
 //	    return err
 //	}
+//
+// Logging and retries are configured per call through the context; see
+// [github.com/grafana/nanogit/log.ToContext] and
+// [github.com/grafana/nanogit/retry.ToContext].
 func NewHTTPClient(repo string, opts ...options.Option) (Client, error) {
 	// Resolve options once so both the raw transport and the higher-level
 	// httpClient fields come from the same application of each Option.

--- a/commit.go
+++ b/commit.go
@@ -94,12 +94,15 @@ type CommitFile struct {
 	Status protocol.FileStatus
 }
 
-// CompareCommitsOptions configures the behavior of CompareCommits
+// CompareCommitsOptions configures the behavior of CompareCommits.
 type CompareCommitsOptions struct {
+	// DetectRenames reports delete/add pairs with identical content hashes
+	// as a single renamed file instead of separate delete and add entries.
+	// Enable it with WithRenameDetection.
 	DetectRenames bool
 }
 
-// CompareCommitsOption configures CompareCommits behavior
+// CompareCommitsOption configures CompareCommits behavior.
 type CompareCommitsOption func(*CompareCommitsOptions)
 
 // WithRenameDetection enables rename detection in CompareCommits.
@@ -228,9 +231,9 @@ func (c *httpClient) CompareCommits(ctx context.Context, baseCommit, headCommit 
 // Additional optimizations considered:
 // - Could use byte enum for common modes (0o100644, 0o100755, 0o040000) + overflow field
 type entryInfo struct {
-	hash     hash.Hash
-	mode     uint16              // uint16 is sufficient for Git file modes (max 0o160000)
-	objType  protocol.ObjectType // Git object type (blob, tree, etc.)
+	hash    hash.Hash
+	mode    uint16              // uint16 is sufficient for Git file modes (max 0o160000)
+	objType protocol.ObjectType // Git object type (blob, tree, etc.)
 }
 
 // compareTrees recursively compares two trees and collects changes between them.

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,72 @@
+// Package nanogit is a lightweight Git client for services that read from and
+// write to remote repositories over HTTPS — with no local clone, no .git
+// directory, and no git binary. It speaks the Git Smart HTTP protocol v2
+// directly, so it works with GitHub, GitLab, Bitbucket, Gitea, and any other
+// server that supports protocol v2.
+//
+// nanogit is deliberately narrow: it implements the essential server-side
+// operations (refs, blobs, trees, commits, diffs, staged writes, and
+// path-filtered shallow clones) and nothing else. For local worktrees,
+// merges, SSH, or full Git functionality, use the git CLI or a
+// general-purpose implementation such as go-git.
+//
+// # Reading
+//
+// Create a [Client] with [NewHTTPClient], resolve a ref, and read objects:
+//
+//	client, err := nanogit.NewHTTPClient(
+//	    "https://github.com/owner/repo.git",
+//	    options.WithBasicAuth("git", token),
+//	)
+//	if err != nil {
+//	    return err
+//	}
+//	ref, err := client.GetRef(ctx, "refs/heads/main")
+//	if err != nil {
+//	    return err
+//	}
+//	commit, err := client.GetCommit(ctx, ref.Hash)
+//	if err != nil {
+//	    return err
+//	}
+//	blob, err := client.GetBlobByPath(ctx, commit.Tree, "README.md")
+//	if err != nil {
+//	    return err
+//	}
+//
+// # Writing
+//
+// Writes are transactional: a [StagedWriter] stages any number of changes,
+// commits them, and pushes the result as a single atomic ref update:
+//
+//	writer, err := client.NewStagedWriter(ctx, ref)
+//	if err != nil {
+//	    return err
+//	}
+//	if _, err := writer.CreateBlob(ctx, "hello.txt", []byte("hi\n")); err != nil {
+//	    return err
+//	}
+//	if _, err := writer.Commit(ctx, "Add hello.txt", author, committer); err != nil {
+//	    return err
+//	}
+//	if err := writer.Push(ctx); err != nil {
+//	    return err
+//	}
+//
+// # Configuration
+//
+// Construction-time behavior (authentication, response size limits,
+// receive-pack capabilities) is configured with functional options from
+// [github.com/grafana/nanogit/options]. Cross-cutting concerns are injected
+// per call through the context: logging via
+// [github.com/grafana/nanogit/log.ToContext], retries via
+// [github.com/grafana/nanogit/retry.ToContext], and object caching via
+// [github.com/grafana/nanogit/storage.ToContext].
+//
+// Generated mocks for [Client] and [StagedWriter] live in
+// [github.com/grafana/nanogit/mocks], and
+// [github.com/grafana/nanogit/gittest] runs integration tests against a real
+// containerized Git server.
+//
+// Full documentation, guides, and benchmarks: https://grafana.github.io/nanogit
+package nanogit

--- a/errors.go
+++ b/errors.go
@@ -75,9 +75,11 @@ var (
 
 // ObjectNotFoundError provides structured information about a Git object that was not found.
 type ObjectNotFoundError struct {
+	// ObjectID is the hash of the object that was not found.
 	ObjectID hash.Hash
 }
 
+// Error implements the error interface.
 func (e *ObjectNotFoundError) Error() string {
 	return "object " + e.ObjectID.String() + " not found"
 }
@@ -96,9 +98,11 @@ func NewObjectNotFoundError(objectID hash.Hash) *ObjectNotFoundError {
 
 // ObjectAlreadyExistsError provides structured information about a Git object that already exists.
 type ObjectAlreadyExistsError struct {
+	// ObjectID is the hash of the object that already exists.
 	ObjectID hash.Hash
 }
 
+// Error implements the error interface.
 func (e *ObjectAlreadyExistsError) Error() string {
 	return "object " + e.ObjectID.String() + " already exists"
 }
@@ -117,11 +121,15 @@ func NewObjectAlreadyExistsError(objectID hash.Hash) *ObjectAlreadyExistsError {
 
 // UnexpectedObjectCountError provides structured information about a Git object with an unexpected count.
 type UnexpectedObjectCountError struct {
+	// ExpectedCount is the number of objects the caller requested.
 	ExpectedCount int
-	ActualCount   int
-	Objects       []*protocol.PackfileObject
+	// ActualCount is the number of objects the server returned.
+	ActualCount int
+	// Objects are the objects the server returned.
+	Objects []*protocol.PackfileObject
 }
 
+// Error implements the error interface.
 func (e *UnexpectedObjectCountError) Error() string {
 	objectNames := make([]string, 0, len(e.Objects))
 	for _, obj := range e.Objects {
@@ -146,11 +154,15 @@ func NewUnexpectedObjectCountError(expectedCount int, objects []*protocol.Packfi
 
 // UnexpectedObjectTypeError provides structured information about a Git object with an unexpected type.
 type UnexpectedObjectTypeError struct {
-	ObjectID     hash.Hash
+	// ObjectID is the hash of the mismatched object.
+	ObjectID hash.Hash
+	// ExpectedType is the object type the caller requested.
 	ExpectedType protocol.ObjectType
-	ActualType   protocol.ObjectType
+	// ActualType is the object type the server returned.
+	ActualType protocol.ObjectType
 }
 
+// Error implements the error interface.
 func (e *UnexpectedObjectTypeError) Error() string {
 	return "object " + e.ObjectID.String() + " has unexpected type " + e.ActualType.String() + " (expected " + e.ExpectedType.String() + ")"
 }
@@ -171,14 +183,16 @@ func NewUnexpectedObjectTypeError(objectID hash.Hash, expectedType, actualType p
 
 // PathNotFoundError provides structured information about a Git path that was not found.
 type PathNotFoundError struct {
+	// Path is the repository-relative path that was not found.
 	Path string
 }
 
+// Error implements the error interface.
 func (e *PathNotFoundError) Error() string {
 	return "path not found: " + e.Path
 }
 
-// Unwrap enables errors.Is() compatibility with ErrPathNotFound
+// Unwrap enables errors.Is() compatibility with ErrObjectNotFound
 func (e *PathNotFoundError) Unwrap() error {
 	return ErrObjectNotFound
 }
@@ -192,14 +206,16 @@ func NewPathNotFoundError(path string) *PathNotFoundError {
 
 // RefNotFoundError provides structured information about a Git reference that was not found.
 type RefNotFoundError struct {
+	// RefName is the full name of the reference that was not found (e.g. "refs/heads/main").
 	RefName string
 }
 
+// Error implements the error interface.
 func (e *RefNotFoundError) Error() string {
 	return "reference not found: " + e.RefName
 }
 
-// Unwrap enables errors.Is() compatibility with ErrRefNotFound
+// Unwrap enables errors.Is() compatibility with ErrObjectNotFound
 func (e *RefNotFoundError) Unwrap() error {
 	return ErrObjectNotFound
 }
@@ -213,9 +229,11 @@ func NewRefNotFoundError(refName string) *RefNotFoundError {
 
 // RefAlreadyExistsError provides structured information about a Git reference that already exists.
 type RefAlreadyExistsError struct {
+	// RefName is the full name of the reference that already exists (e.g. "refs/heads/main").
 	RefName string
 }
 
+// Error implements the error interface.
 func (e *RefAlreadyExistsError) Error() string {
 	return "reference already exists: " + e.RefName
 }
@@ -234,14 +252,18 @@ func NewRefAlreadyExistsError(refName string) *RefAlreadyExistsError {
 
 // AuthorError provides structured information about invalid author information.
 type AuthorError struct {
-	Field  string
+	// Field is the author field that failed validation (e.g. "name", "email").
+	Field string
+	// Reason describes why the field is invalid.
 	Reason string
 }
 
+// Error implements the error interface.
 func (e *AuthorError) Error() string {
 	return fmt.Sprintf("invalid author %s: %s", e.Field, e.Reason)
 }
 
+// Unwrap enables errors.Is() compatibility with ErrInvalidAuthor
 func (e *AuthorError) Unwrap() error {
 	return ErrInvalidAuthor
 }
@@ -271,7 +293,19 @@ type PermissionDeniedError = client.PermissionDeniedError
 // RepositoryNotFoundError provides structured information about a repository not found error.
 type RepositoryNotFoundError = client.RepositoryNotFoundError
 
-// Re-export constructors
+// NewUnauthorizedError constructs the typed error returned when the server
+// rejects the request with HTTP 401 (authentication failed) for the given
+// HTTP method and Git endpoint.
+// It is re-exported from the protocol/client package to avoid import cycles.
 var NewUnauthorizedError = client.NewUnauthorizedError
+
+// NewPermissionDeniedError constructs the typed error returned when the
+// server rejects the request with HTTP 403 (authenticated but not allowed)
+// for the given HTTP method and Git endpoint.
+// It is re-exported from the protocol/client package to avoid import cycles.
 var NewPermissionDeniedError = client.NewPermissionDeniedError
+
+// NewRepositoryNotFoundError constructs the typed error returned when the
+// server responds with HTTP 404 because the repository does not exist.
+// It is re-exported from the protocol/client package to avoid import cycles.
 var NewRepositoryNotFoundError = client.NewRepositoryNotFoundError

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,155 @@
+package nanogit_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/options"
+)
+
+// ExampleNewHTTPClient creates a client for a repository and verifies the
+// server speaks Git protocol v2.
+func ExampleNewHTTPClient() {
+	ctx := context.Background()
+
+	client, err := nanogit.NewHTTPClient(
+		"https://github.com/owner/repo.git",
+		options.WithBasicAuth("git", "your-token"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	compatible, err := client.IsServerCompatible(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("server supports protocol v2:", compatible)
+}
+
+// ExampleClient_GetBlobByPath reads a single file from a repository without
+// cloning it: resolve the ref, load its commit, and walk the tree to a path.
+func ExampleClient_GetBlobByPath() {
+	ctx := context.Background()
+
+	client, err := nanogit.NewHTTPClient("https://github.com/owner/repo.git")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ref, err := client.GetRef(ctx, "refs/heads/main")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	commit, err := client.GetCommit(ctx, ref.Hash)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	blob, err := client.GetBlobByPath(ctx, commit.Tree, "docs/README.md")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%d bytes at %s\n", len(blob.Content), blob.Hash)
+}
+
+// ExampleClient_NewStagedWriter stages a new file, commits it, and pushes the
+// result as a single atomic ref update — entirely over HTTPS.
+func ExampleClient_NewStagedWriter() {
+	ctx := context.Background()
+
+	client, err := nanogit.NewHTTPClient(
+		"https://github.com/owner/repo.git",
+		options.WithBasicAuth("git", "your-token"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ref, err := client.GetRef(ctx, "refs/heads/main")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	writer, err := client.NewStagedWriter(ctx, ref)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := writer.CreateBlob(ctx, "hello/world.txt", []byte("pushed without a checkout\n")); err != nil {
+		log.Fatal(err)
+	}
+
+	author := nanogit.Author{Name: "Example", Email: "example@example.com", Time: time.Now()}
+	committer := nanogit.Committer{Name: "Example", Email: "example@example.com", Time: time.Now()}
+	commit, err := writer.Commit(ctx, "Add hello/world.txt", author, committer)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := writer.Push(ctx); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("pushed", commit.Hash)
+}
+
+// ExampleClient_Clone writes a path-filtered snapshot of a repository to a
+// local directory, fetching only the objects those paths need. No .git
+// directory is created.
+func ExampleClient_Clone() {
+	ctx := context.Background()
+
+	client, err := nanogit.NewHTTPClient("https://github.com/owner/repo.git")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ref, err := client.GetRef(ctx, "refs/heads/main")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err := client.Clone(ctx, nanogit.CloneOptions{
+		Path:         "/tmp/repo-docs",
+		Hash:         ref.Hash,
+		IncludePaths: []string{"docs/**"},
+		BatchSize:    50,
+		Concurrency:  8,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("wrote %d of %d files to %s\n", result.FilteredFiles, result.TotalFiles, result.Path)
+}
+
+// ExampleClient_CompareCommits lists the files that changed between two
+// commits, with rename detection enabled.
+func ExampleClient_CompareCommits() {
+	ctx := context.Background()
+
+	client, err := nanogit.NewHTTPClient("https://github.com/owner/repo.git")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	base, err := client.GetRef(ctx, "refs/tags/v1.0.0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	head, err := client.GetRef(ctx, "refs/heads/main")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	changes, err := client.CompareCommits(ctx, base.Hash, head.Hash, nanogit.WithRenameDetection())
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, change := range changes {
+		fmt.Printf("%s %s\n", change.Status, change.Path)
+	}
+}

--- a/log/context.go
+++ b/log/context.go
@@ -7,28 +7,14 @@ import (
 // loggerCtxKey is the key used to store the logger in the context.
 type loggerCtxKey struct{}
 
-// ToContext adds a logger to the context that can be retrieved later.
-// The logger will be used for operations performed with this context.
-// If no logger is provided in the context, a no-op logger will be used.
-//
-// Parameters:
-//   - ctx: The context to add the logger to
-//   - logger: The logger to store in the context
-//
-// Returns:
-//   - context.Context: A new context with the logger stored
+// ToContext returns a copy of ctx carrying the given logger. nanogit
+// operations performed with the returned context log through it.
 func ToContext(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, loggerCtxKey{}, logger)
 }
 
-// FromContext retrieves the logger from the context.
-// If no logger is stored in the context, nil will be returned.
-//
-// Parameters:
-//   - ctx: The context to retrieve the logger from
-//
-// Returns:
-//   - Logger: The logger stored in the context, or nil if none is found
+// FromContext returns the Logger stored in ctx, or a NoopLogger if none is
+// stored, so callers can log unconditionally.
 func FromContext(ctx context.Context) Logger {
 	logger, ok := ctx.Value(loggerCtxKey{}).(Logger)
 	if !ok {

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -1,0 +1,29 @@
+package log_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/grafana/nanogit/log"
+)
+
+// slogAdapter adapts a *slog.Logger to nanogit's log.Logger interface.
+type slogAdapter struct{ l *slog.Logger }
+
+func (s slogAdapter) Debug(msg string, keysAndValues ...any) { s.l.Debug(msg, keysAndValues...) }
+func (s slogAdapter) Info(msg string, keysAndValues ...any)  { s.l.Info(msg, keysAndValues...) }
+func (s slogAdapter) Warn(msg string, keysAndValues ...any)  { s.l.Warn(msg, keysAndValues...) }
+func (s slogAdapter) Error(msg string, keysAndValues ...any) { s.l.Error(msg, keysAndValues...) }
+
+// ExampleToContext wires a logger into the context so nanogit operations
+// performed with that context emit debug and progress logs. Without it,
+// nanogit is silent (NoopLogger).
+func ExampleToContext() {
+	logger := slogAdapter{l: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+
+	ctx := log.ToContext(context.Background(), logger)
+
+	// Pass ctx to any nanogit operation: client.GetRef(ctx, ...), etc.
+	_ = ctx
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,3 +1,7 @@
+// Package log defines the Logger interface nanogit uses for diagnostics and
+// the context plumbing to inject an implementation. Attach a logger with
+// ToContext; nanogit retrieves it with FromContext and falls back to a
+// NoopLogger when none is set.
 package log
 
 // Logger is a minimal logging interface for nanogit clients.
@@ -5,8 +9,12 @@ package log
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -header ../internal/tools/fake_header.txt -o ../mocks/logger.go . Logger
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -header ../internal/tools/fake_header.txt -o mocks/logger.go . Logger
 type Logger interface {
+	// Debug logs a debug-level message with alternating key/value pairs.
 	Debug(msg string, keysAndValues ...any)
+	// Info logs an info-level message with alternating key/value pairs.
 	Info(msg string, keysAndValues ...any)
+	// Error logs an error-level message with alternating key/value pairs.
 	Error(msg string, keysAndValues ...any)
+	// Warn logs a warning-level message with alternating key/value pairs.
 	Warn(msg string, keysAndValues ...any)
 }

--- a/log/mocks/doc.go
+++ b/log/mocks/doc.go
@@ -1,0 +1,6 @@
+// Package mocks contains the counterfeiter-generated test fake for the log
+// package's Logger interface, for use in tests of code that logs through it.
+//
+// The fake is generated code; do not edit it by hand. Regenerate it with
+// "make generate".
+package mocks

--- a/log/noop.go
+++ b/log/noop.go
@@ -1,9 +1,17 @@
 package log
 
-// noopLogger implements Logger but does nothing.
+// NoopLogger implements Logger but does nothing. It is the fallback returned
+// by FromContext when no logger is stored in the context.
 type NoopLogger struct{}
 
+// Debug discards the message and key/value pairs.
 func (n *NoopLogger) Debug(msg string, keysAndValues ...any) {}
-func (n *NoopLogger) Info(msg string, keysAndValues ...any)  {}
+
+// Info discards the message and key/value pairs.
+func (n *NoopLogger) Info(msg string, keysAndValues ...any) {}
+
+// Error discards the message and key/value pairs.
 func (n *NoopLogger) Error(msg string, keysAndValues ...any) {}
-func (n *NoopLogger) Warn(msg string, keysAndValues ...any)  {}
+
+// Warn discards the message and key/value pairs.
+func (n *NoopLogger) Warn(msg string, keysAndValues ...any) {}

--- a/mocks/doc.go
+++ b/mocks/doc.go
@@ -1,0 +1,7 @@
+// Package mocks contains counterfeiter-generated test fakes for nanogit's
+// public interfaces (Client, StagedWriter, RawClient, PackfileStorage,
+// Logger, Retrier), for use in tests of code that depends on nanogit.
+//
+// The fakes are generated code; do not edit them by hand. Regenerate them
+// with "make generate".
+package mocks

--- a/mocks/example_test.go
+++ b/mocks/example_test.go
@@ -14,6 +14,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ExampleFakeClient configures the generated Client fake and exercises code
+// that depends on nanogit.Client without any network access.
+func ExampleFakeClient() {
+	mockClient := &mocks.FakeClient{}
+
+	testHash, _ := hash.FromHex("abcdef1234567890abcdef1234567890abcdef12")
+	mockClient.GetRefReturns(nanogit.Ref{
+		Name: "refs/heads/main",
+		Hash: testHash,
+	}, nil)
+
+	ref, _ := mockClient.GetRef(context.Background(), "refs/heads/main")
+	fmt.Println(ref.Name)
+	fmt.Println(mockClient.GetRefCallCount())
+	// Output:
+	// refs/heads/main
+	// 1
+}
+
 // Example test showing how to use the Client mock
 func TestServiceWithMockedClient(t *testing.T) {
 	// Create a mock client
@@ -27,7 +46,7 @@ func TestServiceWithMockedClient(t *testing.T) {
 	}
 
 	mockClient.GetRefReturns(expectedRef, nil)
-	mockClient.IsAuthorizedReturns(true, nil)
+	mockClient.CanReadReturns(true, nil)
 
 	// Test your service that uses the client
 	service := &MyService{client: mockClient}
@@ -41,7 +60,7 @@ func TestServiceWithMockedClient(t *testing.T) {
 
 	// Verify the mock was called as expected
 	assert.Equal(t, 1, mockClient.GetRefCallCount())
-	assert.Equal(t, 1, mockClient.IsAuthorizedCallCount())
+	assert.Equal(t, 1, mockClient.CanReadCallCount())
 
 	// Verify the arguments passed to the mock
 	_, refName := mockClient.GetRefArgsForCall(0)
@@ -104,7 +123,7 @@ func TestServiceErrorHandling(t *testing.T) {
 	mockClient := &mocks.FakeClient{}
 
 	// Simulate an authorization error
-	mockClient.IsAuthorizedReturns(false, assert.AnError)
+	mockClient.CanReadReturns(false, assert.AnError)
 
 	service := &MyService{client: mockClient}
 
@@ -123,7 +142,7 @@ type MyService struct {
 
 func (s *MyService) GetMainBranch(ctx context.Context) (nanogit.Ref, error) {
 	// Check authorization first
-	authorized, err := s.client.IsAuthorized(ctx)
+	authorized, err := s.client.CanRead(ctx)
 	if err != nil {
 		return nanogit.Ref{}, fmt.Errorf("authorization failed: %w", err)
 	}

--- a/options/example_test.go
+++ b/options/example_test.go
@@ -1,0 +1,39 @@
+package options_test
+
+import (
+	"log"
+
+	"github.com/grafana/nanogit"
+	"github.com/grafana/nanogit/options"
+)
+
+// ExampleWithBasicAuth authenticates with a username and token. Most
+// providers accept any username (conventionally "git") with a personal
+// access token as the password; GitLab expects "oauth2".
+func ExampleWithBasicAuth() {
+	client, err := nanogit.NewHTTPClient(
+		"https://github.com/owner/repo.git",
+		options.WithBasicAuth("git", "your-token"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = client
+}
+
+// ExampleWithLimits caps how many bytes the client will read from the server
+// per response class, protecting services against oversized or malicious
+// responses.
+func ExampleWithLimits() {
+	client, err := nanogit.NewHTTPClient(
+		"https://github.com/owner/repo.git",
+		options.WithLimits(options.Limits{
+			SingleObjectFetchMaxBytes: 10 << 20,  // 10 MiB per single-object fetch
+			MultiObjectFetchMaxBytes:  512 << 20, // 512 MiB per multi-object fetch
+		}),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = client
+}

--- a/options/http.go
+++ b/options/http.go
@@ -31,11 +31,11 @@ func WithUserAgent(userAgent string) Option {
 	}
 }
 
-// WithoutGitSuffix disables the automatic appending of ".git" to the repository URL path.
-// By default, nanogit appends ".git" to URLs that don't already end with it.
-// Some Git hosting providers (e.g., Azure DevOps) treat ".git" as a literal part of
-// the repository name rather than a suffix to strip, causing 404 errors.
-// Use this option when connecting to such providers.
+// WithoutGitSuffix disables the automatic appending of ".git" to the
+// repository URL path. By default, nanogit appends ".git" to URLs that don't
+// already end with it, matching the canonical layout of most hosted Git
+// repositories. Use this option when the repository URL must be used exactly
+// as given, for example on servers whose repository paths do not end in ".git".
 func WithoutGitSuffix() Option {
 	return func(o *Options) error {
 		o.SkipGitSuffix = true

--- a/options/options.go
+++ b/options/options.go
@@ -1,3 +1,7 @@
+// Package options configures the nanogit HTTP client. It defines the
+// functional options passed to nanogit.NewHTTPClient: authentication
+// (WithBasicAuth, WithTokenAuth), user agent, custom HTTP transport,
+// response size limits, and receive-pack capability control.
 package options
 
 import (
@@ -14,16 +18,27 @@ func defaultHTTPClient() *http.Client {
 	return &http.Client{}
 }
 
+// BasicAuth holds credentials for HTTP basic authentication.
 type BasicAuth struct {
+	// Username is the basic auth username.
 	Username string
+	// Password is the basic auth password or personal access token.
 	Password string
 }
 
+// Options is the resolved client configuration produced by applying Option
+// functions (see Resolve). Most callers never build it directly; they pass
+// Option values to nanogit.NewHTTPClient instead.
 type Options struct {
-	HTTPClient    *http.Client
-	UserAgent     string
-	BasicAuth     *BasicAuth
-	AuthToken     *string
+	// HTTPClient performs the underlying HTTP requests.
+	HTTPClient *http.Client
+	// UserAgent overrides the User-Agent header sent with each request.
+	UserAgent string
+	// BasicAuth holds basic authentication credentials, if set.
+	BasicAuth *BasicAuth
+	// AuthToken is the raw Authorization header value, if set.
+	AuthToken *string
+	// SkipGitSuffix disables appending ".git" to the repository URL path.
 	SkipGitSuffix bool
 	// ReceivePackCapabilities, when non-empty, overrides the capabilities
 	// advertised on receive-pack ref update commands. When nil or empty,
@@ -67,6 +82,8 @@ type Limits struct {
 	ReceivePackResponseMaxBytes int64
 }
 
+// Option mutates Options during Resolve. An Option returns an error to
+// reject invalid configuration at client construction time.
 type Option func(*Options) error
 
 // Resolve applies the given Option functions in order to a fresh Options

--- a/protocol/client/fetch.go
+++ b/protocol/client/fetch.go
@@ -14,6 +14,9 @@ import (
 	"github.com/grafana/nanogit/storage"
 )
 
+// FetchOptions controls a raw protocol v2 fetch request: which objects to
+// request (Want), depth and filter arguments, cache bypass, and response
+// size limits.
 type FetchOptions struct {
 	NoCache      bool
 	NoProgress   bool

--- a/protocol/client/lsrefs.go
+++ b/protocol/client/lsrefs.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/nanogit/protocol"
 )
 
+// LsRefsOptions controls an ls-refs command. Prefix, when non-empty, limits
+// the results to refs whose names start with it (e.g. "refs/heads/").
 type LsRefsOptions struct {
 	Prefix string
 }

--- a/protocol/client/rawclient.go
+++ b/protocol/client/rawclient.go
@@ -1,3 +1,10 @@
+// Package client implements the low-level Git Smart HTTP protocol version 2
+// transport used by the root nanogit package: the info/refs handshake,
+// upload-pack and receive-pack exchanges, authentication headers, retries,
+// and typed errors for common HTTP failures.
+//
+// It is low-level plumbing. Most users should use the root nanogit package
+// instead of this one directly.
 package client
 
 import (
@@ -19,15 +26,36 @@ import (
 //
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -header ../../internal/tools/fake_header.txt -o ../../mocks/raw_client.go . RawClient
 type RawClient interface {
+	// CanRead reports whether the credentials grant read (fetch) access to
+	// the repository.
 	CanRead(ctx context.Context) (bool, error)
+	// CanWrite reports whether the credentials grant repository-level write
+	// (push) access.
 	CanWrite(ctx context.Context) (bool, error)
-	IsAuthorized(ctx context.Context) (bool, error) // Deprecated: Use CanRead instead
+	// IsAuthorized reports whether the client can read from the repository.
+	//
+	// Deprecated: Use CanRead instead.
+	IsAuthorized(ctx context.Context) (bool, error)
+	// SmartInfo performs the GET info/refs handshake for the given service
+	// ("git-upload-pack" or "git-receive-pack").
 	SmartInfo(ctx context.Context, service string) error
+	// IsServerCompatible reports whether the server supports Git protocol
+	// v2, which nanogit requires.
 	IsServerCompatible(ctx context.Context) (bool, error)
+	// UploadPack posts a raw git-upload-pack request body and returns the
+	// response stream. The caller must close it.
 	UploadPack(ctx context.Context, data io.Reader) (io.ReadCloser, error)
+	// ReceivePack posts a raw git-receive-pack request body and checks the
+	// server's status response.
 	ReceivePack(ctx context.Context, data io.Reader) error
+	// FetchReceivePackCapabilities returns the capabilities the server
+	// advertises for git-receive-pack.
 	FetchReceivePackCapabilities(ctx context.Context) ([]protocol.Capability, error)
+	// Fetch requests the objects named in opts.Want and returns the parsed
+	// pack-file objects keyed by hash.
 	Fetch(ctx context.Context, opts FetchOptions) (map[string]*protocol.PackfileObject, error)
+	// LsRefs lists the server's refs via the ls-refs command, optionally
+	// filtered by opts.Prefix.
 	LsRefs(ctx context.Context, opts LsRefsOptions) ([]protocol.RefLine, error)
 }
 

--- a/protocol/hash/hash.go
+++ b/protocol/hash/hash.go
@@ -1,4 +1,8 @@
-// A Git-oriented hashing implementation. Supports all hashing algorithms that Git does.
+// Package hash represents SHA-1 Git object identifiers: parsing, formatting,
+// and computing the 20-byte hashes Git uses to name objects.
+//
+// Only SHA-1 is supported; repositories using the SHA-256 object format are
+// not supported.
 package hash
 
 import (
@@ -6,10 +10,17 @@ import (
 	"hash"
 )
 
+// Hash is a 20-byte SHA-1 Git object identifier.
 type Hash [20]byte
 
-var Zero Hash // All zeros, no need to initialize
+// Zero is the all-zero Hash. It is the zero value of Hash and denotes a
+// nonexistent object, such as the old value of a ref being created or the
+// new value of a ref being deleted.
+var Zero Hash
 
+// FromHex parses a 40-character hexadecimal string into a Hash. As a special
+// case, the empty string yields (Zero, nil) rather than an error; any other
+// length is rejected with hex.InvalidByteError.
 func FromHex(hs string) (Hash, error) {
 	if len(hs) == 0 {
 		return Zero, nil
@@ -38,14 +49,19 @@ func MustFromHex(hs string) Hash {
 	return h
 }
 
+// String returns the lowercase 40-character hexadecimal form of h.
 func (h Hash) String() string {
 	return hex.EncodeToString(h[:])
 }
 
+// Is reports whether h equals other.
 func (h Hash) Is(other Hash) bool {
 	return h == other
 }
 
+// Hasher computes a Git object identifier incrementally. Construct it with
+// protocol.NewHasher, which writes the object header ("<type> <size>\x00")
+// before the caller writes the object content.
 type Hasher struct {
 	hash.Hash
 }

--- a/protocol/object.go
+++ b/protocol/object.go
@@ -1,22 +1,14 @@
-// Package object defines the types of objects that can be stored in a Git repository.
+// Package protocol implements the Git wire protocol: pack-file encoding and
+// decoding, pkt-line framing, delta resolution, and the object model
+// (commits, trees, blobs, tags) those formats carry.
 //
-// Git stores all content as objects in its object database. Each object has a type
-// that determines how Git interprets its contents. The object types are:
+// It is low-level plumbing. Most users should use the root nanogit package,
+// which wraps this one in a high-level client.
 //
-//   - Commit: A snapshot of the repository at a point in time, containing metadata
-//     about the commit (author, committer, message) and references to tree and parent
-//     objects.
-//   - Tree: A directory listing, containing references to blobs and other trees.
-//   - Blob: A file's contents.
-//   - Tag: A reference to a specific object, usually a commit, with additional metadata.
-//
-// Additionally, Git uses two special object types for pack files:
-//   - OfsDelta: A delta object that references its base by offset within the pack.
-//   - RefDelta: A delta object that references its base by its object ID.
-//
-// For more details about Git's object types and their formats, see:
+// For more details about Git's object and transfer formats, see:
 // https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-// https://git-scm.com/docs/pack-format#_object_types
+// https://git-scm.com/docs/pack-format
+// https://git-scm.com/docs/protocol-v2
 package protocol
 
 import (

--- a/retry/example_test.go
+++ b/retry/example_test.go
@@ -1,0 +1,24 @@
+package retry_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/nanogit/retry"
+)
+
+// ExampleToContext enables retries with exponential backoff for every nanogit
+// operation performed with the returned context. Without a retrier in the
+// context, operations are attempted exactly once.
+func ExampleToContext() {
+	retrier := retry.NewExponentialBackoffRetrier().
+		WithMaxAttempts(5).
+		WithInitialDelay(200 * time.Millisecond).
+		WithMaxDelay(10 * time.Second).
+		WithJitter()
+
+	ctx := retry.ToContext(context.Background(), retrier)
+
+	// Pass ctx to any nanogit operation: client.GetRef(ctx, ...), etc.
+	_ = ctx
+}

--- a/storage/context.go
+++ b/storage/context.go
@@ -5,12 +5,13 @@ import "context"
 // packfileStorageKey is the key for the packfile storage in the context.
 type packfileStorageKey struct{}
 
-// ToContext sets the packfile storage for the client from the context.
+// ToContext returns a copy of ctx carrying the given packfile storage.
+// nanogit clients retrieve it with FromContext during Git operations.
 func ToContext(ctx context.Context, storage PackfileStorage) context.Context {
 	return context.WithValue(ctx, packfileStorageKey{}, storage)
 }
 
-// FromContext gets the packfile storage from the context.
+// FromContext returns the packfile storage stored in ctx, or nil if none is set.
 func FromContext(ctx context.Context) PackfileStorage {
 	storage, ok := ctx.Value(packfileStorageKey{}).(PackfileStorage)
 	if !ok {
@@ -20,7 +21,9 @@ func FromContext(ctx context.Context) PackfileStorage {
 	return storage
 }
 
-// FromContextOrInMemory creates a new in-memory storage if the storage is not set in the context.
+// FromContextOrInMemory returns the packfile storage stored in ctx, if any.
+// Otherwise it creates a new in-memory storage and returns it along with a
+// derived context that carries it.
 func FromContextOrInMemory(ctx context.Context) (context.Context, PackfileStorage) {
 	storage := FromContext(ctx)
 	if storage != nil {

--- a/storage/example_test.go
+++ b/storage/example_test.go
@@ -1,0 +1,21 @@
+package storage_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/nanogit/storage"
+)
+
+// ExampleToContext shares an object cache across nanogit operations performed
+// with the same context, so objects fetched by one operation can be reused by
+// the next instead of being re-downloaded.
+func ExampleToContext() {
+	ctx := context.Background()
+
+	cache := storage.NewInMemoryStorage(ctx, storage.WithTTL(5*time.Minute))
+	ctx = storage.ToContext(ctx, cache)
+
+	// Pass ctx to any nanogit operation: client.GetFlatTree(ctx, ...), etc.
+	_ = ctx
+}

--- a/storage/inmemory.go
+++ b/storage/inmemory.go
@@ -9,14 +9,24 @@ import (
 	"github.com/grafana/nanogit/protocol/hash"
 )
 
+// InMemoryStorageOption configures an InMemoryStorage created by NewInMemoryStorage.
 type InMemoryStorageOption func(*InMemoryStorage)
 
+// WithTTL enables time-based expiry: objects not accessed within ttl are
+// eligible for removal. When ttl > 0, NewInMemoryStorage starts a background
+// goroutine that sweeps expired objects every ttl. The goroutine stops only
+// when the context passed to NewInMemoryStorage is canceled, so pass a
+// cancelable context to avoid leaking it.
 func WithTTL(ttl time.Duration) InMemoryStorageOption {
 	return func(s *InMemoryStorage) {
 		s.ttl = ttl
 	}
 }
 
+// InMemoryStorage is a thread-safe, map-backed PackfileStorage. It is the
+// default storage nanogit uses when none is present in the context (see
+// FromContextOrInMemory). Entries live until deleted, or until they expire
+// when built with WithTTL.
 type InMemoryStorage struct {
 	objects    map[string]*protocol.PackfileObject
 	lastAccess map[string]time.Time
@@ -24,6 +34,9 @@ type InMemoryStorage struct {
 	mu         sync.RWMutex
 }
 
+// NewInMemoryStorage returns an empty InMemoryStorage. If WithTTL is given
+// with a positive duration, ctx bounds the lifetime of the background
+// cleanup goroutine started here; otherwise ctx is unused.
 func NewInMemoryStorage(ctx context.Context, opts ...InMemoryStorageOption) *InMemoryStorage {
 	s := &InMemoryStorage{
 		objects:    make(map[string]*protocol.PackfileObject),
@@ -41,6 +54,8 @@ func NewInMemoryStorage(ctx context.Context, opts ...InMemoryStorageOption) *InM
 	return s
 }
 
+// Get returns the object stored under key, refreshing its last-access time
+// when a TTL is configured.
 func (s *InMemoryStorage) Get(key hash.Hash) (*protocol.PackfileObject, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -55,6 +70,7 @@ func (s *InMemoryStorage) Get(key hash.Hash) (*protocol.PackfileObject, bool) {
 	return obj, ok
 }
 
+// GetByType returns the object stored under key only if it has the given type.
 func (s *InMemoryStorage) GetByType(key hash.Hash, objType protocol.ObjectType) (*protocol.PackfileObject, bool) {
 	obj, ok := s.Get(key)
 	if !ok {
@@ -82,6 +98,7 @@ func (s *InMemoryStorage) LastAccess(key hash.Hash) (time.Time, bool) {
 	return t, ok
 }
 
+// GetAllKeys returns the hashes of all stored objects.
 func (s *InMemoryStorage) GetAllKeys() []hash.Hash {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -93,6 +110,7 @@ func (s *InMemoryStorage) GetAllKeys() []hash.Hash {
 	return keys
 }
 
+// Add stores the given objects, keyed by their hashes.
 func (s *InMemoryStorage) Add(objs ...*protocol.PackfileObject) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -107,6 +125,7 @@ func (s *InMemoryStorage) Add(objs ...*protocol.PackfileObject) {
 	}
 }
 
+// Delete removes the object stored under key.
 func (s *InMemoryStorage) Delete(key hash.Hash) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -118,6 +137,7 @@ func (s *InMemoryStorage) Delete(key hash.Hash) {
 	}
 }
 
+// Len returns the number of stored objects.
 func (s *InMemoryStorage) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/storage/noop.go
+++ b/storage/noop.go
@@ -6,20 +6,26 @@ import (
 )
 
 // NoopPackfileStorage is a no-op implementation of PackfileStorage.
+// It stores nothing, so every operation runs uncached.
 type NoopPackfileStorage struct{}
 
+// Get always reports a miss.
 func (n *NoopPackfileStorage) Get(key hash.Hash) (*protocol.PackfileObject, bool) {
 	return nil, false
 }
 
+// GetAllKeys returns nil.
 func (n *NoopPackfileStorage) GetAllKeys() []hash.Hash {
 	return nil
 }
 
+// Add discards the given objects.
 func (n *NoopPackfileStorage) Add(objs ...*protocol.PackfileObject) {}
 
+// Delete does nothing.
 func (n *NoopPackfileStorage) Delete(key hash.Hash) {}
 
+// Len returns 0.
 func (n *NoopPackfileStorage) Len() int {
 	return 0
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,3 +1,8 @@
+// Package storage provides context-injected packfile object storage for
+// nanogit clients. Objects fetched or written during Git operations are
+// cached in a PackfileStorage carried in the context.Context, so callers can
+// plug in a custom backend with ToContext or rely on the built-in in-memory
+// implementation (see FromContextOrInMemory).
 package storage
 
 import (

--- a/tests/provider_limits_integration_test.go
+++ b/tests/provider_limits_integration_test.go
@@ -144,4 +144,3 @@ func resolveAnyDefaultBranch(ctx context.Context, c nanogit.Client) (nanogit.Ref
 	}
 	return nanogit.Ref{}, errors.New("no refs/heads/* branch found on remote")
 }
-

--- a/tests/writer_submodule_integration_test.go
+++ b/tests/writer_submodule_integration_test.go
@@ -37,11 +37,12 @@ import (
 // rebuilt — i.e., when nothing under that parent changed. So these tests
 // deliberately exercise the two scenarios the bug actually breaks:
 //
-//   1. Submodule at the repository root: ANY edit always re-marks the
-//      root tree dirty, so the submodule is dropped.
-//   2. Submodule as a sibling of the modified blob (same parent
-//      directory): that directory is dirty, so the submodule sibling
-//      gets dropped.
+//  1. Submodule at the repository root: ANY edit always re-marks the
+//     root tree dirty, so the submodule is dropped.
+//  2. Submodule as a sibling of the modified blob (same parent
+//     directory): that directory is dirty, so the submodule sibling
+//     gets dropped.
+//
 // As with the main writer Describe, the submodule preservation specs run
 // once with the default static capability set and once with capability
 // negotiation enabled, so the gitlink-preservation invariants hold under

--- a/writer.go
+++ b/writer.go
@@ -1026,10 +1026,11 @@ func (w *stagedWriter) Push(ctx context.Context) error {
 	// Always reset the writer and update the ref even if cleanup fails, to maintain consistency
 	// with the successful push that already happened on the server.
 	cleanupErr := w.writer.Cleanup()
-	// Capability negotiation is cached behind sync.Once on the client; by the
-	// time we reach this post-push reset the same client has already
-	// negotiated successfully (NewStagedWriter is the first call that fires
-	// it), so this lookup hits the cached value with no extra round-trip.
+	// Successful capability negotiation is cached on the client (guarded by
+	// negotiateMu; failures are never cached); by the time we reach this
+	// post-push reset the same client has already negotiated successfully
+	// (NewStagedWriter is the first call that triggers it), so this lookup
+	// hits the cached value with no extra round-trip.
 	caps, capsErr := w.client.effectiveReceivePackCapabilities(ctx)
 	if capsErr != nil {
 		w.ref.Hash = w.lastCommit.Hash
@@ -1433,9 +1434,10 @@ func (w *stagedWriter) Cleanup(ctx context.Context) error {
 	w.dirtyPaths = make(map[string]bool)
 	w.submoduleEntries = make(map[string]*FlatTreeEntry)
 
-	// Reset writer state. Capability negotiation, if enabled, is cached
-	// behind sync.Once so this lookup reuses the result negotiated when the
-	// writer was constructed.
+	// Reset writer state. Successful capability negotiation, if enabled, is
+	// cached on the client (guarded by negotiateMu; failures are never
+	// cached), so this lookup reuses the result negotiated when the writer
+	// was constructed.
 	caps, err := w.client.effectiveReceivePackCapabilities(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve receive-pack capabilities during cleanup: %w", err)

--- a/writer_submodule_test.go
+++ b/writer_submodule_test.go
@@ -74,8 +74,8 @@ func TestCollectDirectChildren_MergesSubmodules(t *testing.T) {
 
 	w := newWriterWithState(t,
 		map[string]*FlatTreeEntry{
-			"dashboards":    {Path: "dashboards", Hash: dashboards, Type: protocol.ObjectTypeTree, Mode: 0o40000},
-			"rootfile.txt":  {Path: "rootfile.txt", Hash: rootFile, Type: protocol.ObjectTypeBlob, Mode: 0o100644},
+			"dashboards":   {Path: "dashboards", Hash: dashboards, Type: protocol.ObjectTypeTree, Mode: 0o40000},
+			"rootfile.txt": {Path: "rootfile.txt", Hash: rootFile, Type: protocol.ObjectTypeBlob, Mode: 0o100644},
 		},
 		map[string]*FlatTreeEntry{
 			"thirdparty": {Path: "thirdparty", Hash: gitlink, Type: protocol.ObjectTypeCommit, Mode: 0o160000},
@@ -140,8 +140,8 @@ func TestCollectDirectChildren_OnlyDirectChildren(t *testing.T) {
 
 	w := newWriterWithState(t,
 		map[string]*FlatTreeEntry{
-			"dashboards":         {Path: "dashboards", Hash: siblingTree, Type: protocol.ObjectTypeTree, Mode: 0o40000},
-			"dashboards/nested":  {Path: "dashboards/nested", Hash: siblingTree, Type: protocol.ObjectTypeTree, Mode: 0o40000},
+			"dashboards":        {Path: "dashboards", Hash: siblingTree, Type: protocol.ObjectTypeTree, Mode: 0o40000},
+			"dashboards/nested": {Path: "dashboards/nested", Hash: siblingTree, Type: protocol.ObjectTypeTree, Mode: 0o40000},
 		},
 		map[string]*FlatTreeEntry{
 			// Direct child of "dashboards" — must appear in the rebuild.
@@ -239,8 +239,8 @@ func TestPruneSubmoduleEntriesAfterPush_KeepsValidSubmodule(t *testing.T) {
 			"dashboards": {Path: "dashboards", Hash: dashTree, Type: protocol.ObjectTypeTree, Mode: 0o40000},
 		},
 		map[string]*FlatTreeEntry{
-			"dashboards/lib":  {Path: "dashboards/lib", Hash: gitlink, Type: protocol.ObjectTypeCommit, Mode: 0o160000},
-			"thirdparty":      {Path: "thirdparty", Hash: gitlink, Type: protocol.ObjectTypeCommit, Mode: 0o160000},
+			"dashboards/lib": {Path: "dashboards/lib", Hash: gitlink, Type: protocol.ObjectTypeCommit, Mode: 0o160000},
+			"thirdparty":     {Path: "thirdparty", Hash: gitlink, Type: protocol.ObjectTypeCommit, Mode: 0o160000},
 		},
 	)
 


### PR DESCRIPTION
Part of the repo-maturity polish series. This PR makes the pkg.go.dev page match the library's production-ready positioning. Comment/doc changes and new example tests only — no behavior changes.

## What was wrong

- The **root package had no package comment** — pkg.go.dev opened with a bare identifier list and search results showed an empty synopsis. Same for `options`, `storage`, `log`, and `protocol/client`; `protocol`'s comment named the wrong package ("Package object…"), and `protocol/hash` claimed support for "all hashing algorithms that Git does" (it's SHA-1 only).
- The **`Client` interface doc ended mid-sentence** and **13 of its 21 methods were undocumented** — the section headers ("// Repo operations") misattached as method docs, and the real docs lived on the unexported `httpClient`, invisible to consumers.
- The **flagship `NewHTTPClient` godoc example didn't compile**: it called `options.WithLogger`, which doesn't exist anywhere.
- `IsAuthorized`'s deprecation was a trailing same-line comment — **invisible to pkg.go.dev, gopls, and staticcheck**.
- The module shipped **zero `Example*` functions** (gittest has 9; the root module had none), and `mocks/example_test.go` contained only `Test*` funcs.
- Assorted comment/code mismatches: `log.FromContext` claimed to return nil (returns `&NoopLogger{}`), garbled `storage.ToContext` doc, `writer.go` claiming negotiation is "cached behind `sync.Once`" (it's a mutex that never caches failures), two `Unwrap` docs referencing nonexistent sentinels, and `WithoutGitSuffix` recommending Azure DevOps — which nanogit explicitly doesn't support.
- `commit.go` + three test files were gofmt-dirty (this also dings the Go Report Card badge the README shows).

## What this PR does

- `doc.go` package overview (what/when/when-not, read + write examples, config pointers)
- All 21 `Client` methods documented on the interface, adapted from the implementation docs (including the `CanWrite` branch-protection caveat and `GetRef` requiring fully qualified ref names — the latter verified against a live server)
- Proper `Deprecated:` paragraphs on `IsAuthorized` (both interfaces); internal examples migrated to `CanRead` — the marker is now machine-visible (gopls flags usages immediately)
- 11 new testable examples across root/options/log/retry/storage/mocks, all compile-checked by `go test`; `ExampleFakeClient` actually runs with verified output
- Package comments + exported-identifier docs for options/storage/log/protocol/hash/protocol/client (storage's `WithTTL` now documents its cleanup-goroutine lifecycle)
- All comment/code mismatches above fixed; gofmt clean

## Verification

- `gofmt -l .` → clean
- `go build ./... && go vet ./...` → clean
- `staticcheck ./...` (same as CI) → clean
- `go test ./...` → passes, except `TestGPGSignerVerify`, which fails identically on clean main (environment-dependent GPG setup, pre-existing, untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)