### PR TITLE
fix(ci): skip Codecov upload on fork PRs to avoid OIDC failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
         run: |
           apk add --no-cache git make gcc musl-dev bash curl gpg gpg-agent gpgsm openssh-keygen
       - id: get-secrets
+        # Vault OIDC is unavailable on fork PRs, so only fetch the Codecov
+        # token for pushes and same-repo PRs. Forks still run the tests below.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
         with:
           # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
@@ -125,6 +128,8 @@ jobs:
           CGO_ENABLED: 1
         run: make test-coverage
       - name: Upload coverage
+        # Skip on fork PRs where the Codecov token is unavailable.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
## What
The `test-coverage` CI job now skips the Vault secret fetch and the Codecov upload on pull requests coming from forks. Forks still run the full test suite (`make test-coverage`) — they just don't upload coverage.

## Why
On fork PRs, GitHub makes `GITHUB_TOKEN` read-only and does **not** grant `id-token: write`, regardless of the job's `permissions:` block. The `test-coverage` job calls `grafana/shared-workflows/actions/get-vault-secrets`, which relies on Vault OIDC, so it failed with:

> ❌ Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable

Unlike the provider jobs (`test-github-provider`, `test-gitlab-provider`), `test-coverage` had no fork guard, so it ran on fork PRs and then died at the Vault step. The generic "add `id-token: write`" advice in that error is a red herring here — the permission was already present.

## How
Gate the two credential-dependent steps with a condition that is true for pushes and same-repo PRs, false for forks:

```yaml
if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

Applied to:
- the `get-secrets` (Vault) step
- the `Upload coverage` (Codecov) step

The job itself is not gated, so tests continue to run on forks. Nothing changes for pushes to `main` or same-repo PRs.

## Testing
- Workflow-only YAML change; no application code affected.
- Verified the `if:` expression evaluates truthy for `push` and same-repo `pull_request` events and falsy for fork PRs.

## Checklist
- [ ] Tests added/updated (n/a — CI config)
- [ ] Documentation updated (n/a)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)