### PR TITLE
docs: link StagedWriter/NewStagedWriter and other API symbols to godoc

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-nanogit is HTTPS-only and token-oriented: there is no SSH key management. Two options cover every provider, both passed to `NewHTTPClient`.
+nanogit is HTTPS-only and token-oriented: there is no SSH key management. Two options cover every provider, both passed to [`NewHTTPClient`](https://pkg.go.dev/github.com/grafana/nanogit#NewHTTPClient).
 
 ## Basic auth (most providers)
 

--- a/docs/guides/commit-signing.md
+++ b/docs/guides/commit-signing.md
@@ -1,6 +1,6 @@
 # Commit signing
 
-A `StagedWriter` can cryptographically sign every commit it creates. Three signature formats are supported, selected with a writer option at `NewStagedWriter` time:
+A [`StagedWriter`](writing.md) can cryptographically sign every commit it creates. Three signature formats are supported, selected with a writer option at [`NewStagedWriter`](https://pkg.go.dev/github.com/grafana/nanogit#Client.NewStagedWriter) time:
 
 | Option | Format | Key material |
 | ------ | ------ | ------------ |

--- a/docs/guides/history.md
+++ b/docs/guides/history.md
@@ -1,6 +1,6 @@
 # History and diffs
 
-nanogit reads commit history and computes file-level diffs without cloning: `ListCommits` walks history backwards from a commit, and `CompareCommits` diffs two commits' trees.
+nanogit reads commit history and computes file-level diffs without cloning: [`ListCommits`](https://pkg.go.dev/github.com/grafana/nanogit#Client.ListCommits) walks history backwards from a commit, and [`CompareCommits`](https://pkg.go.dev/github.com/grafana/nanogit#Client.CompareCommits) diffs two commits' trees.
 
 ## Listing commits
 

--- a/docs/guides/response-limits.md
+++ b/docs/guides/response-limits.md
@@ -1,6 +1,6 @@
 # Response limits
 
-When a service talks to Git servers it doesn't control — the multitenant situation nanogit was built for — an oversized (or malicious) response can exhaust memory or disk. `options.WithLimits` caps how many bytes nanogit will read from the server per HTTP response, classified by operation, so a single misbehaving repository can't take out the process.
+When a service talks to Git servers it doesn't control — the multitenant situation nanogit was built for — an oversized (or malicious) response can exhaust memory or disk. [`options.WithLimits`](https://pkg.go.dev/github.com/grafana/nanogit/options#WithLimits) caps how many bytes nanogit will read from the server per HTTP response, classified by operation, so a single misbehaving repository can't take out the process.
 
 By default there are **no limits** (a zero `Limits` preserves historic behavior).
 


### PR DESCRIPTION
Addresses the review nit on #390 ([discussion](https://github.com/grafana/nanogit/pull/390#discussion_r3620314161)): the commit-signing guide named `StagedWriter` and `NewStagedWriter` without linking to their code/docs, which is confusing for a reader landing there directly.

## Changes

- **commit-signing.md** — link `StagedWriter` to the [writing guide](docs/guides/writing.md) (the conceptual doc) and `NewStagedWriter` to its godoc.
- Applied the same first-mention linking to the intros of the other guides for consistency, since they had the identical issue:
  - **authentication.md** — `NewHTTPClient` → godoc
  - **history.md** — `ListCommits`, `CompareCommits` → godoc
  - **response-limits.md** — `options.WithLimits` → godoc

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)