### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
   <a href="https://github.com/grafana/nanogit/releases"><img src="https://img.shields.io/github/v/release/grafana/nanogit" alt="GitHub Release"></a>
   <a href="LICENSE.md"><img src="https://img.shields.io/github/license/grafana/nanogit" alt="License"></a>
   <a href="https://github.com/grafana/nanogit/actions/workflows/ci.yml"><img src="https://github.com/grafana/nanogit/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
-  <a href="https://goreportcard.com/report/github.com/grafana/nanogit"><img src="https://goreportcard.com/badge/github.com/grafana/nanogit" alt="Go Report Card"></a>
   <a href="https://pkg.go.dev/github.com/grafana/nanogit"><img src="https://pkg.go.dev/badge/github.com/grafana/nanogit.svg" alt="Go Reference"></a>
   <a href="https://codecov.io/gh/grafana/nanogit"><img src="https://codecov.io/gh/grafana/nanogit/branch/main/graph/badge.svg" alt="codecov"></a>
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,6 @@
   <a href="https://github.com/grafana/nanogit/stargazers"><img src="https://img.shields.io/github/stars/grafana/nanogit?style=social" alt="GitHub Stars"></a>
   <a href="https://github.com/grafana/nanogit/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/grafana/nanogit" alt="License"></a>
   <a href="https://github.com/grafana/nanogit/actions/workflows/ci.yml"><img src="https://github.com/grafana/nanogit/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
-  <a href="https://goreportcard.com/report/github.com/grafana/nanogit"><img src="https://goreportcard.com/badge/github.com/grafana/nanogit" alt="Go Report Card"></a>
   <a href="https://pkg.go.dev/github.com/grafana/nanogit"><img src="https://pkg.go.dev/badge/github.com/grafana/nanogit.svg" alt="Go Reference"></a>
   <a href="https://codecov.io/gh/grafana/nanogit"><img src="https://codecov.io/gh/grafana/nanogit/branch/main/graph/badge.svg" alt="codecov"></a>
 </p>


### PR DESCRIPTION
## What
Removes the Go Report Card badge from `README.md` and the docs home (`docs/index.md`).

## Why
Go Report Card has been [sunset](https://goreportcard.com/report/github.com/grafana/nanogit) after 10+ years of service. The badge now points at a dead service and no longer reflects code quality. Its maintainers recommend golangci-lint as the successor — which this repo already runs via `make lint` and surfaces through the CI badge — so no replacement badge is needed.

## How
Deleted the single `<a>`/`<img>` badge line in each of the two badge rows. All other badges (Release, License, CI, Go Reference, codecov, and Stars on the docs page) are untouched.

## Testing
- Docs-only change; no code affected.
- Verified both badge rows render with the remaining badges intact.

## Checklist
- [ ] Tests added/updated (N/A — docs only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code